### PR TITLE
Clear inline-style lint backlog, promote forbid-component-props to error

### DIFF
--- a/apps/admin/src/components/layout/Layout.css.ts
+++ b/apps/admin/src/components/layout/Layout.css.ts
@@ -54,3 +54,11 @@ export const main = style({
   flex: 1,
   padding: `${vars.spacing.xl} 0`,
 });
+
+export const pageShell = style({
+  minHeight: '100vh',
+});
+
+export const brand = style({
+  cursor: 'pointer',
+});

--- a/apps/admin/src/components/layout/Layout.tsx
+++ b/apps/admin/src/components/layout/Layout.tsx
@@ -20,11 +20,11 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
   };
 
   return (
-    <Flex direction="column" style={{ minHeight: '100vh' }}>
+    <Flex direction="column" className={styles.pageShell}>
       <Card className={styles.header}>
         <Container>
           <Flex className={styles.headerContent}>
-            <H1 onClick={() => navigate('/')} style={{ cursor: 'pointer' }}>
+            <H1 onClick={() => navigate('/')} className={styles.brand}>
               PairFlix
             </H1>
             {isAuthenticated && (

--- a/apps/admin/src/features/admin/components/EnvironmentOverrides.css.ts
+++ b/apps/admin/src/features/admin/components/EnvironmentOverrides.css.ts
@@ -28,6 +28,14 @@ export const buttonGroup = style({
   marginTop: vars.spacing.md,
 });
 
+export const overridesGrid = style({
+  marginBottom: vars.spacing.md,
+});
+
+export const note = style({
+  marginTop: vars.spacing.md,
+});
+
 // `33` hex alpha suffix (~20%) becomes color-mix against the var() reference.
 export const environmentLabel = recipe({
   base: {

--- a/apps/admin/src/features/admin/components/EnvironmentOverrides.tsx
+++ b/apps/admin/src/features/admin/components/EnvironmentOverrides.tsx
@@ -183,7 +183,7 @@ const EnvironmentOverrides: React.FC = () => {
         </Alert>
       )}
 
-      <Grid columns={3} gap="md" style={{ marginBottom: '1rem' }}>
+      <Grid columns={3} gap="md" className={styles.overridesGrid}>
         {overrides.map(override => (
           <Card key={override.environment} className={styles.overrideCard}>
             <CardContent>
@@ -262,11 +262,7 @@ const EnvironmentOverrides: React.FC = () => {
         </CardContent>
       </Card>
 
-      <Typography
-        variant="body2"
-        color="secondary"
-        style={{ marginTop: '1rem' }}
-      >
+      <Typography variant="body2" color="secondary" className={styles.note}>
         Note: Environment overrides apply only when enabled and in the correct
         environment. When a setting is overridden, it completely replaces the
         default value.

--- a/apps/admin/src/features/admin/components/activity/AuditLogContent.tsx
+++ b/apps/admin/src/features/admin/components/activity/AuditLogContent.tsx
@@ -323,13 +323,13 @@ const AuditLogContent: React.FC = () => {
               <TableBody>
                 {isLoading ? (
                   <tr>
-                    <TableCell colSpan={5} style={{ textAlign: 'center' }}>
+                    <TableCell colSpan={5} align="center">
                       Loading...
                     </TableCell>
                   </tr>
                 ) : logs.length === 0 ? (
                   <tr>
-                    <TableCell colSpan={5} style={{ textAlign: 'center' }}>
+                    <TableCell colSpan={5} align="center">
                       No logs found
                     </TableCell>
                   </tr>

--- a/apps/admin/src/features/admin/components/activity/UserActivityContent.css.ts
+++ b/apps/admin/src/features/admin/components/activity/UserActivityContent.css.ts
@@ -17,6 +17,10 @@ export const sectionHeader = style({
   marginBottom: vars.spacing.md,
 });
 
+export const todayButton = style({
+  marginRight: '8px',
+});
+
 // `10` hex alpha suffix (~6%) becomes color-mix against the var() reference.
 export const tableRow = recipe({
   base: {

--- a/apps/admin/src/features/admin/components/activity/UserActivityContent.tsx
+++ b/apps/admin/src/features/admin/components/activity/UserActivityContent.tsx
@@ -306,7 +306,7 @@ const UserActivityContent: React.FC = () => {
               setTimeout(applyFilters, 0);
             }}
             variant="secondary"
-            style={{ marginRight: '8px' }}
+            className={styles.todayButton}
           >
             Today&apos;s Activities ({findTodayActivities()})
           </Button>
@@ -376,13 +376,13 @@ const UserActivityContent: React.FC = () => {
               <TableBody>
                 {isLoading ? (
                   <tr>
-                    <TableCell colSpan={4} style={{ textAlign: 'center' }}>
+                    <TableCell colSpan={4} align="center">
                       Loading...
                     </TableCell>
                   </tr>
                 ) : activities.length === 0 ? (
                   <tr>
-                    <TableCell colSpan={4} style={{ textAlign: 'center' }}>
+                    <TableCell colSpan={4} align="center">
                       No activities found
                     </TableCell>
                   </tr>

--- a/apps/admin/src/features/admin/components/content/ContentModerationContent.css.ts
+++ b/apps/admin/src/features/admin/components/content/ContentModerationContent.css.ts
@@ -15,3 +15,41 @@ export const styledCard = style({
   marginBottom: '10px',
   padding: '15px',
 });
+
+export const alertSpacing = style({
+  marginBottom: '1rem',
+});
+
+export const filterBar = style({
+  marginBottom: '1rem',
+});
+
+export const resultsCount = style({
+  margin: '1rem 0',
+});
+
+export const pageIndicator = style({
+  alignSelf: 'center',
+});
+
+export const modalFooter = style({
+  marginTop: '20px',
+});
+
+export const fieldLabel = style({
+  marginBottom: '8px',
+});
+
+export const contentTypeHint = style({
+  marginTop: '4px',
+  fontSize: '0.875rem',
+  color: '#666',
+});
+
+export const reporterName = style({
+  fontWeight: vars.typography.fontWeight.bold,
+});
+
+export const reportMeta = style({
+  marginTop: '8px',
+});

--- a/apps/admin/src/features/admin/components/content/ContentModerationContent.tsx
+++ b/apps/admin/src/features/admin/components/content/ContentModerationContent.tsx
@@ -373,18 +373,18 @@ const ContentModerationContent: React.FC = () => {
         <CardContent>
           {/* Success/Error Messages */}
           {successMessage && (
-            <Alert variant="success" style={{ marginBottom: '1rem' }}>
+            <Alert variant="success" className={styles.alertSpacing}>
               {successMessage}
             </Alert>
           )}
           {errorMessage && (
-            <Alert variant="error" style={{ marginBottom: '1rem' }}>
+            <Alert variant="error" className={styles.alertSpacing}>
               {errorMessage}
             </Alert>
           )}
 
           {/* Optimized Filters */}
-          <Flex direction="column" gap="md" style={{ marginBottom: '1rem' }}>
+          <Flex direction="column" gap="md" className={styles.filterBar}>
             <Flex direction="row" gap="sm" wrap="wrap">
               <div style={{ flex: '1 1 300px', minWidth: '200px' }}>
                 <Input
@@ -462,7 +462,7 @@ const ContentModerationContent: React.FC = () => {
           ) : (
             <>
               {/* Optimized content grid rendering would go here */}
-              <Typography variant="body2" style={{ margin: '1rem 0' }}>
+              <Typography variant="body2" className={styles.resultsCount}>
                 Showing {filteredContent.length} items (Page {page} of{' '}
                 {totalPages})
               </Typography>
@@ -484,7 +484,7 @@ const ContentModerationContent: React.FC = () => {
                 >
                   Previous
                 </Button>
-                <Typography style={{ alignSelf: 'center' }}>
+                <Typography className={styles.pageIndicator}>
                   Page {page} of {totalPages}
                 </Typography>
                 <Button
@@ -530,7 +530,7 @@ const ContentModerationContent: React.FC = () => {
           />
         </div>
 
-        <Flex justifyContent="end" gap="md" style={{ marginTop: '20px' }}>
+        <Flex justifyContent="end" gap="md" className={styles.modalFooter}>
           <Button variant="secondary" onClick={() => setShowRemoveModal(false)}>
             Cancel
           </Button>
@@ -596,7 +596,7 @@ const ContentModerationContent: React.FC = () => {
             </div>
 
             <div style={{ marginBottom: '16px' }}>
-              <Typography style={{ marginBottom: '8px' }}>
+              <Typography className={styles.fieldLabel}>
                 Content Type:
               </Typography>
               <Badge
@@ -605,18 +605,12 @@ const ContentModerationContent: React.FC = () => {
               >
                 {contentToEdit.type}
               </Badge>
-              <Typography
-                style={{
-                  marginTop: '4px',
-                  fontSize: '0.875rem',
-                  color: '#666',
-                }}
-              >
+              <Typography className={styles.contentTypeHint}>
                 Content type cannot be changed
               </Typography>
             </div>
 
-            <Flex justifyContent="end" gap="md" style={{ marginTop: '20px' }}>
+            <Flex justifyContent="end" gap="md" className={styles.modalFooter}>
               <Button
                 variant="secondary"
                 onClick={() => setShowEditModal(false)}
@@ -667,15 +661,15 @@ const ContentModerationContent: React.FC = () => {
                     <Card className={styles.styledCard} key={report.id}>
                       <Flex justifyContent="space-between" alignItems="start">
                         <div>
-                          <Typography style={{ fontWeight: 'bold' }}>
+                          <Typography className={styles.reporterName}>
                             Reported by: {report.user_name} on{' '}
                             {new Date(report.created_at).toLocaleDateString()}
                           </Typography>
-                          <Typography style={{ marginTop: '8px' }}>
+                          <Typography className={styles.reportMeta}>
                             Reason: {report.reason}
                           </Typography>
                           {report.details && (
-                            <Typography style={{ marginTop: '8px' }}>
+                            <Typography className={styles.reportMeta}>
                               Details: {report.details}
                             </Typography>
                           )}

--- a/apps/admin/src/features/admin/components/content/user-management/BanUserModal.css.ts
+++ b/apps/admin/src/features/admin/components/content/user-management/BanUserModal.css.ts
@@ -1,0 +1,5 @@
+import { style } from '@vanilla-extract/css';
+
+export const modalFooter = style({
+  marginTop: '20px',
+});

--- a/apps/admin/src/features/admin/components/content/user-management/BanUserModal.tsx
+++ b/apps/admin/src/features/admin/components/content/user-management/BanUserModal.tsx
@@ -6,6 +6,7 @@ import {
   Typography,
 } from '@pairflix/components';
 import React from 'react';
+import * as styles from './BanUserModal.css';
 import type { User } from './types';
 
 interface BanUserModalProps {
@@ -51,7 +52,7 @@ const BanUserModal: React.FC<BanUserModalProps> = ({
         />
       </div>
 
-      <Flex justifyContent="end" gap="md" style={{ marginTop: '20px' }}>
+      <Flex justifyContent="end" gap="md" className={styles.modalFooter}>
         <Button variant="secondary" onClick={onClose}>
           Cancel
         </Button>

--- a/apps/admin/src/features/admin/components/content/user-management/ChangeRoleModal.css.ts
+++ b/apps/admin/src/features/admin/components/content/user-management/ChangeRoleModal.css.ts
@@ -1,0 +1,5 @@
+import { style } from '@vanilla-extract/css';
+
+export const modalFooter = style({
+  marginTop: '20px',
+});

--- a/apps/admin/src/features/admin/components/content/user-management/ChangeRoleModal.tsx
+++ b/apps/admin/src/features/admin/components/content/user-management/ChangeRoleModal.tsx
@@ -8,6 +8,7 @@ import {
   Typography,
 } from '@pairflix/components';
 import React from 'react';
+import * as styles from './ChangeRoleModal.css';
 import type { User, UserRole } from './types';
 import { getRoleBadgeVariant } from './utils';
 interface ChangeRoleModalProps {
@@ -84,7 +85,7 @@ const ChangeRoleModal: React.FC<ChangeRoleModalProps> = ({
           />
         </div>
 
-        <Flex justifyContent="end" gap="md" style={{ marginTop: '20px' }}>
+        <Flex justifyContent="end" gap="md" className={styles.modalFooter}>
           <Button variant="secondary" onClick={onClose}>
             Cancel
           </Button>

--- a/apps/admin/src/features/admin/components/content/user-management/ChangeStatusModal.css.ts
+++ b/apps/admin/src/features/admin/components/content/user-management/ChangeStatusModal.css.ts
@@ -1,0 +1,5 @@
+import { style } from '@vanilla-extract/css';
+
+export const modalFooter = style({
+  marginTop: '20px',
+});

--- a/apps/admin/src/features/admin/components/content/user-management/ChangeStatusModal.tsx
+++ b/apps/admin/src/features/admin/components/content/user-management/ChangeStatusModal.tsx
@@ -8,6 +8,7 @@ import {
   Typography,
 } from '@pairflix/components';
 import React from 'react';
+import * as styles from './ChangeStatusModal.css';
 import type { User, UserStatus } from './types';
 import { getBadgeVariant } from './utils';
 interface ChangeStatusModalProps {
@@ -86,7 +87,7 @@ const ChangeStatusModal: React.FC<ChangeStatusModalProps> = ({
           />
         </div>
 
-        <Flex justifyContent="end" gap="md" style={{ marginTop: '20px' }}>
+        <Flex justifyContent="end" gap="md" className={styles.modalFooter}>
           <Button variant="secondary" onClick={onClose}>
             Cancel
           </Button>

--- a/apps/admin/src/features/admin/components/content/user-management/CreateUserModal.css.ts
+++ b/apps/admin/src/features/admin/components/content/user-management/CreateUserModal.css.ts
@@ -28,3 +28,11 @@ export const modalContent = style({
   maxWidth: '500px',
   width: '100%',
 });
+
+export const modalFooter = style({
+  marginTop: '20px',
+});
+
+export const buttonIcon = style({
+  marginRight: '8px',
+});

--- a/apps/admin/src/features/admin/components/content/user-management/CreateUserModal.tsx
+++ b/apps/admin/src/features/admin/components/content/user-management/CreateUserModal.tsx
@@ -198,12 +198,12 @@ const CreateUserModal: React.FC<CreateUserModalProps> = ({
             </select>
           </div>
 
-          <Flex justifyContent="end" gap="md" style={{ marginTop: '20px' }}>
+          <Flex justifyContent="end" gap="md" className={styles.modalFooter}>
             <Button variant="secondary" onClick={onClose}>
               Cancel
             </Button>
             <Button type="submit">
-              <FiUser style={{ marginRight: '8px' }} /> Create User
+              <FiUser className={styles.buttonIcon} /> Create User
             </Button>
           </Flex>
         </form>

--- a/apps/admin/src/features/admin/components/content/user-management/EditUserModal.css.ts
+++ b/apps/admin/src/features/admin/components/content/user-management/EditUserModal.css.ts
@@ -1,0 +1,9 @@
+import { style } from '@vanilla-extract/css';
+
+export const readonlyLabel = style({
+  marginBottom: '8px',
+});
+
+export const modalFooter = style({
+  marginTop: '20px',
+});

--- a/apps/admin/src/features/admin/components/content/user-management/EditUserModal.tsx
+++ b/apps/admin/src/features/admin/components/content/user-management/EditUserModal.tsx
@@ -1,5 +1,6 @@
 import { Button, Flex, Modal, Select, Typography } from '@pairflix/components';
 import React from 'react';
+import * as styles from './EditUserModal.css';
 import type { User, UserRole, UserStatus } from './types';
 
 interface EditUserModalProps {
@@ -78,7 +79,7 @@ const EditUserModal: React.FC<EditUserModalProps> = ({
         </div>
 
         <div style={{ marginBottom: '16px' }}>
-          <Typography style={{ fontWeight: 'bold', marginBottom: '8px' }}>
+          <Typography weight="bold" className={styles.readonlyLabel}>
             User Information (Read-only)
           </Typography>
           <div style={{ marginBottom: '8px' }}>
@@ -93,7 +94,7 @@ const EditUserModal: React.FC<EditUserModalProps> = ({
           </div>
         </div>
 
-        <Flex justifyContent="end" gap="md" style={{ marginTop: '20px' }}>
+        <Flex justifyContent="end" gap="md" className={styles.modalFooter}>
           <Button variant="secondary" onClick={onClose}>
             Cancel
           </Button>

--- a/apps/admin/src/features/admin/components/content/user-management/MessageComponents.css.ts
+++ b/apps/admin/src/features/admin/components/content/user-management/MessageComponents.css.ts
@@ -1,0 +1,9 @@
+import { style } from '@vanilla-extract/css';
+
+export const successText = style({
+  color: '#3c763d',
+});
+
+export const errorText = style({
+  color: '#a94442',
+});

--- a/apps/admin/src/features/admin/components/content/user-management/MessageComponents.tsx
+++ b/apps/admin/src/features/admin/components/content/user-management/MessageComponents.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Typography } from '@pairflix/components';
+import * as styles from './MessageComponents.css';
 
 interface MessageProps {
   message: string;
@@ -18,7 +19,7 @@ export const SuccessMessage: React.FC<MessageProps> = ({ message }) => {
         border: '1px solid #d6e9c6',
       }}
     >
-      <Typography style={{ color: '#3c763d' }}>{message}</Typography>
+      <Typography className={styles.successText}>{message}</Typography>
     </div>
   );
 };
@@ -36,7 +37,7 @@ export const ErrorMessage: React.FC<MessageProps> = ({ message }) => {
         border: '1px solid #ebccd1',
       }}
     >
-      <Typography style={{ color: '#a94442' }}>{message}</Typography>
+      <Typography className={styles.errorText}>{message}</Typography>
     </div>
   );
 };

--- a/apps/admin/src/features/admin/components/content/user-management/ResetPasswordModal.css.ts
+++ b/apps/admin/src/features/admin/components/content/user-management/ResetPasswordModal.css.ts
@@ -10,3 +10,7 @@ export const passwordDisplay = style({
   fontFamily: 'monospace',
   fontSize: '18px',
 });
+
+export const modalFooter = style({
+  marginTop: '20px',
+});

--- a/apps/admin/src/features/admin/components/content/user-management/ResetPasswordModal.tsx
+++ b/apps/admin/src/features/admin/components/content/user-management/ResetPasswordModal.tsx
@@ -34,7 +34,7 @@ const ResetPasswordModal: React.FC<ResetPasswordModalProps> = ({
         </div>
       )}
 
-      <Flex justifyContent="end" gap="md" style={{ marginTop: '20px' }}>
+      <Flex justifyContent="end" gap="md" className={styles.modalFooter}>
         <Button variant="secondary" onClick={onClose}>
           Cancel
         </Button>

--- a/apps/admin/src/features/admin/components/content/user-management/UserActivityModal.css.ts
+++ b/apps/admin/src/features/admin/components/content/user-management/UserActivityModal.css.ts
@@ -1,0 +1,5 @@
+import { style } from '@vanilla-extract/css';
+
+export const modalFooter = style({
+  marginTop: '20px',
+});

--- a/apps/admin/src/features/admin/components/content/user-management/UserActivityModal.tsx
+++ b/apps/admin/src/features/admin/components/content/user-management/UserActivityModal.tsx
@@ -13,6 +13,7 @@ import {
   Typography,
 } from '@pairflix/components';
 import React from 'react';
+import * as styles from './UserActivityModal.css';
 import type { User, UserActivity } from './types';
 
 interface UserActivityModalProps {
@@ -101,7 +102,7 @@ const UserActivityModal: React.FC<UserActivityModalProps> = ({
         </Card>
       )}
 
-      <Flex justifyContent="end" gap="md" style={{ marginTop: '20px' }}>
+      <Flex justifyContent="end" gap="md" className={styles.modalFooter}>
         <Button variant="secondary" onClick={onClose}>
           Close
         </Button>

--- a/apps/admin/src/features/admin/components/content/user-management/UserFilter.css.ts
+++ b/apps/admin/src/features/admin/components/content/user-management/UserFilter.css.ts
@@ -1,0 +1,9 @@
+import { style } from '@vanilla-extract/css';
+
+export const filterHeader = style({
+  marginBottom: '20px',
+});
+
+export const createButton = style({
+  marginLeft: '20px',
+});

--- a/apps/admin/src/features/admin/components/content/user-management/UserFilter.tsx
+++ b/apps/admin/src/features/admin/components/content/user-management/UserFilter.tsx
@@ -9,7 +9,8 @@ import {
 import React from 'react';
 import { FiUserPlus } from 'react-icons/fi';
 import type { UserManagementFilters } from './types';
-import { IconStyle } from './utils';
+import * as styles from './UserFilter.css';
+import { icon } from './utils.css';
 
 interface UserFilterProps {
   search: string;
@@ -35,7 +36,7 @@ const UserFilter: React.FC<UserFilterProps> = ({
       <Flex
         justifyContent="space-between"
         alignItems="center"
-        style={{ marginBottom: '20px' }}
+        className={styles.filterHeader}
       >
         <div style={{ flex: 1 }}>
           <Input
@@ -48,10 +49,10 @@ const UserFilter: React.FC<UserFilterProps> = ({
         </div>
         <Button
           variant="primary"
-          style={{ marginLeft: '20px' }}
+          className={styles.createButton}
           onClick={onCreateUser}
         >
-          <FiUserPlus style={IconStyle} /> Create User
+          <FiUserPlus className={icon} /> Create User
         </Button>
       </Flex>
 

--- a/apps/admin/src/features/admin/components/content/user-management/UserTable.tsx
+++ b/apps/admin/src/features/admin/components/content/user-management/UserTable.tsx
@@ -9,7 +9,8 @@ import {
   RiUserUnfollowLine,
 } from 'react-icons/ri';
 import type { User, UserRole, UserStatus } from './types';
-import { getBadgeVariant, getRoleBadgeVariant, IconStyle } from './utils';
+import { getBadgeVariant, getRoleBadgeVariant } from './utils';
+import { icon } from './utils.css';
 
 import {
   Badge,
@@ -98,7 +99,7 @@ const UserTable: React.FC<UserTableProps> = (props: UserTableProps) => {
   const renderActions = (user: UserRecord) => (
     <Flex gap="xs">
       <TableActionButton onClick={() => onEditUser(user)} title="Edit user">
-        <FiEdit style={IconStyle} />
+        <FiEdit className={icon} />
       </TableActionButton>
 
       <TableActionButton
@@ -106,7 +107,7 @@ const UserTable: React.FC<UserTableProps> = (props: UserTableProps) => {
         title="View activity"
         variant="secondary"
       >
-        <RiHistoryLine style={IconStyle} />
+        <RiHistoryLine className={icon} />
       </TableActionButton>
 
       <TableActionButton
@@ -114,7 +115,7 @@ const UserTable: React.FC<UserTableProps> = (props: UserTableProps) => {
         title="Reset password"
         variant="secondary"
       >
-        <FiKey style={IconStyle} />
+        <FiKey className={icon} />
       </TableActionButton>
 
       <TableActionButton
@@ -122,7 +123,7 @@ const UserTable: React.FC<UserTableProps> = (props: UserTableProps) => {
         title="Change role"
         variant="primary"
       >
-        <RiUserSettingsLine style={IconStyle} />
+        <RiUserSettingsLine className={icon} />
       </TableActionButton>
 
       <TableActionButton
@@ -130,7 +131,7 @@ const UserTable: React.FC<UserTableProps> = (props: UserTableProps) => {
         title="Change status"
         variant="warning"
       >
-        <RiExchangeLine style={IconStyle} />
+        <RiExchangeLine className={icon} />
       </TableActionButton>
 
       {(user.status as UserStatus) === 'suspended' ||
@@ -140,7 +141,7 @@ const UserTable: React.FC<UserTableProps> = (props: UserTableProps) => {
           title="Activate user"
           variant="primary"
         >
-          <RiUserFollowLine style={IconStyle} />
+          <RiUserFollowLine className={icon} />
         </TableActionButton>
       ) : (
         <>
@@ -150,7 +151,7 @@ const UserTable: React.FC<UserTableProps> = (props: UserTableProps) => {
               title="Suspend user"
               variant="warning"
             >
-              <RiUserForbidLine style={IconStyle} />
+              <RiUserForbidLine className={icon} />
             </TableActionButton>
           ) : (user.status as UserStatus) === 'pending' ||
             (user.status as UserStatus) === 'inactive' ? (
@@ -159,7 +160,7 @@ const UserTable: React.FC<UserTableProps> = (props: UserTableProps) => {
               title="Activate user"
               variant="primary"
             >
-              <RiUserFollowLine style={IconStyle} />
+              <RiUserFollowLine className={icon} />
             </TableActionButton>
           ) : null}
 
@@ -168,7 +169,7 @@ const UserTable: React.FC<UserTableProps> = (props: UserTableProps) => {
             onClick={() => onBanUser(user)}
             title="Ban user"
           >
-            <RiUserUnfollowLine style={IconStyle} />
+            <RiUserUnfollowLine className={icon} />
           </TableActionButton>
         </>
       )}

--- a/apps/admin/src/features/admin/components/content/user-management/utils.css.ts
+++ b/apps/admin/src/features/admin/components/content/user-management/utils.css.ts
@@ -1,0 +1,5 @@
+import { style } from '@vanilla-extract/css';
+
+export const icon = style({
+  fontSize: '1.2rem',
+});

--- a/apps/admin/src/features/admin/components/content/user-management/utils.ts
+++ b/apps/admin/src/features/admin/components/content/user-management/utils.ts
@@ -40,6 +40,3 @@ export const getRoleBadgeVariant = (
       return 'default';
   }
 };
-
-// Define a style for the icons
-export const IconStyle = { fontSize: '1.2rem' };

--- a/apps/admin/src/features/admin/components/dashboard/AdminDashboardContent.css.ts
+++ b/apps/admin/src/features/admin/components/dashboard/AdminDashboardContent.css.ts
@@ -16,3 +16,25 @@ export const sectionTitle = style({
   marginBottom: vars.spacing.md,
   marginTop: vars.spacing.lg,
 });
+
+export const retryButton = style({
+  marginTop: vars.spacing.md,
+});
+
+export const recentUsersTrend = style({
+  marginTop: vars.spacing.sm,
+});
+
+export const systemErrorText = style({
+  color: 'var(--color-error)',
+  marginTop: vars.spacing.sm,
+});
+
+export const testNavLink = style({
+  display: 'inline-block',
+  padding: '8px 16px',
+  backgroundColor: '#4CAF50',
+  color: 'white',
+  textDecoration: 'none',
+  borderRadius: '4px',
+});

--- a/apps/admin/src/features/admin/components/dashboard/AdminDashboardContent.tsx
+++ b/apps/admin/src/features/admin/components/dashboard/AdminDashboardContent.tsx
@@ -163,7 +163,7 @@ const AdminDashboardContent: React.FC = () => {
         <Card variant="primary" accentColor="var(--color-error)">
           <CardContent>
             <Typography variant="body1">{error}</Typography>
-            <Button onClick={handleRefreshStats} style={{ marginTop: '1rem' }}>
+            <Button onClick={handleRefreshStats} className={styles.retryButton}>
               Try Again
             </Button>
           </CardContent>
@@ -208,7 +208,10 @@ const AdminDashboardContent: React.FC = () => {
                       {metrics.recentUsers.count} new users in the last{' '}
                       {metrics.recentUsers.days} days
                     </Typography>
-                    <Typography variant="body2" style={{ marginTop: '0.5rem' }}>
+                    <Typography
+                      variant="body2"
+                      className={styles.recentUsersTrend}
+                    >
                       {metrics.recentUsers.percentage}%{' '}
                       {metrics.recentUsers.trend === 'up'
                         ? 'increase'
@@ -237,10 +240,7 @@ const AdminDashboardContent: React.FC = () => {
                     {metrics.system.recentErrors > 0 && (
                       <Typography
                         variant="body2"
-                        style={{
-                          color: 'var(--color-error)',
-                          marginTop: '0.5rem',
-                        }}
+                        className={styles.systemErrorText}
                       >
                         {metrics.system.recentErrors} errors in the last 24
                         hours
@@ -312,17 +312,7 @@ const AdminDashboardContent: React.FC = () => {
           >
             <Typography>Test direct navigation:</Typography>
             <div style={{ marginTop: '10px' }}>
-              <Link
-                to="/users"
-                style={{
-                  display: 'inline-block',
-                  padding: '8px 16px',
-                  backgroundColor: '#4CAF50',
-                  color: 'white',
-                  textDecoration: 'none',
-                  borderRadius: '4px',
-                }}
-              >
+              <Link to="/users" className={styles.testNavLink}>
                 Go to Users Page
               </Link>
             </div>

--- a/apps/admin/src/features/admin/components/dashboard/SystemMonitoringContent.css.ts
+++ b/apps/admin/src/features/admin/components/dashboard/SystemMonitoringContent.css.ts
@@ -70,3 +70,20 @@ export const metricChart = style({
   height: '160px',
   marginTop: vars.spacing.md,
 });
+
+export const retryButton = style({
+  marginTop: vars.spacing.md,
+});
+
+export const detailedStatsGrid = style({
+  marginTop: vars.spacing.lg,
+});
+
+export const sectionHeading = style({
+  marginTop: vars.spacing.lg,
+  marginBottom: vars.spacing.md,
+});
+
+export const alertMessage = style({
+  fontWeight: vars.typography.fontWeight.bold,
+});

--- a/apps/admin/src/features/admin/components/dashboard/SystemMonitoringContent.tsx
+++ b/apps/admin/src/features/admin/components/dashboard/SystemMonitoringContent.tsx
@@ -381,7 +381,7 @@ const SystemMonitoringContent: React.FC = () => {
       <Card variant="primary" accentColor="var(--color-error)">
         <CardContent>
           <Typography variant="body1">{error}</Typography>
-          <Button onClick={handleRefresh} style={{ marginTop: '1rem' }}>
+          <Button onClick={handleRefresh} className={styles.retryButton}>
             Try Again
           </Button>
         </CardContent>
@@ -565,7 +565,7 @@ const SystemMonitoringContent: React.FC = () => {
           </Grid>
 
           {/* Detailed System Stats */}
-          <Grid columns={3} gap="md" style={{ marginTop: '1.5rem' }}>
+          <Grid columns={3} gap="md" className={styles.detailedStatsGrid}>
             <Card className={styles.statsCard}>
               <CardContent>
                 <H3>Database Stats</H3>
@@ -672,9 +672,7 @@ const SystemMonitoringContent: React.FC = () => {
           </Grid>
 
           {/* Active Users */}
-          <H3 style={{ marginTop: '1.5rem', marginBottom: '1rem' }}>
-            User Activity
-          </H3>
+          <H3 className={styles.sectionHeading}>User Activity</H3>
           <Card className={styles.statsCard}>
             <CardContent>
               <Grid columns={3} gap="md">
@@ -743,9 +741,7 @@ const SystemMonitoringContent: React.FC = () => {
           {/* System Alerts */}
           {monitoringData.alerts && monitoringData.alerts.length > 0 && (
             <>
-              <H3 style={{ marginTop: '1.5rem', marginBottom: '1rem' }}>
-                System Alerts
-              </H3>
+              <H3 className={styles.sectionHeading}>System Alerts</H3>
               <Card
                 className={styles.statsCard}
                 variant="primary"
@@ -757,7 +753,7 @@ const SystemMonitoringContent: React.FC = () => {
                       <div key={index} style={{ marginBottom: '1rem' }}>
                         <Typography
                           variant="body1"
-                          style={{ fontWeight: 'bold' }}
+                          className={styles.alertMessage}
                         >
                           {alert.severity === 'critical'
                             ? '🔴'

--- a/apps/admin/src/features/admin/components/dashboard/SystemStatsContent.css.ts
+++ b/apps/admin/src/features/admin/components/dashboard/SystemStatsContent.css.ts
@@ -15,3 +15,11 @@ export const sectionHeader = style({
 export const statsTable = style({
   overflow: 'hidden',
 });
+
+export const cellLabel = style({
+  fontWeight: vars.typography.fontWeight.bold,
+});
+
+export const refreshButton = style({
+  marginTop: vars.spacing.md,
+});

--- a/apps/admin/src/features/admin/components/dashboard/SystemStatsContent.tsx
+++ b/apps/admin/src/features/admin/components/dashboard/SystemStatsContent.tsx
@@ -177,25 +177,25 @@ const SystemStatsContent: React.FC = () => {
                   <Table>
                     <TableBody>
                       <tr>
-                        <TableCell style={{ fontWeight: 'bold' }}>
+                        <TableCell className={styles.cellLabel}>
                           Hostname
                         </TableCell>
                         <TableCell>{statsData.system.hostname}</TableCell>
                       </tr>
                       <tr>
-                        <TableCell style={{ fontWeight: 'bold' }}>
+                        <TableCell className={styles.cellLabel}>
                           Platform
                         </TableCell>
                         <TableCell>{statsData.system.platform}</TableCell>
                       </tr>
                       <tr>
-                        <TableCell style={{ fontWeight: 'bold' }}>
+                        <TableCell className={styles.cellLabel}>
                           Architecture
                         </TableCell>
                         <TableCell>{statsData.system.arch}</TableCell>
                       </tr>
                       <tr>
-                        <TableCell style={{ fontWeight: 'bold' }}>
+                        <TableCell className={styles.cellLabel}>
                           Server Uptime
                         </TableCell>
                         <TableCell>
@@ -213,7 +213,7 @@ const SystemStatsContent: React.FC = () => {
                   <Table>
                     <TableBody>
                       <tr>
-                        <TableCell style={{ fontWeight: 'bold' }}>
+                        <TableCell className={styles.cellLabel}>
                           Node Version
                         </TableCell>
                         <TableCell>
@@ -221,7 +221,7 @@ const SystemStatsContent: React.FC = () => {
                         </TableCell>
                       </tr>
                       <tr>
-                        <TableCell style={{ fontWeight: 'bold' }}>
+                        <TableCell className={styles.cellLabel}>
                           App Version
                         </TableCell>
                         <TableCell>
@@ -229,7 +229,7 @@ const SystemStatsContent: React.FC = () => {
                         </TableCell>
                       </tr>
                       <tr>
-                        <TableCell style={{ fontWeight: 'bold' }}>
+                        <TableCell className={styles.cellLabel}>
                           Process Uptime
                         </TableCell>
                         <TableCell>
@@ -239,7 +239,7 @@ const SystemStatsContent: React.FC = () => {
                         </TableCell>
                       </tr>
                       <tr>
-                        <TableCell style={{ fontWeight: 'bold' }}>
+                        <TableCell className={styles.cellLabel}>
                           Process ID
                         </TableCell>
                         <TableCell>
@@ -269,7 +269,7 @@ const SystemStatsContent: React.FC = () => {
                       {Object.entries(statsData.environment || {}).map(
                         ([key, value]) => (
                           <tr key={key}>
-                            <TableCell style={{ fontWeight: 'bold' }}>
+                            <TableCell className={styles.cellLabel}>
                               {key}
                             </TableCell>
                             <TableCell>
@@ -299,7 +299,7 @@ const SystemStatsContent: React.FC = () => {
                   <Table>
                     <TableBody>
                       <tr>
-                        <TableCell style={{ fontWeight: 'bold' }}>
+                        <TableCell className={styles.cellLabel}>
                           Status
                         </TableCell>
                         <TableCell>
@@ -317,13 +317,11 @@ const SystemStatsContent: React.FC = () => {
                         </TableCell>
                       </tr>
                       <tr>
-                        <TableCell style={{ fontWeight: 'bold' }}>
-                          Type
-                        </TableCell>
+                        <TableCell className={styles.cellLabel}>Type</TableCell>
                         <TableCell>{statsData.database.type}</TableCell>
                       </tr>
                       <tr>
-                        <TableCell style={{ fontWeight: 'bold' }}>
+                        <TableCell className={styles.cellLabel}>
                           Version
                         </TableCell>
                         <TableCell>{statsData.database.version}</TableCell>
@@ -339,7 +337,7 @@ const SystemStatsContent: React.FC = () => {
                   <Table>
                     <TableBody>
                       <tr>
-                        <TableCell style={{ fontWeight: 'bold' }}>
+                        <TableCell className={styles.cellLabel}>
                           Connections
                         </TableCell>
                         <TableCell>
@@ -348,7 +346,7 @@ const SystemStatsContent: React.FC = () => {
                         </TableCell>
                       </tr>
                       <tr>
-                        <TableCell style={{ fontWeight: 'bold' }}>
+                        <TableCell className={styles.cellLabel}>
                           Avg. Query Time
                         </TableCell>
                         <TableCell>
@@ -358,7 +356,7 @@ const SystemStatsContent: React.FC = () => {
                         </TableCell>
                       </tr>
                       <tr>
-                        <TableCell style={{ fontWeight: 'bold' }}>
+                        <TableCell className={styles.cellLabel}>
                           Slow Queries (24h)
                         </TableCell>
                         <TableCell>
@@ -412,10 +410,7 @@ const SystemStatsContent: React.FC = () => {
                         ))
                       ) : (
                         <tr>
-                          <TableCell
-                            colSpan={4}
-                            style={{ textAlign: 'center' }}
-                          >
+                          <TableCell colSpan={4} align="center">
                             No dependency information available
                           </TableCell>
                         </tr>
@@ -444,10 +439,7 @@ const SystemStatsContent: React.FC = () => {
                     <TableBody>
                       {!statsData.events || statsData.events.length === 0 ? (
                         <tr>
-                          <TableCell
-                            colSpan={4}
-                            style={{ textAlign: 'center' }}
-                          >
+                          <TableCell colSpan={4} align="center">
                             No events recorded in the last 24 hours
                           </TableCell>
                         </tr>
@@ -491,7 +483,7 @@ const SystemStatsContent: React.FC = () => {
       <Button
         variant="primary"
         onClick={fetchSystemStats}
-        style={{ marginTop: '1rem' }}
+        className={styles.refreshButton}
       >
         Refresh Stats
       </Button>

--- a/apps/admin/src/features/admin/components/shared/StatsOverview.css.ts
+++ b/apps/admin/src/features/admin/components/shared/StatsOverview.css.ts
@@ -42,6 +42,10 @@ export const statIcon = style({
   color: vars.colors.primary,
 });
 
+export const mostActiveLabel = style({
+  marginTop: vars.spacing.md,
+});
+
 export const statusIndicator = recipe({
   base: {
     width: '12px',

--- a/apps/admin/src/features/admin/components/shared/StatsOverview.tsx
+++ b/apps/admin/src/features/admin/components/shared/StatsOverview.tsx
@@ -380,7 +380,11 @@ export const ActivityCard: React.FC<ActivityCardProps> = ({
             </Flex>
           ))}
 
-        <Typography variant="body2" gutterBottom style={{ marginTop: '1rem' }}>
+        <Typography
+          variant="body2"
+          gutterBottom
+          className={styles.mostActiveLabel}
+        >
           Most active users:
         </Typography>
 

--- a/apps/client/src/components/layout/Layout.css.ts
+++ b/apps/client/src/components/layout/Layout.css.ts
@@ -172,6 +172,11 @@ export const section = recipe({
 
 // ======== Main layout shell ========
 
+export const appShell = style({
+  minHeight: '100vh',
+  width: '100%',
+});
+
 export const header = style({
   margin: 0,
   borderRadius: 0,

--- a/apps/client/src/components/layout/Layout.tsx
+++ b/apps/client/src/components/layout/Layout.tsx
@@ -416,7 +416,7 @@ const Layout: React.FC<LayoutProps> = ({
   };
 
   return (
-    <Flex direction="column" style={{ minHeight: '100vh', width: '100%' }}>
+    <Flex direction="column" className={styles.appShell}>
       <Header>
         <Container fluid>
           <HeaderContent>

--- a/apps/client/src/features/auth/RegisterPage.css.ts
+++ b/apps/client/src/features/auth/RegisterPage.css.ts
@@ -34,3 +34,16 @@ export const iconWrapper = style({
   fontSize: '3rem',
   marginBottom: '1rem',
 });
+
+export const successHeading = style({
+  marginBottom: '1rem',
+});
+
+export const successMessageSpacing = style({
+  marginBottom: '1rem',
+});
+
+export const createAccountHeading = style({
+  textAlign: 'center',
+  marginBottom: '2rem',
+});

--- a/apps/client/src/features/auth/RegisterPage.tsx
+++ b/apps/client/src/features/auth/RegisterPage.tsx
@@ -128,8 +128,8 @@ const RegisterPage: React.FC = () => {
           <CardContent>
             <div className={styles.successContainer}>
               <div className={styles.iconWrapper}>📧</div>
-              <H2 style={{ marginBottom: '1rem' }}>Check Your Email!</H2>
-              <SuccessText style={{ marginBottom: '1rem' }}>
+              <H2 className={styles.successHeading}>Check Your Email!</H2>
+              <SuccessText className={styles.successMessageSpacing}>
                 {success}
               </SuccessText>
               <p
@@ -168,9 +168,7 @@ const RegisterPage: React.FC = () => {
     <Container className={styles.registerContainer}>
       <Card className={styles.registerCard}>
         <CardContent>
-          <H2 style={{ textAlign: 'center', marginBottom: '2rem' }}>
-            Create Account
-          </H2>
+          <H2 className={styles.createAccountHeading}>Create Account</H2>
           <form className={styles.registerForm} onSubmit={handleSubmit}>
             <InputGroup>
               <Input

--- a/apps/client/src/features/households/InviteToHouseholdPage.css.ts
+++ b/apps/client/src/features/households/InviteToHouseholdPage.css.ts
@@ -8,6 +8,10 @@ export const form = style({
   maxWidth: '480px',
 });
 
+export const inviteLinkContainer = style({
+  marginTop: vars.spacing.lg,
+});
+
 export const linkBox = style({
   display: 'block',
   padding: vars.spacing.sm,

--- a/apps/client/src/features/households/InviteToHouseholdPage.tsx
+++ b/apps/client/src/features/households/InviteToHouseholdPage.tsx
@@ -70,7 +70,7 @@ const InviteToHouseholdPage: React.FC = () => {
         </form>
 
         {inviteUrl && (
-          <Container fluid style={{ marginTop: 24 }}>
+          <Container fluid className={styles.inviteLinkContainer}>
             <Typography variant="body2" gutterBottom>
               Send this link. It expires in 7 days.
             </Typography>

--- a/apps/client/src/features/tonight/TonightPicker.css.ts
+++ b/apps/client/src/features/tonight/TonightPicker.css.ts
@@ -99,3 +99,11 @@ export const label = style({
   marginBottom: vars.spacing.sm,
   fontWeight: vars.typography.fontWeight.bold,
 });
+
+export const errorMessage = style({
+  marginTop: vars.spacing.md,
+});
+
+export const badgeRow = style({
+  flexWrap: 'wrap',
+});

--- a/apps/client/src/features/tonight/TonightPicker.tsx
+++ b/apps/client/src/features/tonight/TonightPicker.tsx
@@ -256,7 +256,7 @@ const TonightPicker: React.FC = () => {
         </Button>
 
         {pickMutation.error && (
-          <Typography variant="body2" style={{ marginTop: 16 }}>
+          <Typography variant="body2" className={styles.errorMessage}>
             {pickMutation.error.message}
           </Typography>
         )}
@@ -274,7 +274,7 @@ const TonightPicker: React.FC = () => {
                 )}
                 <div>
                   <H2>{result.pick.title}</H2>
-                  <Flex gap="sm" style={{ flexWrap: 'wrap' }}>
+                  <Flex gap="sm" className={styles.badgeRow}>
                     {result.pick.year && (
                       <Badge variant="secondary">{result.pick.year}</Badge>
                     )}

--- a/apps/client/src/features/watchlist/SearchMedia.css.ts
+++ b/apps/client/src/features/watchlist/SearchMedia.css.ts
@@ -104,3 +104,26 @@ export const searchControls = style({
   flexWrap: 'wrap',
   marginBottom: vars.spacing.lg,
 });
+
+export const searchStatusMessage = style({
+  textAlign: 'center',
+  marginTop: vars.spacing.xl,
+});
+
+export const searchInputGroup = style({
+  flex: 1,
+});
+
+export const performanceInfo = style({
+  marginBottom: vars.spacing.md,
+  opacity: 0.7,
+});
+
+export const addedMessage = style({
+  color: 'green',
+  textAlign: 'center',
+  marginTop: vars.spacing.md,
+  padding: vars.spacing.sm,
+  backgroundColor: '#f0f9ff',
+  borderRadius: vars.borderRadius.sm,
+});

--- a/apps/client/src/features/watchlist/SearchMedia.tsx
+++ b/apps/client/src/features/watchlist/SearchMedia.tsx
@@ -283,10 +283,7 @@ const SearchMedia: React.FC = () => {
   const renderSearchResults = useCallback(() => {
     if (!debouncedSearchQuery || debouncedSearchQuery.length < 2) {
       return (
-        <Typography
-          variant="body2"
-          style={{ textAlign: 'center', marginTop: '2rem' }}
-        >
+        <Typography variant="body2" className={styles.searchStatusMessage}>
           Enter at least 2 characters to search for movies and TV shows.
         </Typography>
       );
@@ -294,10 +291,7 @@ const SearchMedia: React.FC = () => {
 
     if (isSearching) {
       return (
-        <Typography
-          variant="body2"
-          style={{ textAlign: 'center', marginTop: '2rem' }}
-        >
+        <Typography variant="body2" className={styles.searchStatusMessage}>
           Searching...
         </Typography>
       );
@@ -305,7 +299,7 @@ const SearchMedia: React.FC = () => {
 
     if (searchError) {
       return (
-        <ErrorText style={{ textAlign: 'center', marginTop: '2rem' }}>
+        <ErrorText className={styles.searchStatusMessage}>
           Error searching:{' '}
           {searchError instanceof Error ? searchError.message : 'Unknown error'}
         </ErrorText>
@@ -314,10 +308,7 @@ const SearchMedia: React.FC = () => {
 
     if (searchResults.length === 0) {
       return (
-        <Typography
-          variant="body2"
-          style={{ textAlign: 'center', marginTop: '2rem' }}
-        >
+        <Typography variant="body2" className={styles.searchStatusMessage}>
           No results found for &quot;{debouncedSearchQuery}&quot;. Try a
           different search term.
         </Typography>
@@ -352,7 +343,7 @@ const SearchMedia: React.FC = () => {
   return (
     <>
       <div className={styles.searchControls}>
-        <InputGroup style={{ flex: 1 }}>
+        <InputGroup className={styles.searchInputGroup}>
           <Input
             type="text"
             placeholder="Search for movies and TV shows..."
@@ -379,10 +370,7 @@ const SearchMedia: React.FC = () => {
 
       {/* Performance info for development */}
       {process.env.NODE_ENV === 'development' && searchResults.length > 0 && (
-        <Typography
-          variant="caption"
-          style={{ marginBottom: '1rem', opacity: 0.7 }}
-        >
+        <Typography variant="caption" className={styles.performanceInfo}>
           Found {searchResults.length} results • Images load lazily for better
           performance
         </Typography>
@@ -392,17 +380,7 @@ const SearchMedia: React.FC = () => {
 
       {/* Success message for additions */}
       {addToWatchlistMutation.isSuccess && (
-        <Typography
-          variant="body2"
-          style={{
-            color: 'green',
-            textAlign: 'center',
-            marginTop: '1rem',
-            padding: '0.5rem',
-            backgroundColor: '#f0f9ff',
-            borderRadius: '4px',
-          }}
-        >
+        <Typography variant="body2" className={styles.addedMessage}>
           Item added to your watchlist!
         </Typography>
       )}

--- a/apps/client/src/features/watchlist/WatchlistPage.css.ts
+++ b/apps/client/src/features/watchlist/WatchlistPage.css.ts
@@ -133,6 +133,14 @@ export const tag = style({
   fontSize: vars.typography.fontSize.sm,
 });
 
+export const doneEditingButton = style({
+  marginTop: vars.spacing.sm,
+});
+
+export const tabsRow = style({
+  marginBottom: vars.spacing.md,
+});
+
 export const virtualizedContainer = style({
   overflow: 'auto',
   position: 'relative',

--- a/apps/client/src/features/watchlist/WatchlistPage.tsx
+++ b/apps/client/src/features/watchlist/WatchlistPage.tsx
@@ -325,7 +325,7 @@ const WatchlistItem = React.memo<WatchlistItemProps>(
                 />
                 <Button
                   onClick={handleDoneEditing}
-                  style={{ marginTop: '0.5rem' }}
+                  className={styles.doneEditingButton}
                 >
                   Done
                 </Button>
@@ -603,7 +603,7 @@ const WatchlistPage: React.FC = () => {
 
         <Card accentColor="#69c176">
           <CardContent>
-            <Flex gap="md" wrap="wrap" style={{ marginBottom: '1rem' }}>
+            <Flex gap="md" wrap="wrap" className={styles.tabsRow}>
               <TabButton
                 active={activeTab === 'list'}
                 onClick={() => setActiveTab('list')}

--- a/packages/eslint-config-react/index.js
+++ b/packages/eslint-config-react/index.js
@@ -27,13 +27,8 @@ export default [
         { allowConstantExport: true },
       ],
       'react/no-danger': 'error',
-      // 'warn' rather than creatorgrid's 'error': pairflix is retrofitting this rule onto an
-      // existing codebase, and it surfaces a large pre-existing backlog of decorative inline
-      // styles in Storybook-only .stories.tsx files. Newly-introduced violations in real
-      // component code should still be fixed on sight; promote to 'error' once the backlog
-      // is cleared.
       'react/forbid-component-props': [
-        'warn',
+        'error',
         {
           forbid: [
             {

--- a/packages/lib.components/src/components/layout/AppLayout/AppLayout.css.ts
+++ b/packages/lib.components/src/components/layout/AppLayout/AppLayout.css.ts
@@ -44,6 +44,12 @@ export const header = recipe({
   },
 });
 
+// Height for the Flex row nested inside `header` (Container > Flex) so its
+// content aligns to the same fixed header height.
+export const headerRow = style({
+  height: layoutTokens.header.height,
+});
+
 export const sidebar = recipe({
   base: {
     backgroundColor: vars.colors.background.secondary,
@@ -207,6 +213,16 @@ globalStyle(`${navIconContainer} svg`, {
   display: 'block',
 });
 
+export const navLink = style({
+  textDecoration: 'none',
+  color: 'inherit',
+  padding: '0.5rem 1rem',
+  borderRadius: '0.25rem',
+  transition: 'background-color 0.2s ease',
+  display: 'flex',
+  alignItems: 'center',
+});
+
 export const sidebarIconContainerBase = style({
   display: 'inline-flex',
   alignItems: 'center',
@@ -233,6 +249,17 @@ export const sidebarIconContainer = recipe({
   defaultVariants: {
     collapsed: false,
   },
+});
+
+export const sidebarNavLink = style({
+  display: 'flex',
+  alignItems: 'center',
+  padding: '0.75rem',
+  marginBottom: '0.25rem',
+  borderRadius: '0.25rem',
+  textDecoration: 'none',
+  color: 'inherit',
+  transition: 'background-color 0.2s ease',
 });
 
 export const dropdownIconContainer = style({

--- a/packages/lib.components/src/components/layout/AppLayout/AppLayout.tsx
+++ b/packages/lib.components/src/components/layout/AppLayout/AppLayout.tsx
@@ -4,19 +4,21 @@ import { Link } from 'react-router-dom';
 import { DropdownMenu, DropdownMenuItem } from '../../overlay';
 import { Container } from '../components/Container';
 import { Flex } from '../components/Flex';
-import { layoutTokens } from '../utils/responsive';
 import {
   adminLayoutContainer,
   appLayoutContainer,
   dropdownIconContainer,
   footer as footerClass,
   header as headerClass,
+  headerRow,
   mainContent,
   mobileOverlay,
   navIconContainer,
+  navLink,
   sidebar as sidebarClass,
   sidebarIconContainer,
   sidebarIconContainerBase,
+  sidebarNavLink,
   sidebarUserMenuTrigger,
   userMenuTrigger,
 } from './AppLayout.css';
@@ -101,7 +103,7 @@ const TopNavigation: React.FC<{
       <Flex
         alignItems="center"
         justifyContent="space-between"
-        style={{ height: layoutTokens.header.height }}
+        className={headerRow}
       >
         <Flex alignItems="center" gap="md">
           {navigation.logo}
@@ -109,19 +111,7 @@ const TopNavigation: React.FC<{
             <Flex gap="md" alignItems="center">
               {navigation.sections.flatMap(section =>
                 section.items.map(item => (
-                  <Link
-                    key={item.key}
-                    to={item.path}
-                    style={{
-                      textDecoration: 'none',
-                      color: 'inherit',
-                      padding: '0.5rem 1rem',
-                      borderRadius: '0.25rem',
-                      transition: 'background-color 0.2s ease',
-                      display: 'flex',
-                      alignItems: 'center',
-                    }}
-                  >
+                  <Link key={item.key} to={item.path} className={navLink}>
                     {item.icon && (
                       <span className={navIconContainer}>{item.icon}</span>
                     )}
@@ -246,20 +236,7 @@ const SidebarNavigation: React.FC<{
               </div>
             )}
             {section.items.map(item => (
-              <Link
-                key={item.key}
-                to={item.path}
-                style={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  padding: '0.75rem',
-                  marginBottom: '0.25rem',
-                  borderRadius: '0.25rem',
-                  textDecoration: 'none',
-                  color: 'inherit',
-                  transition: 'background-color 0.2s ease',
-                }}
-              >
+              <Link key={item.key} to={item.path} className={sidebarNavLink}>
                 {item.icon && (
                   <span
                     className={clsx(
@@ -448,7 +425,7 @@ export const AppLayout: React.FC<AppLayoutProps> = ({
               <Flex
                 alignItems="center"
                 justifyContent="space-between"
-                style={{ height: layoutTokens.header.height }}
+                className={headerRow}
               >
                 <div>{header.title}</div>
                 <div>{header.actions}</div>

--- a/packages/lib.components/src/components/layout/Box/Box.stories.css.ts
+++ b/packages/lib.components/src/components/layout/Box/Box.stories.css.ts
@@ -1,0 +1,33 @@
+import { style } from '@vanilla-extract/css';
+import { recipe } from '@vanilla-extract/recipes';
+
+// Fixed label styling for the ColorBox demo helper below -- every ColorBox
+// instance in these stories uses the same white/bold/14px text.
+export const colorBoxText = style({
+  color: 'white',
+  fontWeight: 500,
+  fontSize: 14,
+});
+
+// Centers the "Center" demo Box within its absolutely-positioned parent.
+export const centerTransform = style({
+  transform: 'translate(-50%, -50%)',
+});
+
+// Dev-only section heading used throughout these stories -- not part of the
+// component itself, purely a Storybook documentation aid.
+export const sectionTitle = recipe({
+  base: {
+    margin: '0 0 16px 0',
+    fontWeight: 500,
+  },
+  variants: {
+    small: {
+      true: { fontSize: 16 },
+      false: { fontSize: 18 },
+    },
+  },
+  defaultVariants: {
+    small: false,
+  },
+});

--- a/packages/lib.components/src/components/layout/Box/Box.stories.tsx
+++ b/packages/lib.components/src/components/layout/Box/Box.stories.tsx
@@ -1,14 +1,16 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import type { CSSProperties, ReactNode } from 'react';
+import type { ReactNode } from 'react';
+import clsx from 'clsx';
 
 import { Box, type BoxProps } from './Box';
+import { centerTransform, colorBoxText, sectionTitle } from './Box.stories.css';
 
-const ColorBox = ({ style, ...props }: BoxProps) => (
+const ColorBox = ({ className, ...props }: BoxProps) => (
   <Box
     display="flex"
     alignItems="center"
     justifyContent="center"
-    style={{ color: 'white', fontWeight: 500, fontSize: 14, ...style }}
+    className={clsx(colorBoxText, className)}
     {...props}
   />
 );
@@ -21,15 +23,11 @@ const DemoContent = ({ children }: { children: ReactNode }) => (
 
 const SectionTitle = ({
   children,
-  style,
+  small,
 }: {
   children: ReactNode;
-  style?: CSSProperties;
-}) => (
-  <h3 style={{ margin: '0 0 16px 0', fontSize: 18, fontWeight: 500, ...style }}>
-    {children}
-  </h3>
-);
+  small?: boolean;
+}) => <h3 className={sectionTitle({ small })}>{children}</h3>;
 
 const SectionDescription = ({ children }: { children: ReactNode }) => (
   <p style={{ margin: '0 0 16px 0', color: '#666', fontSize: 14 }}>
@@ -546,7 +544,7 @@ export const Positioning: Story = {
           padding="16px"
           backgroundColor="#2196f3"
           borderRadius="50%"
-          style={{ transform: 'translate(-50%, -50%)' }}
+          className={centerTransform}
         >
           Center
         </Box>
@@ -985,9 +983,7 @@ export const PropsReference: Story = {
       </Box>
 
       <Box>
-        <SectionTitle style={{ fontSize: '16px' }}>
-          Available Props
-        </SectionTitle>
+        <SectionTitle small>Available Props</SectionTitle>
         <PropsTable>
           <TableHeader>
             <div>Prop</div>

--- a/packages/lib.components/src/components/layout/components/Container.stories.css.ts
+++ b/packages/lib.components/src/components/layout/components/Container.stories.css.ts
@@ -1,0 +1,88 @@
+import { style } from '@vanilla-extract/css';
+import { recipe } from '@vanilla-extract/recipes';
+
+// Dev-only demo helpers for these stories -- not part of the Container
+// component itself. Only backgroundColor/paddingTop/paddingBottom/marginTop
+// are used here, none of which Container's own class ever sets, so these
+// compose safely alongside it regardless of stylesheet order.
+
+export const containerBgLight = style({
+  backgroundColor: '#f5f5f5',
+});
+
+export const containerMarginTop = style({
+  marginTop: '24px',
+});
+
+// Nested-container demo: horizontal padding still comes from Container's own
+// `padding` prop (kept in sync with these values at each call site) -- these
+// classes only add the vertical padding and background tint.
+export const containerBgOuter = style({
+  backgroundColor: '#f0f0f0',
+  paddingTop: '24px',
+  paddingBottom: '24px',
+});
+
+export const containerBgInner = style({
+  backgroundColor: '#e0e0e0',
+  paddingTop: '16px',
+  paddingBottom: '16px',
+});
+
+export const containerBgInnermost = style({
+  backgroundColor: '#d0d0d0',
+  paddingTop: '16px',
+  paddingBottom: '16px',
+});
+
+// Local SectionTitle helper (defined in Container.stories.tsx) -- `small` is
+// used for the sub-headings inside the "Common Use Cases" story.
+export const sectionTitle = recipe({
+  base: {
+    margin: '0 0 16px 0',
+    fontSize: 18,
+    fontWeight: 500,
+  },
+  variants: {
+    small: {
+      true: { margin: '24px 0 16px 0', fontSize: 16 },
+      false: {},
+    },
+  },
+  defaultVariants: {
+    small: false,
+  },
+});
+
+// Local ContentBlock helper (defined in Container.stories.tsx). `bgColor`
+// stays a per-call-site inline value (arbitrary demo colors); everything
+// else is one of these fixed shapes.
+const contentBlockBase = {
+  padding: 16,
+  borderRadius: 8,
+  width: '100%',
+  minHeight: 80,
+  boxShadow: '0 1px 3px rgba(0, 0, 0, 0.12)',
+  display: 'flex',
+  flexDirection: 'column',
+  justifyContent: 'center',
+  alignItems: 'center',
+  position: 'relative',
+} as const;
+
+export const contentBlock = style(contentBlockBase);
+
+export const contentBlockTallContent = style({
+  ...contentBlockBase,
+  minHeight: '180px',
+});
+
+export const contentBlockFormPadding = style({
+  ...contentBlockBase,
+  padding: '24px',
+});
+
+export const contentBlockSidebarContent = style({
+  ...contentBlockBase,
+  minHeight: '200px',
+});

--- a/packages/lib.components/src/components/layout/components/Container.stories.tsx
+++ b/packages/lib.components/src/components/layout/components/Container.stories.tsx
@@ -1,8 +1,20 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import type { CSSProperties, ReactNode } from 'react';
+import type { ReactNode } from 'react';
 
 import { Container } from './Container';
 import { Flex } from './Flex';
+import {
+  containerBgInner,
+  containerBgInnermost,
+  containerBgLight,
+  containerBgOuter,
+  containerMarginTop,
+  contentBlock,
+  contentBlockFormPadding,
+  contentBlockSidebarContent,
+  contentBlockTallContent,
+  sectionTitle,
+} from './Container.stories.css';
 
 // Plain demo helpers for storybook documentation
 const DemoContent = ({ children }: { children: ReactNode }) => (
@@ -13,15 +25,11 @@ const DemoContent = ({ children }: { children: ReactNode }) => (
 
 const SectionTitle = ({
   children,
-  style,
+  small,
 }: {
   children: ReactNode;
-  style?: CSSProperties;
-}) => (
-  <h3 style={{ margin: '0 0 16px 0', fontSize: 18, fontWeight: 500, ...style }}>
-    {children}
-  </h3>
-);
+  small?: boolean;
+}) => <h3 className={sectionTitle({ small })}>{children}</h3>;
 
 const SectionDescription = ({ children }: { children: ReactNode }) => (
   <p style={{ margin: '0 0 16px 0', color: '#666', fontSize: 14 }}>
@@ -32,29 +40,14 @@ const SectionDescription = ({ children }: { children: ReactNode }) => (
 // Content block to show container boundaries
 const ContentBlock = ({
   bgColor,
-  style,
+  className = contentBlock,
   children,
 }: {
   bgColor?: string;
-  style?: CSSProperties;
+  className?: string;
   children: ReactNode;
 }) => (
-  <div
-    style={{
-      backgroundColor: bgColor || '#f5f5f5',
-      padding: 16,
-      borderRadius: 8,
-      width: '100%',
-      minHeight: 80,
-      boxShadow: '0 1px 3px rgba(0, 0, 0, 0.12)',
-      display: 'flex',
-      flexDirection: 'column',
-      justifyContent: 'center',
-      alignItems: 'center',
-      position: 'relative',
-      ...style,
-    }}
-  >
+  <div className={className} style={{ backgroundColor: bgColor || '#f5f5f5' }}>
     {children}
   </div>
 );
@@ -295,7 +288,7 @@ export const PaddingVariations: Story = {
 
       <ContainerVisualization>
         <ContainerLabel>padding=&quot;xs&quot; (0.25rem)</ContainerLabel>
-        <Container padding="xs" style={{ backgroundColor: '#f5f5f5' }}>
+        <Container padding="xs" className={containerBgLight}>
           <ContentBlock bgColor="#ffffff">
             <p>Extra Small Padding (xs)</p>
           </ContentBlock>
@@ -304,7 +297,7 @@ export const PaddingVariations: Story = {
 
       <ContainerVisualization>
         <ContainerLabel>padding=&quot;sm&quot; (0.5rem)</ContainerLabel>
-        <Container padding="sm" style={{ backgroundColor: '#f5f5f5' }}>
+        <Container padding="sm" className={containerBgLight}>
           <ContentBlock bgColor="#ffffff">
             <p>Small Padding (sm)</p>
           </ContentBlock>
@@ -313,7 +306,7 @@ export const PaddingVariations: Story = {
 
       <ContainerVisualization>
         <ContainerLabel>padding=&quot;md&quot; (1rem) - Default</ContainerLabel>
-        <Container padding="md" style={{ backgroundColor: '#f5f5f5' }}>
+        <Container padding="md" className={containerBgLight}>
           <ContentBlock bgColor="#ffffff">
             <p>Medium Padding (md) - Default</p>
           </ContentBlock>
@@ -322,7 +315,7 @@ export const PaddingVariations: Story = {
 
       <ContainerVisualization>
         <ContainerLabel>padding=&quot;lg&quot; (1.5rem)</ContainerLabel>
-        <Container padding="lg" style={{ backgroundColor: '#f5f5f5' }}>
+        <Container padding="lg" className={containerBgLight}>
           <ContentBlock bgColor="#ffffff">
             <p>Large Padding (lg)</p>
           </ContentBlock>
@@ -331,7 +324,7 @@ export const PaddingVariations: Story = {
 
       <ContainerVisualization>
         <ContainerLabel>padding=&quot;xl&quot; (2rem)</ContainerLabel>
-        <Container padding="xl" style={{ backgroundColor: '#f5f5f5' }}>
+        <Container padding="xl" className={containerBgLight}>
           <ContentBlock bgColor="#ffffff">
             <p>Extra Large Padding (xl)</p>
           </ContentBlock>
@@ -499,7 +492,7 @@ export const ResponsivePadding: Story = {
 
       <ContainerVisualization>
         <ContainerLabel>Default Responsive Padding</ContainerLabel>
-        <Container style={{ backgroundColor: '#f5f5f5' }}>
+        <Container className={containerBgLight}>
           <ContentBlock bgColor="#ffffff">
             <h4>Default Padding Behavior</h4>
             <p>
@@ -512,7 +505,7 @@ export const ResponsivePadding: Story = {
 
       <ContainerVisualization>
         <ContainerLabel>No Padding on Mobile</ContainerLabel>
-        <Container noPaddingOnMobile style={{ backgroundColor: '#f5f5f5' }}>
+        <Container noPaddingOnMobile className={containerBgLight}>
           <ContentBlock bgColor="#ffffff">
             <h4>No Padding on Mobile</h4>
             <p>
@@ -531,7 +524,7 @@ export const ResponsivePadding: Story = {
             tablet: 'md',
             desktop: 'xl',
           }}
-          style={{ backgroundColor: '#f5f5f5' }}
+          className={containerBgLight}
         >
           <ContentBlock bgColor="#ffffff">
             <h4>Custom Responsive Padding</h4>
@@ -555,9 +548,7 @@ export const CommonUseCases: Story = {
         Examples of common container usage patterns in applications.
       </SectionDescription>
 
-      <SectionTitle style={{ fontSize: '16px', marginTop: '24px' }}>
-        Page Layout
-      </SectionTitle>
+      <SectionTitle small>Page Layout</SectionTitle>
       <ContainerVisualization dark>
         <Container>
           <Flex direction="column" gap="md">
@@ -565,7 +556,7 @@ export const CommonUseCases: Story = {
               <h3>Page Header</h3>
               <p>Typically contains navigation, logo, user menu</p>
             </ContentBlock>
-            <ContentBlock bgColor="#e8f5e9" style={{ minHeight: '180px' }}>
+            <ContentBlock bgColor="#e8f5e9" className={contentBlockTallContent}>
               <h3>Page Content</h3>
               <p>
                 Main content area with contained width for better readability
@@ -579,14 +570,12 @@ export const CommonUseCases: Story = {
         </Container>
       </ContainerVisualization>
 
-      <SectionTitle style={{ fontSize: '16px', marginTop: '24px' }}>
-        Form Container
-      </SectionTitle>
+      <SectionTitle small>Form Container</SectionTitle>
       <ContainerVisualization dark>
         <Container maxWidth="sm" padding="lg">
-          <ContentBlock bgColor="#f9f9f9" style={{ padding: '24px' }}>
+          <ContentBlock bgColor="#f9f9f9" className={contentBlockFormPadding}>
             <h3 style={{ marginTop: 0 }}>Sign In</h3>
-            <Flex direction="column" gap="md" style={{ width: '100%' }}>
+            <Flex direction="column" gap="md" isFullWidth>
               <Flex direction="column" gap="xs">
                 <label htmlFor="login-email" style={{ fontWeight: 500 }}>
                   Email
@@ -635,20 +624,21 @@ export const CommonUseCases: Story = {
         </Container>
       </ContainerVisualization>
 
-      <SectionTitle style={{ fontSize: '16px', marginTop: '24px' }}>
-        Content with Sidebar
-      </SectionTitle>
+      <SectionTitle small>Content with Sidebar</SectionTitle>
       <ContainerVisualization dark>
         <Container>
           <Flex gap="md">
-            <Flex direction="column" gap="md" style={{ flex: '0 0 250px' }}>
+            <Flex direction="column" gap="md" flex="0 0 250px">
               <ContentBlock bgColor="#e3f2fd">
                 <h4>Sidebar</h4>
                 <p>Navigation or filters</p>
               </ContentBlock>
             </Flex>
-            <Flex direction="column" gap="md" style={{ flex: 1 }}>
-              <ContentBlock bgColor="#f5f5f5" style={{ minHeight: '200px' }}>
+            <Flex direction="column" gap="md" flex="1">
+              <ContentBlock
+                bgColor="#f5f5f5"
+                className={contentBlockSidebarContent}
+              >
                 <h4>Main Content</h4>
                 <p>Page content with constrained width</p>
               </ContentBlock>
@@ -657,7 +647,7 @@ export const CommonUseCases: Story = {
         </Container>
       </ContainerVisualization>
 
-      <SectionTitle style={{ fontSize: '16px', marginTop: '24px' }}>
+      <SectionTitle small>
         Full Width Header with Contained Content
       </SectionTitle>
       <div style={{ backgroundColor: '#3f51b5', padding: '24px 0' }}>
@@ -668,7 +658,7 @@ export const CommonUseCases: Story = {
           </p>
         </Container>
       </div>
-      <Container style={{ marginTop: '24px' }}>
+      <Container className={containerMarginTop}>
         <ContentBlock>
           <h3>Contained Content Area</h3>
           <p>Following a full-width colored section</p>
@@ -691,10 +681,7 @@ export const NestedContainers: Story = {
         <ContainerLabel>
           Outer Container (maxWidth=&quot;lg&quot;)
         </ContainerLabel>
-        <Container
-          maxWidth="lg"
-          style={{ backgroundColor: '#f0f0f0', padding: '24px' }}
-        >
+        <Container maxWidth="lg" padding="lg" className={containerBgOuter}>
           <h3>Outer Container</h3>
           <p style={{ marginBottom: '16px' }}>
             This is the outer container with maxWidth=&quot;lg&quot;
@@ -704,10 +691,7 @@ export const NestedContainers: Story = {
             <ContainerLabel>
               Inner Container (maxWidth=&quot;md&quot;)
             </ContainerLabel>
-            <Container
-              maxWidth="md"
-              style={{ backgroundColor: '#e0e0e0', padding: '16px' }}
-            >
+            <Container maxWidth="md" padding="md" className={containerBgInner}>
               <h4>Inner Container</h4>
               <p style={{ marginBottom: '16px' }}>
                 This is an inner container with maxWidth=&quot;md&quot;
@@ -719,7 +703,8 @@ export const NestedContainers: Story = {
                 </ContainerLabel>
                 <Container
                   maxWidth="sm"
-                  style={{ backgroundColor: '#d0d0d0', padding: '16px' }}
+                  padding="md"
+                  className={containerBgInnermost}
                 >
                   <ContentBlock>
                     <h5>Innermost Container</h5>

--- a/packages/lib.components/src/components/layout/components/Flex.stories.css.ts
+++ b/packages/lib.components/src/components/layout/components/Flex.stories.css.ts
@@ -1,0 +1,44 @@
+import { style } from '@vanilla-extract/css';
+import { recipe } from '@vanilla-extract/recipes';
+
+// Local SectionTitle helper (defined in Flex.stories.tsx). `small` matches
+// the fontSize-only override used for the first sub-heading in a section;
+// `spaced` adds the extra top margin used for subsequent sub-headings.
+export const sectionTitle = recipe({
+  base: {
+    margin: '0 0 16px 0',
+    fontSize: 18,
+    fontWeight: 500,
+  },
+  variants: {
+    small: {
+      true: { fontSize: 16 },
+      false: {},
+    },
+    spaced: {
+      true: { marginTop: '24px' },
+      false: {},
+    },
+  },
+  defaultVariants: {
+    small: false,
+    spaced: false,
+  },
+});
+
+// Card Layout demo: clips the card image to the card's rounded corners and
+// caps the card's width.
+export const cardLayoutWrapper = style({
+  overflow: 'hidden',
+  maxWidth: '320px',
+});
+
+// Form Layout demo wrapper.
+export const formLayoutWrapper = style({
+  maxWidth: '400px',
+});
+
+// Center Alignment demo: caps the width of the centered content block.
+export const centeredContentWrapper = style({
+  maxWidth: '300px',
+});

--- a/packages/lib.components/src/components/layout/components/Flex.stories.tsx
+++ b/packages/lib.components/src/components/layout/components/Flex.stories.tsx
@@ -1,16 +1,28 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import type { CSSProperties, ReactNode } from 'react';
+import type { ReactNode } from 'react';
 
 import { Flex } from './Flex';
+import {
+  cardLayoutWrapper,
+  centeredContentWrapper,
+  formLayoutWrapper,
+  sectionTitle,
+} from './Flex.stories.css';
 
 // Plain demo helpers for storybook documentation
 const DemoItem = ({
   color,
-  style,
+  width,
+  height,
+  fontSize,
+  flexShrink,
   children,
 }: {
   color?: string;
-  style?: CSSProperties;
+  width?: string;
+  height?: string;
+  fontSize?: string;
+  flexShrink?: number;
   children: ReactNode;
 }) => (
   <div
@@ -22,9 +34,11 @@ const DemoItem = ({
       alignItems: 'center',
       justifyContent: 'center',
       fontWeight: 500,
-      fontSize: 14,
+      fontSize: fontSize || 14,
       borderRadius: 4,
-      ...style,
+      ...(width && { width }),
+      ...(height && { height }),
+      ...(flexShrink !== undefined && { flexShrink }),
     }}
   >
     {children}
@@ -39,15 +53,13 @@ const DemoContent = ({ children }: { children: ReactNode }) => (
 
 const SectionTitle = ({
   children,
-  style,
+  small,
+  spaced,
 }: {
   children: ReactNode;
-  style?: CSSProperties;
-}) => (
-  <h3 style={{ margin: '0 0 16px 0', fontSize: 18, fontWeight: 500, ...style }}>
-    {children}
-  </h3>
-);
+  small?: boolean;
+  spaced?: boolean;
+}) => <h3 className={sectionTitle({ small, spaced })}>{children}</h3>;
 
 const SectionDescription = ({ children }: { children: ReactNode }) => (
   <p style={{ margin: '0 0 16px 0', color: '#666', fontSize: 14 }}>
@@ -206,41 +218,41 @@ export const DirectionVariations: Story = {
       </SectionDescription>
 
       <Flex direction="row" gap="md">
-        <DemoItem style={{ width: '100px' }}>Row Item 1</DemoItem>
-        <DemoItem style={{ width: '100px' }} color="#7e57c2">
+        <DemoItem width="100px">Row Item 1</DemoItem>
+        <DemoItem width="100px" color="#7e57c2">
           Row Item 2
         </DemoItem>
-        <DemoItem style={{ width: '100px' }} color="#5c6bc0">
+        <DemoItem width="100px" color="#5c6bc0">
           Row Item 3
         </DemoItem>
       </Flex>
 
       <Flex direction="row" reverse gap="md">
-        <DemoItem style={{ width: '100px' }}>Row-Reverse 1</DemoItem>
-        <DemoItem style={{ width: '100px' }} color="#7e57c2">
+        <DemoItem width="100px">Row-Reverse 1</DemoItem>
+        <DemoItem width="100px" color="#7e57c2">
           Row-Reverse 2
         </DemoItem>
-        <DemoItem style={{ width: '100px' }} color="#5c6bc0">
+        <DemoItem width="100px" color="#5c6bc0">
           Row-Reverse 3
         </DemoItem>
       </Flex>
 
       <Flex direction="column" gap="sm">
-        <DemoItem style={{ height: '60px' }}>Column Item 1</DemoItem>
-        <DemoItem style={{ height: '60px' }} color="#7e57c2">
+        <DemoItem height="60px">Column Item 1</DemoItem>
+        <DemoItem height="60px" color="#7e57c2">
           Column Item 2
         </DemoItem>
-        <DemoItem style={{ height: '60px' }} color="#5c6bc0">
+        <DemoItem height="60px" color="#5c6bc0">
           Column Item 3
         </DemoItem>
       </Flex>
 
       <Flex direction="column" reverse gap="sm">
-        <DemoItem style={{ height: '60px' }}>Column-Reverse 1</DemoItem>
-        <DemoItem style={{ height: '60px' }} color="#7e57c2">
+        <DemoItem height="60px">Column-Reverse 1</DemoItem>
+        <DemoItem height="60px" color="#7e57c2">
           Column-Reverse 2
         </DemoItem>
-        <DemoItem style={{ height: '60px' }} color="#5c6bc0">
+        <DemoItem height="60px" color="#5c6bc0">
           Column-Reverse 3
         </DemoItem>
       </Flex>
@@ -258,61 +270,61 @@ export const JustifyContentVariations: Story = {
       </SectionDescription>
 
       <Flex justifyContent="flex-start" gap="md">
-        <DemoItem style={{ width: '100px' }}>flex-start</DemoItem>
-        <DemoItem style={{ width: '100px' }} color="#7e57c2">
+        <DemoItem width="100px">flex-start</DemoItem>
+        <DemoItem width="100px" color="#7e57c2">
           flex-start
         </DemoItem>
-        <DemoItem style={{ width: '100px' }} color="#5c6bc0">
+        <DemoItem width="100px" color="#5c6bc0">
           flex-start
         </DemoItem>
       </Flex>
 
       <Flex justifyContent="flex-end" gap="md">
-        <DemoItem style={{ width: '100px' }}>flex-end</DemoItem>
-        <DemoItem style={{ width: '100px' }} color="#7e57c2">
+        <DemoItem width="100px">flex-end</DemoItem>
+        <DemoItem width="100px" color="#7e57c2">
           flex-end
         </DemoItem>
-        <DemoItem style={{ width: '100px' }} color="#5c6bc0">
+        <DemoItem width="100px" color="#5c6bc0">
           flex-end
         </DemoItem>
       </Flex>
 
       <Flex justifyContent="center" gap="md">
-        <DemoItem style={{ width: '100px' }}>center</DemoItem>
-        <DemoItem style={{ width: '100px' }} color="#7e57c2">
+        <DemoItem width="100px">center</DemoItem>
+        <DemoItem width="100px" color="#7e57c2">
           center
         </DemoItem>
-        <DemoItem style={{ width: '100px' }} color="#5c6bc0">
+        <DemoItem width="100px" color="#5c6bc0">
           center
         </DemoItem>
       </Flex>
 
       <Flex justifyContent="space-between">
-        <DemoItem style={{ width: '100px' }}>space-between</DemoItem>
-        <DemoItem style={{ width: '100px' }} color="#7e57c2">
+        <DemoItem width="100px">space-between</DemoItem>
+        <DemoItem width="100px" color="#7e57c2">
           space-between
         </DemoItem>
-        <DemoItem style={{ width: '100px' }} color="#5c6bc0">
+        <DemoItem width="100px" color="#5c6bc0">
           space-between
         </DemoItem>
       </Flex>
 
       <Flex justifyContent="space-around">
-        <DemoItem style={{ width: '100px' }}>space-around</DemoItem>
-        <DemoItem style={{ width: '100px' }} color="#7e57c2">
+        <DemoItem width="100px">space-around</DemoItem>
+        <DemoItem width="100px" color="#7e57c2">
           space-around
         </DemoItem>
-        <DemoItem style={{ width: '100px' }} color="#5c6bc0">
+        <DemoItem width="100px" color="#5c6bc0">
           space-around
         </DemoItem>
       </Flex>
 
       <Flex justifyContent="space-evenly">
-        <DemoItem style={{ width: '100px' }}>space-evenly</DemoItem>
-        <DemoItem style={{ width: '100px' }} color="#7e57c2">
+        <DemoItem width="100px">space-evenly</DemoItem>
+        <DemoItem width="100px" color="#7e57c2">
           space-evenly
         </DemoItem>
-        <DemoItem style={{ width: '100px' }} color="#5c6bc0">
+        <DemoItem width="100px" color="#5c6bc0">
           space-evenly
         </DemoItem>
       </Flex>
@@ -330,71 +342,61 @@ export const AlignItemsVariations: Story = {
       </SectionDescription>
 
       <Flex alignItems="flex-start" gap="md">
-        <DemoItem style={{ width: '100px', height: '40px' }}>
+        <DemoItem width="100px" height="40px">
           flex-start
         </DemoItem>
-        <DemoItem style={{ width: '100px', height: '60px' }} color="#7e57c2">
+        <DemoItem width="100px" height="60px" color="#7e57c2">
           flex-start
         </DemoItem>
-        <DemoItem style={{ width: '100px', height: '80px' }} color="#5c6bc0">
+        <DemoItem width="100px" height="80px" color="#5c6bc0">
           flex-start
         </DemoItem>
       </Flex>
 
       <Flex alignItems="flex-end" gap="md">
-        <DemoItem style={{ width: '100px', height: '40px' }}>flex-end</DemoItem>
-        <DemoItem style={{ width: '100px', height: '60px' }} color="#7e57c2">
+        <DemoItem width="100px" height="40px">
           flex-end
         </DemoItem>
-        <DemoItem style={{ width: '100px', height: '80px' }} color="#5c6bc0">
+        <DemoItem width="100px" height="60px" color="#7e57c2">
+          flex-end
+        </DemoItem>
+        <DemoItem width="100px" height="80px" color="#5c6bc0">
           flex-end
         </DemoItem>
       </Flex>
 
       <Flex alignItems="center" gap="md">
-        <DemoItem style={{ width: '100px', height: '40px' }}>center</DemoItem>
-        <DemoItem style={{ width: '100px', height: '60px' }} color="#7e57c2">
+        <DemoItem width="100px" height="40px">
           center
         </DemoItem>
-        <DemoItem style={{ width: '100px', height: '80px' }} color="#5c6bc0">
+        <DemoItem width="100px" height="60px" color="#7e57c2">
+          center
+        </DemoItem>
+        <DemoItem width="100px" height="80px" color="#5c6bc0">
           center
         </DemoItem>
       </Flex>
 
       <Flex alignItems="baseline" gap="md">
-        <DemoItem
-          style={{
-            width: '100px',
-            height: '40px',
-            fontSize: '12px',
-          }}
-        >
+        <DemoItem width="100px" height="40px" fontSize="12px">
           baseline
         </DemoItem>
-        <DemoItem
-          style={{
-            width: '100px',
-            height: '60px',
-            fontSize: '18px',
-          }}
-          color="#7e57c2"
-        >
+        <DemoItem width="100px" height="60px" fontSize="18px" color="#7e57c2">
           baseline
         </DemoItem>
-        <DemoItem
-          style={{ width: '100px', height: '80px', fontSize: '24px' }}
-          color="#5c6bc0"
-        >
+        <DemoItem width="100px" height="80px" fontSize="24px" color="#5c6bc0">
           baseline
         </DemoItem>
       </Flex>
 
       <Flex alignItems="stretch" gap="md">
-        <DemoItem style={{ width: '100px', height: 'auto' }}>stretch</DemoItem>
-        <DemoItem style={{ width: '100px', height: 'auto' }} color="#7e57c2">
+        <DemoItem width="100px" height="auto">
           stretch
         </DemoItem>
-        <DemoItem style={{ width: '100px', height: 'auto' }} color="#5c6bc0">
+        <DemoItem width="100px" height="auto" color="#7e57c2">
+          stretch
+        </DemoItem>
+        <DemoItem width="100px" height="auto" color="#5c6bc0">
           stretch
         </DemoItem>
       </Flex>
@@ -412,43 +414,45 @@ export const FlexWrapVariations: Story = {
       </SectionDescription>
 
       <Flex wrap="nowrap">
-        <DemoItem style={{ width: '150px', flexShrink: 0 }}>nowrap</DemoItem>
-        <DemoItem style={{ width: '150px', flexShrink: 0 }} color="#7e57c2">
+        <DemoItem width="150px" flexShrink={0}>
           nowrap
         </DemoItem>
-        <DemoItem style={{ width: '150px', flexShrink: 0 }} color="#5c6bc0">
+        <DemoItem width="150px" flexShrink={0} color="#7e57c2">
+          nowrap
+        </DemoItem>
+        <DemoItem width="150px" flexShrink={0} color="#5c6bc0">
           nowrap
         </DemoItem>
       </Flex>
 
       <Flex wrap="wrap" gap="sm">
-        <DemoItem style={{ width: '150px' }}>wrap</DemoItem>
-        <DemoItem style={{ width: '150px' }} color="#7e57c2">
+        <DemoItem width="150px">wrap</DemoItem>
+        <DemoItem width="150px" color="#7e57c2">
           wrap
         </DemoItem>
-        <DemoItem style={{ width: '150px' }} color="#5c6bc0">
+        <DemoItem width="150px" color="#5c6bc0">
           wrap
         </DemoItem>
-        <DemoItem style={{ width: '150px' }} color="#4caf50">
+        <DemoItem width="150px" color="#4caf50">
           wrap
         </DemoItem>
-        <DemoItem style={{ width: '150px' }} color="#ff9800">
+        <DemoItem width="150px" color="#ff9800">
           wrap
         </DemoItem>
       </Flex>
 
       <Flex wrap="wrap-reverse" gap="sm">
-        <DemoItem style={{ width: '150px' }}>wrap-reverse</DemoItem>
-        <DemoItem style={{ width: '150px' }} color="#7e57c2">
+        <DemoItem width="150px">wrap-reverse</DemoItem>
+        <DemoItem width="150px" color="#7e57c2">
           wrap-reverse
         </DemoItem>
-        <DemoItem style={{ width: '150px' }} color="#5c6bc0">
+        <DemoItem width="150px" color="#5c6bc0">
           wrap-reverse
         </DemoItem>
-        <DemoItem style={{ width: '150px' }} color="#4caf50">
+        <DemoItem width="150px" color="#4caf50">
           wrap-reverse
         </DemoItem>
-        <DemoItem style={{ width: '150px' }} color="#ff9800">
+        <DemoItem width="150px" color="#ff9800">
           wrap-reverse
         </DemoItem>
       </Flex>
@@ -466,30 +470,30 @@ export const FlexWithGap: Story = {
       </SectionDescription>
 
       <Flex gap="lg" wrap="wrap">
-        <DemoItem style={{ width: '120px' }}>Item 1</DemoItem>
-        <DemoItem style={{ width: '120px' }} color="#7e57c2">
+        <DemoItem width="120px">Item 1</DemoItem>
+        <DemoItem width="120px" color="#7e57c2">
           Item 2
         </DemoItem>
-        <DemoItem style={{ width: '120px' }} color="#5c6bc0">
+        <DemoItem width="120px" color="#5c6bc0">
           Item 3
         </DemoItem>
-        <DemoItem style={{ width: '120px' }} color="#4caf50">
+        <DemoItem width="120px" color="#4caf50">
           Item 4
         </DemoItem>
-        <DemoItem style={{ width: '120px' }} color="#ff9800">
+        <DemoItem width="120px" color="#ff9800">
           Item 5
         </DemoItem>
-        <DemoItem style={{ width: '120px' }} color="#f44336">
+        <DemoItem width="120px" color="#f44336">
           Item 6
         </DemoItem>
       </Flex>
 
       <Flex direction="column" gap="md">
-        <DemoItem style={{ height: '60px' }}>Item 1</DemoItem>
-        <DemoItem style={{ height: '60px' }} color="#7e57c2">
+        <DemoItem height="60px">Item 1</DemoItem>
+        <DemoItem height="60px" color="#7e57c2">
           Item 2
         </DemoItem>
-        <DemoItem style={{ height: '60px' }} color="#5c6bc0">
+        <DemoItem height="60px" color="#5c6bc0">
           Item 3
         </DemoItem>
       </Flex>
@@ -506,13 +510,10 @@ export const CommonUIPatterns: Story = {
         Demonstration of common UI patterns using Flex.
       </SectionDescription>
 
-      <SectionTitle style={{ fontSize: '16px', marginTop: '24px' }}>
+      <SectionTitle small spaced>
         Card Layout
       </SectionTitle>
-      <Flex
-        direction="column"
-        style={{ overflow: 'hidden', maxWidth: '320px' }}
-      >
+      <Flex direction="column" className={cardLayoutWrapper}>
         <div
           style={{
             backgroundColor: '#5c6bc0',
@@ -551,27 +552,19 @@ export const CommonUIPatterns: Story = {
         </Flex>
       </Flex>
 
-      <SectionTitle style={{ fontSize: '16px', marginTop: '24px' }}>
+      <SectionTitle small spaced>
         Split Layout
       </SectionTitle>
+      {/* Flex always sets its own inline height ('100%' or 'auto'), so only an inline override can win here. */}
+      {/* eslint-disable-next-line react/forbid-component-props */}
       <Flex style={{ height: '240px', overflow: 'hidden' }}>
-        <Flex
-          direction="column"
-          justifyContent="center"
-          style={{ flex: 1 }}
-          gap="md"
-        >
+        <Flex direction="column" justifyContent="center" flex="1" gap="md">
           <h3 style={{ margin: '0 0 16px 0' }}>Left Side</h3>
           <p style={{ margin: '0', opacity: 0.8 }}>
             Content for the left side of the split layout.
           </p>
         </Flex>
-        <Flex
-          direction="column"
-          justifyContent="center"
-          style={{ flex: 1 }}
-          gap="md"
-        >
+        <Flex direction="column" justifyContent="center" flex="1" gap="md">
           <h3 style={{ margin: '0 0 16px 0' }}>Right Side</h3>
           <p style={{ margin: '0', color: '#666' }}>
             Content for the right side of the split layout.
@@ -579,7 +572,7 @@ export const CommonUIPatterns: Story = {
         </Flex>
       </Flex>
 
-      <SectionTitle style={{ fontSize: '16px', marginTop: '24px' }}>
+      <SectionTitle small spaced>
         Navbar Layout
       </SectionTitle>
       <Flex justifyContent="space-between" alignItems="center">
@@ -612,10 +605,10 @@ export const CommonUIPatterns: Story = {
         </button>
       </Flex>
 
-      <SectionTitle style={{ fontSize: '16px', marginTop: '24px' }}>
+      <SectionTitle small spaced>
         Form Layout
       </SectionTitle>
-      <Flex direction="column" gap="md" style={{ maxWidth: '400px' }}>
+      <Flex direction="column" gap="md" className={formLayoutWrapper}>
         <h3 style={{ margin: '0 0 8px 0' }}>Contact Form</h3>
         <Flex direction="column" gap="xs">
           <label htmlFor="flex-demo-name" style={{ fontWeight: 500 }}>
@@ -693,11 +686,11 @@ export const ResponsiveFlexLayouts: Story = {
       </SectionDescription>
 
       <div>
-        <SectionTitle style={{ fontSize: '16px' }}>
+        <SectionTitle small>
           Mobile-First Layout (resize browser to see changes)
         </SectionTitle>
         <Flex gap="md" direction="row" mobileDirection="column">
-          <Flex direction="column" style={{ flex: 1 }} gap="xs">
+          <Flex direction="column" flex="1" gap="xs">
             <h4 style={{ margin: '0 0 8px 0' }}>Section 1</h4>
             <p style={{ margin: 0, fontSize: '14px' }}>
               This section will stack vertically on mobile and horizontally on
@@ -705,7 +698,7 @@ export const ResponsiveFlexLayouts: Story = {
             </p>
           </Flex>
 
-          <Flex direction="column" style={{ flex: 1 }} gap="xs">
+          <Flex direction="column" flex="1" gap="xs">
             <h4 style={{ margin: '0 0 8px 0' }}>Section 2</h4>
             <p style={{ margin: 0, fontSize: '14px' }}>
               Resize your browser window to see how the layout changes between
@@ -713,7 +706,7 @@ export const ResponsiveFlexLayouts: Story = {
             </p>
           </Flex>
 
-          <Flex direction="column" style={{ flex: 1 }} gap="xs">
+          <Flex direction="column" flex="1" gap="xs">
             <h4 style={{ margin: '0 0 8px 0' }}>Section 3</h4>
             <p style={{ margin: 0, fontSize: '14px' }}>
               Using Flex with proper media queries creates responsive layouts
@@ -723,12 +716,12 @@ export const ResponsiveFlexLayouts: Story = {
         </Flex>
       </div>
 
-      <SectionTitle style={{ fontSize: '16px', marginTop: '24px' }}>
+      <SectionTitle small spaced>
         Responsive Gap Examples
       </SectionTitle>
       <Flex gap="lg" mobileGap="sm" direction="row" mobileDirection="column">
         {[...Array(3)].map((_, i) => (
-          <Flex key={i} direction="column" style={{ flex: 1 }} gap="xs">
+          <Flex key={i} direction="column" flex="1" gap="xs">
             <h4 style={{ margin: '0 0 8px 0' }}>Responsive Gap</h4>
             <p style={{ margin: 0, fontSize: '14px' }}>
               This layout uses a larger gap on desktop and a smaller gap on
@@ -751,13 +744,18 @@ export const CenterAlignment: Story = {
       </SectionDescription>
 
       <Flex center>
-        <DemoItem style={{ width: '150px', height: '80px' }}>
+        <DemoItem width="150px" height="80px">
           Centered Item
         </DemoItem>
       </Flex>
 
       <Flex center>
-        <Flex direction="column" gap="md" center style={{ maxWidth: '300px' }}>
+        <Flex
+          direction="column"
+          gap="md"
+          center
+          className={centeredContentWrapper}
+        >
           <h3 style={{ margin: '0' }}>Centered Content</h3>
           <p style={{ margin: '0', textAlign: 'center' }}>
             This content is centered both horizontally and vertically using the

--- a/packages/lib.components/src/components/layout/components/Grid.stories.css.ts
+++ b/packages/lib.components/src/components/layout/components/Grid.stories.css.ts
@@ -1,4 +1,61 @@
 import { style } from '@vanilla-extract/css';
+import { recipe } from '@vanilla-extract/recipes';
+
+// Local SectionTitle helper (defined in Grid.stories.tsx). `heading`/
+// `headingLg` are the fontSize-16 sub-headings (differing only in the top
+// margin before them); `subheading` is the smaller fontSize-14 gray label
+// used above each alignItems/justifyContent demo row.
+export const sectionTitle = recipe({
+  base: {
+    margin: '0 0 16px 0',
+    fontSize: 18,
+    fontWeight: 500,
+  },
+  variants: {
+    variant: {
+      default: {},
+      heading: { fontSize: 16, marginTop: '24px' },
+      headingLg: { fontSize: 16, marginTop: '32px' },
+      subheading: { fontSize: 14, marginTop: '16px', color: '#666' },
+    },
+  },
+  defaultVariants: {
+    variant: 'default',
+  },
+});
+
+// Local SectionDescription helper (defined in Grid.stories.tsx).
+const sectionDescriptionBase = {
+  margin: '0 0 16px 0',
+  color: '#666',
+  fontSize: 14,
+} as const;
+
+export const sectionDescription = style(sectionDescriptionBase);
+
+export const sectionDescriptionSpaced = style({
+  ...sectionDescriptionBase,
+  marginTop: '24px',
+});
+
+// Fixed-height bordered demo frame for the alignItems rows in
+// AlignmentOptions -- gives the "start"/"center"/"end"/"stretch" comparison
+// something visibly taller than its items to align within.
+export const gridDemoBordered = style({
+  height: '150px',
+  border: '1px dashed #ccc',
+});
+
+// Dashboard Layout demo (UIPatterns) -- gives the content column a minimum
+// height so it visually matches the sidebar next to it.
+export const gridDashboardWrapper = style({
+  minHeight: '400px',
+});
+
+// Stat-cards row within the Dashboard Layout demo.
+export const gridStatCardsWrapper = style({
+  marginBottom: '16px',
+});
 
 // Dev-only viewport indicator for the stories below -- not part of the
 // component itself, purely a Storybook documentation aid.

--- a/packages/lib.components/src/components/layout/components/Grid.stories.tsx
+++ b/packages/lib.components/src/components/layout/components/Grid.stories.tsx
@@ -1,8 +1,16 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import type { CSSProperties, ReactNode } from 'react';
+import type { ReactNode } from 'react';
 
 import { Grid } from './Grid';
-import { responsiveIndicator } from './Grid.stories.css';
+import {
+  gridDashboardWrapper,
+  gridDemoBordered,
+  gridStatCardsWrapper,
+  responsiveIndicator,
+  sectionDescription,
+  sectionDescriptionSpaced,
+  sectionTitle,
+} from './Grid.stories.css';
 
 // Plain demo helpers for storybook documentation
 const DemoContent = ({ children }: { children: ReactNode }) => (
@@ -13,24 +21,20 @@ const DemoContent = ({ children }: { children: ReactNode }) => (
 
 const SectionTitle = ({
   children,
-  style,
+  variant,
 }: {
   children: ReactNode;
-  style?: CSSProperties;
-}) => (
-  <h3 style={{ margin: '0 0 16px 0', fontSize: 18, fontWeight: 500, ...style }}>
-    {children}
-  </h3>
-);
+  variant?: 'heading' | 'headingLg' | 'subheading';
+}) => <h3 className={sectionTitle({ variant })}>{children}</h3>;
 
 const SectionDescription = ({
   children,
-  style,
+  spaced,
 }: {
   children: ReactNode;
-  style?: CSSProperties;
+  spaced?: boolean;
 }) => (
-  <p style={{ margin: '0 0 16px 0', color: '#666', fontSize: 14, ...style }}>
+  <p className={spaced ? sectionDescriptionSpaced : sectionDescription}>
     {children}
   </p>
 );
@@ -39,12 +43,14 @@ const SectionDescription = ({
 const GridItem = ({
   color,
   height,
-  style,
+  gridColumn,
+  gridRow,
   children,
 }: {
   color?: string;
   height?: string;
-  style?: CSSProperties;
+  gridColumn?: string;
+  gridRow?: string;
   children: ReactNode;
 }) => (
   <div
@@ -61,7 +67,8 @@ const GridItem = ({
       height: height || 'auto',
       minHeight: 60,
       boxShadow: '0 2px 4px rgba(0, 0, 0, 0.1)',
-      ...style,
+      ...(gridColumn && { gridColumn }),
+      ...(gridRow && { gridRow }),
     }}
   >
     {children}
@@ -190,17 +197,13 @@ export const ColumnVariations: Story = {
         Demonstration of different column configurations.
       </SectionDescription>
 
-      <SectionTitle style={{ fontSize: '16px', marginTop: '24px' }}>
-        1 Column Grid
-      </SectionTitle>
+      <SectionTitle variant="heading">1 Column Grid</SectionTitle>
       <Grid columns={1} gap="md">
         <GridItem>Single Column</GridItem>
         <GridItem color="#7e57c2">Single Column</GridItem>
       </Grid>
 
-      <SectionTitle style={{ fontSize: '16px', marginTop: '24px' }}>
-        2 Column Grid
-      </SectionTitle>
+      <SectionTitle variant="heading">2 Column Grid</SectionTitle>
       <Grid columns={2} gap="md">
         <GridItem>Two Columns</GridItem>
         <GridItem color="#7e57c2">Two Columns</GridItem>
@@ -208,9 +211,7 @@ export const ColumnVariations: Story = {
         <GridItem color="#4caf50">Two Columns</GridItem>
       </Grid>
 
-      <SectionTitle style={{ fontSize: '16px', marginTop: '24px' }}>
-        3 Column Grid
-      </SectionTitle>
+      <SectionTitle variant="heading">3 Column Grid</SectionTitle>
       <Grid columns={3} gap="md">
         <GridItem>Three Columns</GridItem>
         <GridItem color="#7e57c2">Three Columns</GridItem>
@@ -220,9 +221,7 @@ export const ColumnVariations: Story = {
         <GridItem color="#f44336">Three Columns</GridItem>
       </Grid>
 
-      <SectionTitle style={{ fontSize: '16px', marginTop: '24px' }}>
-        4 Column Grid
-      </SectionTitle>
+      <SectionTitle variant="heading">4 Column Grid</SectionTitle>
       <Grid columns={4} gap="md">
         <GridItem>Four Columns</GridItem>
         <GridItem color="#7e57c2">Four Columns</GridItem>
@@ -234,9 +233,7 @@ export const ColumnVariations: Story = {
         <GridItem color="#9c27b0">Four Columns</GridItem>
       </Grid>
 
-      <SectionTitle style={{ fontSize: '16px', marginTop: '24px' }}>
-        Custom Grid Template
-      </SectionTitle>
+      <SectionTitle variant="heading">Custom Grid Template</SectionTitle>
       <Grid columns="1fr 2fr 1fr" gap="md">
         <GridItem>1fr width</GridItem>
         <GridItem color="#7e57c2">2fr width</GridItem>
@@ -255,9 +252,7 @@ export const GapVariations: Story = {
         Demonstration of different gap sizes between grid items.
       </SectionDescription>
 
-      <SectionTitle style={{ fontSize: '16px', marginTop: '24px' }}>
-        Extra Small Gap (xs)
-      </SectionTitle>
+      <SectionTitle variant="heading">Extra Small Gap (xs)</SectionTitle>
       <Grid columns={3} gap="xs">
         <GridItem>xs gap</GridItem>
         <GridItem color="#7e57c2">xs gap</GridItem>
@@ -267,9 +262,7 @@ export const GapVariations: Story = {
         <GridItem color="#f44336">xs gap</GridItem>
       </Grid>
 
-      <SectionTitle style={{ fontSize: '16px', marginTop: '24px' }}>
-        Small Gap (sm)
-      </SectionTitle>
+      <SectionTitle variant="heading">Small Gap (sm)</SectionTitle>
       <Grid columns={3} gap="sm">
         <GridItem>sm gap</GridItem>
         <GridItem color="#7e57c2">sm gap</GridItem>
@@ -279,9 +272,7 @@ export const GapVariations: Story = {
         <GridItem color="#f44336">sm gap</GridItem>
       </Grid>
 
-      <SectionTitle style={{ fontSize: '16px', marginTop: '24px' }}>
-        Medium Gap (md) - Default
-      </SectionTitle>
+      <SectionTitle variant="heading">Medium Gap (md) - Default</SectionTitle>
       <Grid columns={3} gap="md">
         <GridItem>md gap</GridItem>
         <GridItem color="#7e57c2">md gap</GridItem>
@@ -291,9 +282,7 @@ export const GapVariations: Story = {
         <GridItem color="#f44336">md gap</GridItem>
       </Grid>
 
-      <SectionTitle style={{ fontSize: '16px', marginTop: '24px' }}>
-        Large Gap (lg)
-      </SectionTitle>
+      <SectionTitle variant="heading">Large Gap (lg)</SectionTitle>
       <Grid columns={3} gap="lg">
         <GridItem>lg gap</GridItem>
         <GridItem color="#7e57c2">lg gap</GridItem>
@@ -303,9 +292,7 @@ export const GapVariations: Story = {
         <GridItem color="#f44336">lg gap</GridItem>
       </Grid>
 
-      <SectionTitle style={{ fontSize: '16px', marginTop: '24px' }}>
-        Extra Large Gap (xl)
-      </SectionTitle>
+      <SectionTitle variant="heading">Extra Large Gap (xl)</SectionTitle>
       <Grid columns={3} gap="xl">
         <GridItem>xl gap</GridItem>
         <GridItem color="#7e57c2">xl gap</GridItem>
@@ -327,20 +314,18 @@ export const AlignmentOptions: Story = {
         Demonstration of different alignment options for grid items.
       </SectionDescription>
 
-      <SectionTitle style={{ fontSize: '16px', marginTop: '24px' }}>
+      <SectionTitle variant="heading">
         Vertical Alignment (alignItems)
       </SectionTitle>
 
-      <SectionTitle
-        style={{ fontSize: '14px', marginTop: '16px', color: '#666' }}
-      >
+      <SectionTitle variant="subheading">
         alignItems=&quot;start&quot;
       </SectionTitle>
       <Grid
         columns={4}
         gap="md"
         alignItems="start"
-        style={{ height: '150px', border: '1px dashed #ccc' }}
+        className={gridDemoBordered}
       >
         <GridItem height="60px">Short</GridItem>
         <GridItem height="90px" color="#7e57c2">
@@ -354,16 +339,14 @@ export const AlignmentOptions: Story = {
         </GridItem>
       </Grid>
 
-      <SectionTitle
-        style={{ fontSize: '14px', marginTop: '16px', color: '#666' }}
-      >
+      <SectionTitle variant="subheading">
         alignItems=&quot;center&quot;
       </SectionTitle>
       <Grid
         columns={4}
         gap="md"
         alignItems="center"
-        style={{ height: '150px', border: '1px dashed #ccc' }}
+        className={gridDemoBordered}
       >
         <GridItem height="60px">Short</GridItem>
         <GridItem height="90px" color="#7e57c2">
@@ -377,17 +360,10 @@ export const AlignmentOptions: Story = {
         </GridItem>
       </Grid>
 
-      <SectionTitle
-        style={{ fontSize: '14px', marginTop: '16px', color: '#666' }}
-      >
+      <SectionTitle variant="subheading">
         alignItems=&quot;end&quot;
       </SectionTitle>
-      <Grid
-        columns={4}
-        gap="md"
-        alignItems="end"
-        style={{ height: '150px', border: '1px dashed #ccc' }}
-      >
+      <Grid columns={4} gap="md" alignItems="end" className={gridDemoBordered}>
         <GridItem height="60px">Short</GridItem>
         <GridItem height="90px" color="#7e57c2">
           Medium
@@ -400,16 +376,14 @@ export const AlignmentOptions: Story = {
         </GridItem>
       </Grid>
 
-      <SectionTitle
-        style={{ fontSize: '14px', marginTop: '16px', color: '#666' }}
-      >
+      <SectionTitle variant="subheading">
         alignItems=&quot;stretch&quot; (Default)
       </SectionTitle>
       <Grid
         columns={4}
         gap="md"
         alignItems="stretch"
-        style={{ height: '150px', border: '1px dashed #ccc' }}
+        className={gridDemoBordered}
       >
         <GridItem>Stretch</GridItem>
         <GridItem color="#7e57c2">Stretch</GridItem>
@@ -417,66 +391,56 @@ export const AlignmentOptions: Story = {
         <GridItem color="#4caf50">Stretch</GridItem>
       </Grid>
 
-      <SectionTitle style={{ fontSize: '16px', marginTop: '32px' }}>
+      <SectionTitle variant="headingLg">
         Horizontal Alignment (justifyContent)
       </SectionTitle>
 
-      <SectionTitle
-        style={{ fontSize: '14px', marginTop: '16px', color: '#666' }}
-      >
+      <SectionTitle variant="subheading">
         justifyContent=&quot;start&quot; (Default)
       </SectionTitle>
       <Grid columns={4} gap="md" justifyContent="start">
-        <GridItem style={{ gridColumn: 'span 1' }}>Item 1</GridItem>
-        <GridItem style={{ gridColumn: 'span 1' }} color="#7e57c2">
+        <GridItem gridColumn="span 1">Item 1</GridItem>
+        <GridItem gridColumn="span 1" color="#7e57c2">
           Item 2
         </GridItem>
       </Grid>
 
-      <SectionTitle
-        style={{ fontSize: '14px', marginTop: '16px', color: '#666' }}
-      >
+      <SectionTitle variant="subheading">
         justifyContent=&quot;center&quot;
       </SectionTitle>
       <Grid columns={4} gap="md" justifyContent="center">
-        <GridItem style={{ gridColumn: 'span 1' }}>Item 1</GridItem>
-        <GridItem style={{ gridColumn: 'span 1' }} color="#7e57c2">
+        <GridItem gridColumn="span 1">Item 1</GridItem>
+        <GridItem gridColumn="span 1" color="#7e57c2">
           Item 2
         </GridItem>
       </Grid>
 
-      <SectionTitle
-        style={{ fontSize: '14px', marginTop: '16px', color: '#666' }}
-      >
+      <SectionTitle variant="subheading">
         justifyContent=&quot;end&quot;
       </SectionTitle>
       <Grid columns={4} gap="md" justifyContent="end">
-        <GridItem style={{ gridColumn: 'span 1' }}>Item 1</GridItem>
-        <GridItem style={{ gridColumn: 'span 1' }} color="#7e57c2">
+        <GridItem gridColumn="span 1">Item 1</GridItem>
+        <GridItem gridColumn="span 1" color="#7e57c2">
           Item 2
         </GridItem>
       </Grid>
 
-      <SectionTitle
-        style={{ fontSize: '14px', marginTop: '16px', color: '#666' }}
-      >
+      <SectionTitle variant="subheading">
         justifyContent=&quot;space-between&quot;
       </SectionTitle>
       <Grid columns={4} gap="md" justifyContent="space-between">
-        <GridItem style={{ gridColumn: 'span 1' }}>Item 1</GridItem>
-        <GridItem style={{ gridColumn: 'span 1' }} color="#7e57c2">
+        <GridItem gridColumn="span 1">Item 1</GridItem>
+        <GridItem gridColumn="span 1" color="#7e57c2">
           Item 2
         </GridItem>
       </Grid>
 
-      <SectionTitle
-        style={{ fontSize: '14px', marginTop: '16px', color: '#666' }}
-      >
+      <SectionTitle variant="subheading">
         justifyContent=&quot;space-around&quot;
       </SectionTitle>
       <Grid columns={4} gap="md" justifyContent="space-around">
-        <GridItem style={{ gridColumn: 'span 1' }}>Item 1</GridItem>
-        <GridItem style={{ gridColumn: 'span 1' }} color="#7e57c2">
+        <GridItem gridColumn="span 1">Item 1</GridItem>
+        <GridItem gridColumn="span 1" color="#7e57c2">
           Item 2
         </GridItem>
       </Grid>
@@ -497,9 +461,7 @@ export const ResponsiveGrid: Story = {
         adapt.
       </SectionDescription>
 
-      <SectionTitle style={{ fontSize: '16px', marginTop: '24px' }}>
-        Responsive Columns
-      </SectionTitle>
+      <SectionTitle variant="heading">Responsive Columns</SectionTitle>
       <Grid
         columns={4}
         desktopColumns={4}
@@ -549,7 +511,7 @@ export const ResponsiveGrid: Story = {
         </GridItem>
       </Grid>
 
-      <SectionTitle style={{ fontSize: '16px', marginTop: '32px' }}>
+      <SectionTitle variant="headingLg">
         Default Responsive Behavior
       </SectionTitle>
       <SectionDescription>
@@ -579,7 +541,7 @@ export const AutoFitGrid: Story = {
         your browser window to see columns adapt.
       </SectionDescription>
 
-      <SectionTitle style={{ fontSize: '16px', marginTop: '24px' }}>
+      <SectionTitle variant="heading">
         Auto-fit with 150px minimum column width
       </SectionTitle>
       <Grid autoFit minColWidth="150px" gap="md">
@@ -591,7 +553,7 @@ export const AutoFitGrid: Story = {
         <GridItem color="#f44336">Auto-fit</GridItem>
       </Grid>
 
-      <SectionTitle style={{ fontSize: '16px', marginTop: '24px' }}>
+      <SectionTitle variant="heading">
         Auto-fit with 250px minimum column width
       </SectionTitle>
       <Grid autoFit minColWidth="250px" gap="md">
@@ -615,9 +577,7 @@ export const UIPatterns: Story = {
         Real-world examples of UI patterns built with the Grid component.
       </SectionDescription>
 
-      <SectionTitle style={{ fontSize: '16px', marginTop: '24px' }}>
-        Product Cards Grid
-      </SectionTitle>
+      <SectionTitle variant="heading">Product Cards Grid</SectionTitle>
       <Grid autoFit minColWidth="250px" gap="md">
         {[1, 2, 3, 4, 5, 6].map(item => (
           <div
@@ -678,10 +638,8 @@ export const UIPatterns: Story = {
         ))}
       </Grid>
 
-      <SectionTitle style={{ fontSize: '16px', marginTop: '32px' }}>
-        Dashboard Layout
-      </SectionTitle>
-      <Grid columns="250px 1fr" gap="lg" style={{ minHeight: '400px' }}>
+      <SectionTitle variant="headingLg">Dashboard Layout</SectionTitle>
+      <Grid columns="250px 1fr" gap="lg" className={gridDashboardWrapper}>
         <div
           style={{
             backgroundColor: '#f5f5f5',
@@ -721,29 +679,25 @@ export const UIPatterns: Story = {
           )}
         </div>
         <div>
-          <Grid columns={3} gap="md" style={{ marginBottom: '16px' }}>
-            <GridItem style={{ height: '100px' }}>Total Sales</GridItem>
-            <GridItem style={{ height: '100px' }} color="#7e57c2">
+          <Grid columns={3} gap="md" className={gridStatCardsWrapper}>
+            <GridItem height="100px">Total Sales</GridItem>
+            <GridItem height="100px" color="#7e57c2">
               New Customers
             </GridItem>
-            <GridItem style={{ height: '100px' }} color="#5c6bc0">
+            <GridItem height="100px" color="#5c6bc0">
               Conversion Rate
             </GridItem>
           </Grid>
           <Grid columns={2} gap="md">
-            <GridItem style={{ height: '200px' }}>
-              Monthly Revenue Chart
-            </GridItem>
-            <GridItem style={{ height: '200px' }} color="#4caf50">
+            <GridItem height="200px">Monthly Revenue Chart</GridItem>
+            <GridItem height="200px" color="#4caf50">
               Traffic Sources
             </GridItem>
           </Grid>
         </div>
       </Grid>
 
-      <SectionTitle style={{ fontSize: '16px', marginTop: '32px' }}>
-        Photo Gallery
-      </SectionTitle>
+      <SectionTitle variant="headingLg">Photo Gallery</SectionTitle>
       <Grid autoFit minColWidth="150px" gap="sm">
         {Array.from({ length: 12 }).map((_, index) => (
           <div
@@ -785,9 +739,7 @@ export const UIPatterns: Story = {
         ))}
       </Grid>
 
-      <SectionTitle style={{ fontSize: '16px', marginTop: '32px' }}>
-        Content with Sidebar
-      </SectionTitle>
+      <SectionTitle variant="headingLg">Content with Sidebar</SectionTitle>
       <Grid columns="1fr 3fr" gap="lg" tabletColumns="1fr" mobileColumns="1fr">
         <div
           style={{
@@ -887,22 +839,20 @@ export const MixedSizeItems: Story = {
       </SectionDescription>
 
       <Grid columns={4} gap="md" tabletColumns={2} mobileColumns={1}>
-        <GridItem
-          style={{ gridColumn: 'span 2', gridRow: 'span 2', height: '200px' }}
-        >
+        <GridItem gridColumn="span 2" gridRow="span 2" height="200px">
           2×2 Item
         </GridItem>
         <GridItem color="#7e57c2">1×1 Item</GridItem>
         <GridItem color="#5c6bc0">1×1 Item</GridItem>
-        <GridItem color="#4caf50" style={{ gridColumn: 'span 2' }}>
+        <GridItem color="#4caf50" gridColumn="span 2">
           2×1 Item
         </GridItem>
         <GridItem color="#ff9800">1×1 Item</GridItem>
-        <GridItem color="#f44336" style={{ gridColumn: 'span 3' }}>
+        <GridItem color="#f44336" gridColumn="span 3">
           3×1 Item
         </GridItem>
         <GridItem color="#e91e63">1×1 Item</GridItem>
-        <GridItem color="#9c27b0" style={{ gridRow: 'span 2' }}>
+        <GridItem color="#9c27b0" gridRow="span 2">
           1×2 Item
         </GridItem>
         <GridItem color="#2196f3">1×1 Item</GridItem>
@@ -910,7 +860,7 @@ export const MixedSizeItems: Story = {
         <GridItem color="#ffeb3b">1×1 Item</GridItem>
       </Grid>
 
-      <SectionDescription style={{ marginTop: '24px' }}>
+      <SectionDescription spaced>
         Note: When using explicit grid spans on responsive grids, you might need
         to adjust the spans for different breakpoints or use CSS media queries
         for more complex cases.


### PR DESCRIPTION
### 🚀 What's New

- 🛠️ Refactor: Clear the ~256 pre-existing `react/forbid-component-props` (inline `style` on a component) violations flagged when #63's vanilla-extract migration turned the rule on at `warn`.
- 🛠️ Refactor: Promote `react/forbid-component-props` from `warn` to `error` in `packages/eslint-config-react`, matching creatorgrid's original rule level, now that the backlog is clear.

---

### 📝 Description

Follow-up to #63, which added `react/forbid-component-props` but left it at `warn` because enabling it surfaced a large pre-existing backlog rather than anything introduced by that PR. This clears the backlog and turns the rule up to `error` so it actually enforces going forward.

Split three ways by directory (dispatched as parallel work, matching how #63 itself was built), all landing together since none of it is independently meaningful without the others:

- **`packages/lib.components/src/components/layout`** — 168 violations across `Flex.stories.tsx`, `Grid.stories.tsx`, `Container.stories.tsx`, `Box.stories.tsx` (Storybook-only decoration) and `AppLayout.tsx` (real component code). Mostly moved into new/extended sibling `.css.ts` files. A few became typed props on existing demo components (`DemoItem`, `GridItem`) mirroring a convention `GridItem.height` already established during #63, rather than minting near-duplicate one-off classes. One `eslint-disable` remains, where `Flex`'s own unconditional inline `height` genuinely can't be overridden by any class — documented inline.
- **`apps/client`** — 16 violations across 6 files, moved into extended `.css.ts` files.
- **`apps/admin`** — 72 violations across 19 files. A few used an existing first-class component prop instead of inventing a redundant class (`TableCell`'s `align`, `Typography`'s `weight`). A shared `IconStyle` object used by 10 call sites became a proper shared vanilla-extract class instead of getting duplicated per file.

No component behavior or visual output changed anywhere — this only relocates where the CSS is authored (inline `style` prop → named `.css.ts` export applied via `className`).

Verified with a full `pnpm install && pnpm lint && pnpm type-check && pnpm test && pnpm build` from the repo root: all green, including the promoted `error`-level rule.

---

### ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented parts that are complex or non-obvious
- [x] I have updated relevant documentation
- [x] I have added or updated tests
- [x] No new warnings or errors are introduced
- [x] All tests pass locally

---

### 📸 Screenshots (if applicable)

Not applicable — purely relocates existing static style values into vanilla-extract classes with the same computed styles; nothing should render differently.

---

### 🔗 Related Issues / PRs

- Follows #63 (styled-components → vanilla-extract migration), which introduced this rule at `warn` and flagged the backlog as a known follow-up.

---

### ⚠️ Notes for Reviewers

- The one remaining `eslint-disable-next-line react/forbid-component-props` (in `Flex.stories.tsx`) is a genuine case, not a shortcut: `Flex` always sets its own inline `height` (`'100%'` or `'auto'`), which unconditionally wins over any CSS class, and there's no pixel-height prop on `Flex` — so a class-based fix would silently do nothing for that one demo. Comment left in place explaining why.
- A couple of judgment calls worth a glance: `apps/admin`'s shared `IconStyle` → `utils.css.ts` consolidation (removed the old export from `utils.ts` entirely rather than leaving it behind unused), and the `lib.components` `DemoItem`/`GridItem` prop additions (small, typed, Storybook-only props — not part of the real component API).

---

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XaZAU6ca9bxsD6vhj8j392

---
_Generated by [Claude Code](https://claude.ai/code/session_01XaZAU6ca9bxsD6vhj8j392)_