### PR TITLE
docs: record auth (ADR 0002) and taste-input decisions

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@
 ## Start here
 
 - [**ADR 0001 — Cloudflare stack**](./adr/0001-cloudflare-stack.md) — the stack decision and why
+- [**ADR 0002 — Session-cookie auth**](./adr/0002-session-cookie-auth.md) — the auth model on Workers
 - [**Architecture**](./architecture.md) — target topology, the pick path, auth, tenancy
 - [**Product Requirements**](./prd.md) — what Pairflix is (household decision layer) and is not
 - [**Roadmap**](./roadmap.md) — real code state, the re-platform phases, path to alpha

--- a/docs/adr/0002-session-cookie-auth.md
+++ b/docs/adr/0002-session-cookie-auth.md
@@ -1,0 +1,60 @@
+# ADR 0002 — Session-cookie auth on Workers (retire JWT)
+
+- **Status:** Accepted
+- **Date:** 2026-08-16
+- **Deciders:** Alex Jenkinson
+- **Relates to:** ADR 0001 (Cloudflare re-platform)
+
+## Context
+
+The pre-pivot backend authenticates with **JWT bearer tokens** (`Authorization: Bearer`), `req.user`
+populated by `authMiddleware`, passwords hashed with **bcrypt**, and the SPA storing/attaching the
+token. ADR 0001 moves the API to Cloudflare Workers, where **bcrypt has no native implementation** —
+so the password-hashing scheme has to change regardless of which auth model we pick.
+
+The `creatorgrid` sibling already runs a full auth surface on Workers: opaque session tokens in D1,
+PBKDF2 via Web Crypto, double-submit CSRF, login lockout, TOTP 2FA, email verification, and password
+reset.
+
+## Decision
+
+**Adopt creatorgrid's session-cookie model. Retire JWT.**
+
+- **Opaque session token** stored in D1 (`sessions`), carried in an HttpOnly `session` cookie;
+  `requireAuth` middleware resolves the caller by looking the token up.
+- **Passwords hashed with PBKDF2 via Web Crypto** (no bcrypt on Workers).
+- **Double-submit CSRF** on state-changing requests: a readable `csrfToken` cookie echoed back as an
+  `x-csrf-token` header, compared with `timingSafeEqual`.
+- Sensitive actions (password change, 2FA disable, password reset) **revoke other sessions**.
+- Port creatorgrid's `sessions` / `auth_tokens` tables and the auth route module wholesale, adapting
+  names to the Pairflix domain.
+
+## Options considered
+
+### A. Session cookie + PBKDF2 + CSRF (creatorgrid) — chosen
+
+- PBKDF2 via Web Crypto is the **native** Workers answer; bcrypt can't run there anyway.
+- **Opaque D1 sessions are revocable** — "log out everywhere", password-reset invalidation, 2FA, and
+  account suspension all need server-side revocation.
+- **HttpOnly cookie removes the SPA token-storage (XSS) risk** and simplifies the frontend: nothing to
+  store or attach (the API client only echoes the CSRF token on writes).
+- Mostly a **port** of proven creatorgrid code, not a fresh build.
+
+### B. JWT on Workers (short-lived access + refresh-token rotation) — rejected
+
+Keeps the current mental model, but still forces the bcrypt→PBKDF2 change, and to get revocation
+(logout-everywhere, reset invalidation, suspension) you reintroduce server-side state via a
+refresh-token store / denylist — i.e. you rebuild sessions with extra moving parts, for less security
+than an HttpOnly cookie. More work, worse outcome.
+
+## Consequences
+
+- **Frontend:** no token handling. The browser sends the `session` cookie automatically; the API
+  client fetches `GET /api/auth/csrf-token` and echoes `x-csrf-token` on writes. `localStorage` is
+  never touched for auth.
+- **CORS:** the SPA (Pages) and API (Worker) are on different origins, so cookies need
+  `SameSite`/`credentials` and an `ALLOWED_ORIGINS` allowlist — creatorgrid's config is the template.
+- **Schema:** adds `sessions` and `auth_tokens` to `packages/db` (see `docs/db-schema.md`).
+- **Trade-off:** a future **native mobile** client handles cookies less naturally than bearer tokens.
+  Not a concern for the web-first alpha; revisit if/when a React Native app is on the table (a
+  token-exchange endpoint can be added then without disturbing the web flow).

--- a/docs/db-schema.md
+++ b/docs/db-schema.md
@@ -11,8 +11,7 @@
 - **Engine:** Cloudflare **D1** (SQLite), one database for all households (row-level tenancy).
 - **ORM:** **Drizzle**. Tables are declared in `packages/db/src/schema.ts`; the typed client is
   `packages/db/src/client.ts`.
-- **Migrations:** authored as SQL under `packages/db/migrations/`, generated with `drizzle-kit
-generate` and applied with `wrangler d1 migrations apply pairflix-db --local|--remote`.
+- **Migrations:** authored as SQL under `packages/db/migrations/`, generated with `drizzle-kit generate` and applied with `wrangler d1 migrations apply pairflix-db --local|--remote`.
 
 ## Type conventions (Postgres → SQLite/Drizzle)
 

--- a/docs/db-schema.md
+++ b/docs/db-schema.md
@@ -12,20 +12,20 @@
 - **ORM:** **Drizzle**. Tables are declared in `packages/db/src/schema.ts`; the typed client is
   `packages/db/src/client.ts`.
 - **Migrations:** authored as SQL under `packages/db/migrations/`, generated with `drizzle-kit
-  generate` and applied with `wrangler d1 migrations apply pairflix-db --local|--remote`.
+generate` and applied with `wrangler d1 migrations apply pairflix-db --local|--remote`.
 
 ## Type conventions (Postgres → SQLite/Drizzle)
 
 SQLite has a narrow type system; the Postgres schema maps as follows:
 
-| Postgres | Drizzle / D1 | Notes |
-|---|---|---|
-| `UUID` PK | `text('id').primaryKey()` | app generates `crypto.randomUUID()` |
-| `TIMESTAMPTZ` | `integer('...', { mode: 'timestamp_ms' })` | stored as epoch millis |
-| `JSONB` | `text('...', { mode: 'json' }).$type<T>()` | serialized JSON |
-| `BOOLEAN` | `integer('...', { mode: 'boolean' })` | 0 / 1 |
-| enum | `text('...').$type<'a' \| 'b'>()` | + a `CHECK` in the migration |
-| `INTEGER` / `TEXT` | `integer(...)` / `text(...)` | unchanged |
+| Postgres           | Drizzle / D1                               | Notes                               |
+| ------------------ | ------------------------------------------ | ----------------------------------- |
+| `UUID` PK          | `text('id').primaryKey()`                  | app generates `crypto.randomUUID()` |
+| `TIMESTAMPTZ`      | `integer('...', { mode: 'timestamp_ms' })` | stored as epoch millis              |
+| `JSONB`            | `text('...', { mode: 'json' }).$type<T>()` | serialized JSON                     |
+| `BOOLEAN`          | `integer('...', { mode: 'boolean' })`      | 0 / 1                               |
+| enum               | `text('...').$type<'a' \| 'b'>()`          | + a `CHECK` in the migration        |
+| `INTEGER` / `TEXT` | `integer(...)` / `text(...)`               | unchanged                           |
 
 `ON DELETE CASCADE` / `SET NULL` are expressed with Drizzle `references(() => t.col, { onDelete })`
 and are enforced by D1 (SQLite foreign keys are on).
@@ -37,25 +37,29 @@ tables ported from creatorgrid.
 
 ```ts
 export const users = sqliteTable('users', {
-  id: text('user_id').primaryKey(),          // UUID string
+  id: text('user_id').primaryKey(), // UUID string
   username: text('username').notNull().unique(),
   email: text('email').notNull().unique(),
-  passwordHash: text('password_hash').notNull(),   // PBKDF2 (Web Crypto)
+  passwordHash: text('password_hash').notNull(), // PBKDF2 (Web Crypto)
   role: text('role').$type<'user' | 'admin'>().notNull().default('user'),
   createdAt: integer('created_at', { mode: 'timestamp_ms' }).notNull(),
   updatedAt: integer('updated_at', { mode: 'timestamp_ms' }).notNull(),
 });
 
 export const sessions = sqliteTable('sessions', {
-  id: text('id').primaryKey(),               // opaque token == cookie value
-  userId: text('user_id').notNull().references(() => users.id, { onDelete: 'cascade' }),
+  id: text('id').primaryKey(), // opaque token == cookie value
+  userId: text('user_id')
+    .notNull()
+    .references(() => users.id, { onDelete: 'cascade' }),
   createdAt: integer('created_at', { mode: 'timestamp_ms' }).notNull(),
   expiresAt: integer('expires_at', { mode: 'timestamp_ms' }).notNull(),
 });
 
 export const authTokens = sqliteTable('auth_tokens', {
   id: text('id').primaryKey(),
-  userId: text('user_id').notNull().references(() => users.id, { onDelete: 'cascade' }),
+  userId: text('user_id')
+    .notNull()
+    .references(() => users.id, { onDelete: 'cascade' }),
   kind: text('kind').$type<'verify_email' | 'password_reset'>().notNull(),
   expiresAt: integer('expires_at', { mode: 'timestamp_ms' }).notNull(),
   consumedAt: integer('consumed_at', { mode: 'timestamp_ms' }),
@@ -67,26 +71,38 @@ export const authTokens = sqliteTable('auth_tokens', {
 ```ts
 export const households = sqliteTable('households', {
   id: text('id').primaryKey(),
-  name: text('name'),                        // nullable
+  name: text('name'), // nullable
   createdAt: integer('created_at', { mode: 'timestamp_ms' }).notNull(),
   updatedAt: integer('updated_at', { mode: 'timestamp_ms' }).notNull(),
 });
 
-export const householdMembers = sqliteTable('household_members', {
-  householdId: text('household_id').notNull().references(() => households.id, { onDelete: 'cascade' }),
-  userId: text('user_id').notNull().references(() => users.id, { onDelete: 'cascade' }),
-  role: text('role').$type<'owner' | 'member'>().notNull().default('member'),
-  joinedAt: integer('joined_at', { mode: 'timestamp_ms' }).notNull(),
-}, (t) => ({ pk: primaryKey({ columns: [t.householdId, t.userId] }) }));
+export const householdMembers = sqliteTable(
+  'household_members',
+  {
+    householdId: text('household_id')
+      .notNull()
+      .references(() => households.id, { onDelete: 'cascade' }),
+    userId: text('user_id')
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
+    role: text('role').$type<'owner' | 'member'>().notNull().default('member'),
+    joinedAt: integer('joined_at', { mode: 'timestamp_ms' }).notNull(),
+  },
+  t => ({ pk: primaryKey({ columns: [t.householdId, t.userId] }) })
+);
 
 export const householdInvites = sqliteTable('household_invites', {
   id: text('id').primaryKey(),
-  householdId: text('household_id').notNull().references(() => households.id, { onDelete: 'cascade' }),
+  householdId: text('household_id')
+    .notNull()
+    .references(() => households.id, { onDelete: 'cascade' }),
   token: text('token').notNull().unique(),
   invitedEmail: text('invited_email'),
   expiresAt: integer('expires_at', { mode: 'timestamp_ms' }).notNull(),
   acceptedAt: integer('accepted_at', { mode: 'timestamp_ms' }),
-  acceptedBy: text('accepted_by').references(() => users.id, { onDelete: 'set null' }),
+  acceptedBy: text('accepted_by').references(() => users.id, {
+    onDelete: 'set null',
+  }),
 });
 ```
 
@@ -96,25 +112,36 @@ Ownership is `household_members.role = 'owner'` — there is no `owner_id` colum
 
 ```ts
 export const tasteProfiles = sqliteTable('taste_profiles', {
-  userId: text('user_id').primaryKey().references(() => users.id, { onDelete: 'cascade' }),
+  userId: text('user_id')
+    .primaryKey()
+    .references(() => users.id, { onDelete: 'cascade' }),
   weights: text('weights', { mode: 'json' }).$type<TasteWeights>().notNull(),
-  embedding: text('embedding', { mode: 'json' }).$type<number[]>(),   // reserved
+  embedding: text('embedding', { mode: 'json' }).$type<number[]>(), // reserved
   updatedAt: integer('updated_at', { mode: 'timestamp_ms' }).notNull(),
 });
 
-export const watchedTogether = sqliteTable('watched_together', {
-  id: text('id').primaryKey(),
-  householdId: text('household_id').notNull().references(() => households.id, { onDelete: 'cascade' }),
-  tmdbId: integer('tmdb_id').notNull(),
-  mediaType: text('media_type').$type<'movie' | 'tv'>().notNull(),
-  watchedAt: integer('watched_at', { mode: 'timestamp_ms' }).notNull(),
-  enjoyed: integer('enjoyed', { mode: 'boolean' }),          // thumbs, nullable
-  moodAtPick: text('mood_at_pick'),
-  minutesBudgetAtPick: integer('minutes_budget_at_pick'),
-}, (t) => ({
-  byRecency: index('idx_wt_household_watched_at').on(t.householdId, t.watchedAt),
-  byTitle: index('idx_wt_household_tmdb').on(t.householdId, t.tmdbId),
-}));
+export const watchedTogether = sqliteTable(
+  'watched_together',
+  {
+    id: text('id').primaryKey(),
+    householdId: text('household_id')
+      .notNull()
+      .references(() => households.id, { onDelete: 'cascade' }),
+    tmdbId: integer('tmdb_id').notNull(),
+    mediaType: text('media_type').$type<'movie' | 'tv'>().notNull(),
+    watchedAt: integer('watched_at', { mode: 'timestamp_ms' }).notNull(),
+    enjoyed: integer('enjoyed', { mode: 'boolean' }), // thumbs, nullable
+    moodAtPick: text('mood_at_pick'),
+    minutesBudgetAtPick: integer('minutes_budget_at_pick'),
+  },
+  t => ({
+    byRecency: index('idx_wt_household_watched_at').on(
+      t.householdId,
+      t.watchedAt
+    ),
+    byTitle: index('idx_wt_household_tmdb').on(t.householdId, t.tmdbId),
+  })
+);
 ```
 
 `TasteWeights` shape (unchanged): `{ genres: Record<string, number>, runtime_pref: number, era?:
@@ -123,15 +150,22 @@ Record<string, number>, tone?: Record<string, number> }`.
 ## Content (TMDb cache)
 
 ```ts
-export const content = sqliteTable('content', {
-  tmdbId: integer('tmdb_id').notNull(),
-  mediaType: text('media_type').$type<'movie' | 'tv'>().notNull(),
-  title: text('title'),
-  year: integer('year'),
-  posterPath: text('poster_path'),
-  providers: text('providers', { mode: 'json' }).$type<ProviderMap>().notNull().default('{}'),
-  // ...existing metadata columns...
-}, (t) => ({ pk: primaryKey({ columns: [t.tmdbId, t.mediaType] }) }));
+export const content = sqliteTable(
+  'content',
+  {
+    tmdbId: integer('tmdb_id').notNull(),
+    mediaType: text('media_type').$type<'movie' | 'tv'>().notNull(),
+    title: text('title'),
+    year: integer('year'),
+    posterPath: text('poster_path'),
+    providers: text('providers', { mode: 'json' })
+      .$type<ProviderMap>()
+      .notNull()
+      .default('{}'),
+    // ...existing metadata columns...
+  },
+  t => ({ pk: primaryKey({ columns: [t.tmdbId, t.mediaType] }) })
+);
 ```
 
 `ProviderMap` is region-keyed, e.g. `{ GB: { flatrate: [{ provider_id, provider_name, logo_path }],
@@ -142,9 +176,15 @@ rent: [], buy: [] }, last_updated_at: <iso> }`.
 ```ts
 export const subscriptions = sqliteTable('subscriptions', {
   id: text('id').primaryKey(),
-  householdId: text('household_id').notNull().unique().references(() => households.id, { onDelete: 'cascade' }),
+  householdId: text('household_id')
+    .notNull()
+    .unique()
+    .references(() => households.id, { onDelete: 'cascade' }),
   tier: text('tier').$type<'free' | 'premium'>().notNull().default('free'),
-  status: text('status').$type<'active' | 'past_due' | 'canceled'>().notNull().default('active'),
+  status: text('status')
+    .$type<'active' | 'past_due' | 'canceled'>()
+    .notNull()
+    .default('active'),
   stripeCustomerId: text('stripe_customer_id'),
   stripeSubscriptionId: text('stripe_subscription_id'),
   currentPeriodEnd: integer('current_period_end', { mode: 'timestamp_ms' }),
@@ -152,11 +192,22 @@ export const subscriptions = sqliteTable('subscriptions', {
   updatedAt: integer('updated_at', { mode: 'timestamp_ms' }).notNull(),
 });
 
-export const pickUsage = sqliteTable('pick_usage', {
-  id: text('id').primaryKey(),
-  householdId: text('household_id').notNull().references(() => households.id, { onDelete: 'cascade' }),
-  pickedAt: integer('picked_at', { mode: 'timestamp_ms' }).notNull(),
-}, (t) => ({ byDay: index('idx_pick_usage_household_picked_at').on(t.householdId, t.pickedAt) }));
+export const pickUsage = sqliteTable(
+  'pick_usage',
+  {
+    id: text('id').primaryKey(),
+    householdId: text('household_id')
+      .notNull()
+      .references(() => households.id, { onDelete: 'cascade' }),
+    pickedAt: integer('picked_at', { mode: 'timestamp_ms' }).notNull(),
+  },
+  t => ({
+    byDay: index('idx_pick_usage_household_picked_at').on(
+      t.householdId,
+      t.pickedAt
+    ),
+  })
+);
 ```
 
 Premium is `tier = 'premium' AND status = 'active' AND current_period_end > now`. `stripe_*` stay
@@ -165,22 +216,37 @@ null until real Stripe is wired.
 ## Analytics
 
 ```ts
-export const pickEvents = sqliteTable('pick_events', {
-  id: text('id').primaryKey(),
-  householdId: text('household_id').notNull().references(() => households.id, { onDelete: 'cascade' }),
-  userId: text('user_id').references(() => users.id, { onDelete: 'set null' }),
-  tmdbId: integer('tmdb_id').notNull(),
-  mediaType: text('media_type').$type<'movie' | 'tv'>().notNull(),
-  kind: text('kind').$type<'proposed' | 'accepted' | 'swapped' | 'dismissed' | 'provider_launched'>().notNull(),
-  mood: text('mood'),
-  minutesBudget: integer('minutes_budget'),
-  providerSlug: text('provider_slug'),        // non-null only for provider_launched
-  region: text('region'),                     // 2-letter
-  occurredAt: integer('occurred_at', { mode: 'timestamp_ms' }).notNull(),
-}, (t) => ({
-  byRecency: index('idx_pe_household_occurred_at').on(t.householdId, t.occurredAt),
-  byKind: index('idx_pe_household_kind').on(t.householdId, t.kind),
-}));
+export const pickEvents = sqliteTable(
+  'pick_events',
+  {
+    id: text('id').primaryKey(),
+    householdId: text('household_id')
+      .notNull()
+      .references(() => households.id, { onDelete: 'cascade' }),
+    userId: text('user_id').references(() => users.id, {
+      onDelete: 'set null',
+    }),
+    tmdbId: integer('tmdb_id').notNull(),
+    mediaType: text('media_type').$type<'movie' | 'tv'>().notNull(),
+    kind: text('kind')
+      .$type<
+        'proposed' | 'accepted' | 'swapped' | 'dismissed' | 'provider_launched'
+      >()
+      .notNull(),
+    mood: text('mood'),
+    minutesBudget: integer('minutes_budget'),
+    providerSlug: text('provider_slug'), // non-null only for provider_launched
+    region: text('region'), // 2-letter
+    occurredAt: integer('occurred_at', { mode: 'timestamp_ms' }).notNull(),
+  },
+  t => ({
+    byRecency: index('idx_pe_household_occurred_at').on(
+      t.householdId,
+      t.occurredAt
+    ),
+    byKind: index('idx_pe_household_kind').on(t.householdId, t.kind),
+  })
+);
 ```
 
 Backs the first-pick acceptance-rate KPI and affiliate attribution.
@@ -188,13 +254,15 @@ Backs the first-pick acceptance-rate KPI and affiliate attribution.
 ## Dropped in the re-platform
 
 Pairflix is pre-launch alpha with **no production data**, so the old matching schema is **not** carried
-into D1 — nothing to preserve or backfill. Dropped: `matches`, `tags`, `entry_tags`, `activity_log`.
-Feature flags move to a small `settings` table (or Worker vars) in place of `app_settings`.
+into D1 — nothing to preserve or backfill. Dropped: `matches`, `watchlist_entries`, `tags`,
+`entry_tags`, `activity_log`. Feature flags move to a small `settings` table (or Worker vars) in place
+of `app_settings`.
 
-**One open product question:** `watchlist_entries` currently feeds `taste_profiles`. Decide whether the
-household product keeps a personal watchlist as a taste input, or seeds taste from onboarding +
-`watched_together` thumbs only. That decision is the only thing keeping `watchlist_entries` on the
-table; everything else legacy goes.
+**Taste input (decided 2026-08-16):** `taste_profiles` is seeded from a light **onboarding** step
+(genre/mood picks + a few love-it/not-for-me swipes + the household's services) and refined from
+`watched_together` thumbs. The personal watchlist is **not** a taste input, so `watchlist_entries` is
+dropped with the rest of the legacy schema. A lightweight "save for tonight" list may return later as a
+convenience, but the recommender won't depend on it.
 
 ## Migrations
 

--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -15,6 +15,12 @@ below:
   Move off Express + Sequelize + Postgres + npm onto pnpm + Turborepo + Hono + Drizzle + D1 + R2 on
   Cloudflare Workers/Pages, mirroring the `creatorgrid` sibling repo. Migration phases in
   `docs/roadmap.md`.
+- **ADR 0002 — Session-cookie auth** (`docs/adr/0002-session-cookie-auth.md`, Accepted 2026-08-16).
+  Retire JWT for opaque D1 sessions + PBKDF2 (Web Crypto) + double-submit CSRF, ported from
+  creatorgrid (no native bcrypt on Workers).
+- **Taste input** (decided 2026-08-16) — seed `taste_profiles` from a light onboarding step and refine
+  from watched-together thumbs; the personal watchlist is retired and is not a taste input
+  (`docs/prd.md`, `docs/db-schema.md`).
 
 The table below is **pre-pivot history** — accurate for the old product, retained for context.
 

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -37,6 +37,7 @@ rate** (the household takes the first title offered).
 ## Features
 
 ### Free tier
+
 - Household pair profile (join two+ members).
 - Mood + time-budget Tonight picker.
 - Up to **3 picks/day**, single region (GB), ad-light.
@@ -44,12 +45,14 @@ rate** (the household takes the first title offered).
 - Watch-together history with thumbs.
 
 ### Premium (per household, monthly)
+
 - **Unlimited** picks.
 - **Multi-region** providers (for households that straddle regions or travel).
 - **LLM-assisted re-ranking** of the shortlist (opt-in, off by default on the platform).
 - Richer watch-together history.
 
 ### Admin
+
 - User management, content moderation, basic platform metrics. Staff-only.
 
 ## Non-goals (explicit)
@@ -57,18 +60,20 @@ rate** (the household takes the first title offered).
 - **Not** a social network — no feeds, groups, watch parties, DMs, or comments. (The old Phase-4
   "social entertainment platform" roadmap is retired.)
 - **Not** user-to-user matchmaking / "find a viewing partner". The household is assumed already paired.
-- **Not** a personal watchlist manager as the headline product. (Whether a lightweight watchlist
-  survives as a taste input is an open question — see `db-schema.md`.)
+- **Not** a personal watchlist manager as the headline product. Taste is seeded from a light
+  onboarding step and learned from watched-together thumbs; the old personal watchlist is retired and
+  is **not** a taste input. A lightweight "save for tonight" list may return later as a convenience,
+  but taste won't depend on it.
 - **Not** a player. Pairflix hands off to the streaming app; it never streams.
 
 ## Success metrics
 
-| Metric | Target |
-|---|---|
-| Time-to-decision | < 30 seconds |
-| First-pick acceptance rate | the north-star; grow it release over release |
-| Free → premium conversion | 3% (Y1) → 7% (Y3), per the seed plan |
-| Provider click-through | tracked via `pick_events` for affiliate attribution |
+| Metric                     | Target                                              |
+| -------------------------- | --------------------------------------------------- |
+| Time-to-decision           | < 30 seconds                                        |
+| First-pick acceptance rate | the north-star; grow it release over release        |
+| Free → premium conversion  | 3% (Y1) → 7% (Y3), per the seed plan                |
+| Provider click-through     | tracked via `pick_events` for affiliate attribution |
 
 ## Current status (alpha, pre-launch)
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -34,28 +34,34 @@
 Staged so the app keeps running through each step. Each phase is a PR with its docs updated.
 
 ### P1 — Restructure
+
 Move to pnpm + Turborepo + `apps/*` + `services/*` + `packages/*`; lift shared eslint/tsconfig/husky
 config from the sibling repos. App still runs on the current Node runtime.
 **Exit:** `pnpm dev` runs everything; `pnpm build` / `pnpm test` green across workspaces.
 
 ### P2 — Data layer
+
 Author the household schema fresh in `packages/db` (Drizzle + D1). No data migration — alpha.
-Drop legacy tables the product doesn't use (settle the watchlist/taste question first).
+Drop the legacy tables the product doesn't use — including `watchlist_entries` (taste now comes from
+onboarding + thumbs; see `db-schema.md`).
 **Exit:** `wrangler d1 migrations apply --local` builds the schema; Drizzle client typed.
 
 ### P3 — API
-Port route modules to a Hono Worker one domain at a time: **auth** (session cookie + PBKDF2 + CSRF) →
+
+Port route modules to a Hono Worker one domain at a time: **auth** (session cookie + PBKDF2 + CSRF, ADR 0002) →
 **households/pick** (wire in the LLM re-rank here) → **providers/history** → **billing/admin**.
 Collapse the two server entries into one; make email flows reachable.
 **Exit:** each domain has `vitest-pool-workers` integration tests against local D1; the pick path
 returns a title end-to-end on Miniflare.
 
 ### P4 — Frontends
+
 Move `app.client` / `app.admin` to `apps/*` on Pages; `lib.components` to `packages/`. Switch API
 clients from JWT to the cookie/CSRF flow.
 **Exit:** both SPAs run on `wrangler pages dev` against the local Worker.
 
 ### P5 — Cutover
+
 Point dev + deploy at wrangler; retire Docker/nginx from the app path; delete the old `backend/`
 Express tree.
 **Exit:** production deploys via `wrangler deploy` + Pages; the old stack is gone.
@@ -68,7 +74,9 @@ Independent of the platform, needed before opening to an invited cohort:
 - Extend the recommender to TV, and make runtime actually influence scoring.
 - Feed `ProviderBadges` real provider data on the Tonight card and history.
 - Integration tests for the pick / providers / entitlements paths.
-- Decide the taste-input model (watchlist vs onboarding + thumbs) and implement onboarding.
+- Build the **onboarding taste-starter** (genre/mood picks + a few love-it/not-for-me swipes + service
+  selection) to seed `taste_profiles` and solve cold-start — the decided taste model is onboarding +
+  watched-together thumbs, no watchlist.
 - Real Stripe (gated on go-live sign-off) — until then premium is comp/mock only.
 
 **Alpha exit criteria:** a real household can create an account, get a genuinely good first pick in


### PR DESCRIPTION
### 🚀 What's New

- 📝 Docs: **ADR 0002** (session-cookie auth) and a resolution of the taste-input open question left by ADR 0001.

---

### 📝 Description

**Docs-only.** Records the two decisions parked in the ADR 0001 migration spec.

**1. Auth (ADR 0002) — session-cookie, retire JWT.** Opaque session token in D1 + PBKDF2 (Web Crypto) + double-submit CSRF, ported from `creatorgrid`. Rationale: bcrypt has no native Workers implementation (hashing changes regardless), opaque D1 sessions are revocable (logout-everywhere, reset invalidation, 2FA, suspension), and an HttpOnly cookie removes the SPA token-storage XSS risk. JWT-on-Workers was rejected — it forces the same hashing change and rebuilds sessions via a refresh-token store for less security.

**2. Taste input — onboarding + thumbs, drop the watchlist.** `taste_profiles` is seeded from a light onboarding step (genre/mood picks + a few love-it/not-for-me swipes + service selection) and refined from watched-together thumbs. The personal watchlist is retired as a taste input, so `watchlist_entries` is dropped with the rest of the legacy schema. A maintained watchlist is the exact curation friction the pivot removes; onboarding solves cold-start without it.

**Changes:**
- New `docs/adr/0002-session-cookie-auth.md` (Accepted).
- `prd.md` / `db-schema.md` — resolved the taste-input question (onboarding + thumbs; `watchlist_entries` dropped).
- `roadmap.md` — folded the onboarding taste-starter into the alpha product work; cited ADR 0002 on the auth port.
- `decision-log.md` + docs index — recorded both decisions.

---

### ✅ Checklist

- [x] Changes follow the project's documentation conventions
- [x] I have performed a self-review
- [x] Relevant documentation updated (this PR *is* documentation)
- [ ] Tests — N/A, docs-only (no code changed)
- [x] No new warnings or errors introduced

---

### ⚠️ Notes for Reviewers

Follows ADR 0001; no code changes. The onboarding flow becomes a concrete build item in `roadmap.md`'s alpha product work, and `watchlist_entries` moves to the "dropped in the re-platform" list in `db-schema.md`.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XaZAU6ca9bxsD6vhj8j392

---
_Generated by [Claude Code](https://claude.ai/code/session_01XaZAU6ca9bxsD6vhj8j392)_