### PR TITLE
feat(api): port households/pick domain to Hono Worker, wire in LLM re-rank (P3)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -46,9 +46,9 @@ many households** — not per-tenant infrastructure, and not a fleet of services
 2. **Membership check** — caller must be a `household_members` row for `:id`.
 3. **Entitlement + quota middleware** — region lock (free = GB) and the daily pick limit (free = 3);
    premium is unlimited and multi-region.
-4. **Recommendation service** (`services/api/src/lib/recommendation`): merge the members' taste
-   profiles (D1) → TMDb `/discover` (edge-cached) → score against mood/time/taste → hydrate the top
-   candidates and filter to titles actually streamable on the household's providers (cached).
+4. **Recommendation service** (`services/api/src/hono/lib/recommendation.ts`): merge the members'
+   taste profiles (D1) → TMDb `/discover` (edge-cached) → score against mood/time/taste → hydrate
+   the top candidates and filter to titles actually streamable on the household's providers (cached).
 5. **LLM re-rank** — premium only, behind `recommendation.llm_rerank`: the Worker calls Anthropic
    over `fetch` to re-order the shortlist; returns `null` to fall back to the pure-ML order. Never on
    the free path.
@@ -91,10 +91,15 @@ until P3's remaining domains land and P5 cuts over:
 ## Recommendation & LLM re-rank
 
 The recommender is **heuristic**, not a heavyweight ML pipeline: taste-profile merge → TMDb
-`/discover` → score → provider filter. The optional Anthropic re-rank (`claude-sonnet-4-6`,
-`max_tokens: 512`, 8s timeout, prompt-cached system + taste blocks, tool-use for structured output)
-is premium-gated and **must be wired into the recommender** — in the current code it is built but
-never called (tracked in the roadmap).
+`/discover` → score → provider filter. Implemented as the P3 households/pick domain
+(`services/api/src/hono/lib/recommendation.ts`, `lib/llm.ts`) — same Express-vs-Hono caveat as Auth
+& CSRF above. The optional Anthropic re-rank (`claude-sonnet-4-6`, `max_tokens: 512`, 8s timeout,
+prompt-cached system + taste blocks, tool-use for structured output) is premium-gated
+(`recommendation.llm_rerank` plus a per-household entitlement check) and **is wired into the
+recommender** in the Hono port: eligible households hydrate the top 10 scored candidates instead of
+3 and pass them to `maybeRerank`, which validates the model's chosen id against what was actually
+sent and falls back to the pure-ML top-1 pick on any failure (flag off, not premium, API error,
+timeout). The Express `llm.service` remains unwired dead code, retired at cutover.
 
 ## Providers & regions
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -47,8 +47,10 @@ many households** — not per-tenant infrastructure, and not a fleet of services
 3. **Entitlement + quota middleware** — region lock (free = GB) and the daily pick limit (free = 3);
    premium is unlimited and multi-region.
 4. **Recommendation service** (`services/api/src/hono/lib/recommendation.ts`): merge the members'
-   taste profiles (D1) → TMDb `/discover` (edge-cached) → score against mood/time/taste → hydrate
-   the top candidates and filter to titles actually streamable on the household's providers (cached).
+   taste profiles (D1) → TMDb `/discover` → score against mood/time/taste → hydrate the top
+   candidates and filter to titles actually streamable on the household's providers. Edge-caching
+   `/discover` and `/watch/providers` (Topology, above) isn't implemented yet in the Hono port --
+   deferred to the providers/history domain (see `lib/tmdb.ts`).
 5. **LLM re-rank** — premium only, behind `recommendation.llm_rerank`: the Worker calls Anthropic
    over `fetch` to re-order the shortlist; returns `null` to fall back to the pure-ML order. Never on
    the free path.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -17,8 +17,10 @@
 
 **Built but not delivering value yet** (fix as part of the re-platform, not before):
 
-- **LLM re-rank is dead code** — `llm.service` / `maybeRerank` is fully implemented and unit-tested
-  but never called by the recommender. Wire it in during the API port.
+- **LLM re-rank was dead code on Express** — `llm.service` / `maybeRerank` was fully implemented and
+  unit-tested but never called by the recommender. Wired in as part of the Hono households/pick port
+  (`services/api/src/hono/lib/llm.ts`, `lib/recommendation.ts`); the Express version is still
+  unwired, retired at cutover along with the rest of that tree.
 - **Two server entry points** (`index.ts` runtime vs orphaned `app.ts`) mount different routes; at
   runtime the **email flows are unreachable** and the user prefix differs. The Hono port collapses
   this to one app and fixes it.
@@ -69,8 +71,32 @@ Resend over nodemailer since Workers can't do SMTP). `packages/lib.validation` h
 request schemas. 30 passing `vitest-pool-workers` tests cover register/login/lockout/suspend/ban/
 verify-email/forgot-password/reset-password/bootstrap-admin/2FA/IP rate limiting.
 
-**Pending:** households/pick, providers/history, billing/admin domains; then collapse the two server
-entries into one and cut over.
+**households/pick — done.** `services/api/src/hono/lib/{household,entitlements,featureFlags,
+tasteSummary,llm,pickEvents,recommendation}.ts`, `middleware/{household,entitlements}.ts`,
+`routes/households.ts`. Household CRUD/membership/invites — including accept-invite, which existed
+in Express (`householdInvites.routes.ts`) but was never mounted on the app router, so invites could
+be created but never accepted — plus `POST /:id/pick` and `POST /:id/picks/:tmdbId/commit`, both
+gated by a consolidated `isMember`/`isOwner` check instead of the several separate reimplementations
+in Express. The LLM re-rank is now wired in for real: eligible households (flag on + premium)
+hydrate the top 10 scored candidates instead of 3 and pass them to `maybeRerank`, which validates
+the model's pick against what was actually sent and falls back to the pure-ML top-1 on any failure.
+Also fixes two bugs found while porting: `commit` now records a `pick_events` "accepted" row
+(Express only ever wrote "proposed", silently breaking the first-pick-acceptance-rate KPI), and the
+pick route now checks household membership at all (Express's controller didn't, though its quota
+middleware happened to). `getFinishedTmdbIdsForMembers` (keyed off the deleted `WatchlistEntry`
+table) is dropped rather than ported — the household-level `watchedTogether` exclusion set already
+covers what the pivoted product needs.
+**Known gap, not fixed here:** nothing computes `taste_profiles` rows going forward — Express's only
+writer (`tasteProfile.service.ts`) is itself entirely built on `WatchlistEntry`. The recommender
+degrades gracefully to mood-only genre filtering when a household has no profiles yet (the common
+case pre-launch); deriving weights from `watchedTogether` instead is a real product decision (what
+signal, what decay) left for a follow-up rather than decided inline here.
+15 new `vitest-pool-workers` tests cover CRUD/invites, pick quota/region-lock/provider-filter,
+commit, and the LLM wiring (including the Anthropic-failure fallback) — the pick path returns a
+title end-to-end on Miniflare, meeting this phase's exit criterion for this domain.
+
+**Pending:** providers/history, billing/admin domains; then collapse the two server entries into
+one and cut over.
 **Exit:** each domain has `vitest-pool-workers` integration tests against local D1; the pick path
 returns a title end-to-end on Miniflare.
 

--- a/packages/lib.validation/src/index.ts
+++ b/packages/lib.validation/src/index.ts
@@ -1,1 +1,2 @@
 export * from './schemas/auth';
+export * from './schemas/household';

--- a/packages/lib.validation/src/schemas/household.ts
+++ b/packages/lib.validation/src/schemas/household.ts
@@ -1,0 +1,53 @@
+import { z } from 'zod';
+import { EmailSchema } from './auth';
+
+export const CreateHouseholdRequestSchema = z.object({
+  name: z.string().trim().max(80, 'Use at most 80 characters').optional(),
+});
+export type CreateHouseholdRequest = z.infer<
+  typeof CreateHouseholdRequestSchema
+>;
+
+export const CreateInviteRequestSchema = z.object({
+  email: EmailSchema.optional(),
+});
+export type CreateInviteRequest = z.infer<typeof CreateInviteRequestSchema>;
+
+export const MoodSchema = z.enum([
+  'funny',
+  'dark',
+  'feelgood',
+  'tense',
+  'romantic',
+  'thoughtful',
+  'action',
+]);
+export type Mood = z.infer<typeof MoodSchema>;
+
+const RegionSchema = z
+  .string()
+  .trim()
+  .toUpperCase()
+  .regex(/^[A-Z]{2}$/, 'Use a 2-letter region code');
+
+export const PickRequestSchema = z.object({
+  mood: MoodSchema,
+  /** Household's available time budget, in minutes -- bounds are a sanity check (no real answer
+   * on either end), not a business rule. */
+  minutes: z
+    .number()
+    .int()
+    .min(15, 'Use at least 15 minutes')
+    .max(600, 'Use at most 600 minutes'),
+  providers: z.array(z.string().trim().min(1)).optional(),
+  region: RegionSchema.optional(),
+  excludeTmdbIds: z.array(z.number().int().positive()).optional(),
+});
+export type PickRequest = z.infer<typeof PickRequestSchema>;
+
+export const CommitPickRequestSchema = z.object({
+  mediaType: z.enum(['movie', 'tv']),
+  mood: MoodSchema.optional(),
+  minutes: z.number().int().positive().optional(),
+});
+export type CommitPickRequest = z.infer<typeof CommitPickRequestSchema>;

--- a/services/api/.dev.vars.example
+++ b/services/api/.dev.vars.example
@@ -27,3 +27,12 @@ EMAIL_FROM=""
 
 # Base URL of apps/client -- verification/reset email links point here.
 APP_CLIENT_URL="http://localhost:5173"
+
+# TMDb -- titles, discover, and watch-provider lookups (src/hono/lib/tmdb.ts). Required for
+# POST /api/households/:id/pick to return anything. Get a key at https://www.themoviedb.org/settings/api.
+TMDB_API_KEY=""
+
+# Anthropic (premium LLM re-rank, src/hono/lib/llm.ts) -- leave blank to keep maybeRerank returning
+# null (falls back to the pure-ML pick, same "unconfigured is a valid state" pattern as email).
+# Also gated behind the recommendation.llm_rerank setting and premium entitlements either way.
+ANTHROPIC_API_KEY=""

--- a/services/api/src/hono/index.ts
+++ b/services/api/src/hono/index.ts
@@ -5,6 +5,7 @@ import { sessionMiddleware } from './middleware/auth';
 import { csrfMiddleware } from './middleware/csrf';
 import { authRoutes } from './routes/auth';
 import { healthRoutes } from './routes/health';
+import { householdsRoutes } from './routes/households';
 import { meRoutes } from './routes/me';
 import type { AppEnv, Bindings } from './types';
 
@@ -37,6 +38,7 @@ app.use('/api/*', csrfMiddleware);
 app.route('/health', healthRoutes);
 app.route('/api/auth', authRoutes);
 app.route('/api/me', meRoutes);
+app.route('/api/households', householdsRoutes);
 
 app.notFound(c => c.json({ error: 'Not found' }, 404));
 app.onError((error, c) => {

--- a/services/api/src/hono/lib/entitlements.ts
+++ b/services/api/src/hono/lib/entitlements.ts
@@ -1,0 +1,84 @@
+import { pickUsage, subscriptions, type Database } from '@pairflix/db';
+import { and, count, eq, gte } from 'drizzle-orm';
+import { newId } from './id';
+
+const FREE_DAILY_PICK_LIMIT = 3;
+const FREE_REGION_LOCK = 'GB';
+
+export type Entitlements = {
+	tier: 'free' | 'premium';
+	dailyPickLimit: number;
+	picksUsedToday: number;
+	picksRemaining: number;
+	canUseLlmRerank: boolean;
+	canUseMultiRegion: boolean;
+	regionLock: string | null;
+};
+
+const startOfTodayUtc = (): Date => {
+	const now = new Date();
+	return new Date(
+		Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate())
+	);
+};
+
+const isEffectivelyPremium = (
+	tier: 'free' | 'premium',
+	status: 'active' | 'past_due' | 'canceled',
+	periodEnd: Date | null
+): boolean =>
+	tier === 'premium' &&
+	status === 'active' &&
+	periodEnd !== null &&
+	periodEnd.getTime() > Date.now();
+
+export const getEntitlements = async (
+	db: Database,
+	householdId: string
+): Promise<Entitlements> => {
+	const sub = await db
+		.select()
+		.from(subscriptions)
+		.where(eq(subscriptions.householdId, householdId))
+		.get();
+	const premium = isEffectivelyPremium(
+		sub?.tier ?? 'free',
+		sub?.status ?? 'active',
+		sub?.currentPeriodEnd ?? null
+	);
+
+	const picksToday = await db
+		.select({ total: count() })
+		.from(pickUsage)
+		.where(
+			and(
+				eq(pickUsage.householdId, householdId),
+				gte(pickUsage.pickedAt, startOfTodayUtc())
+			)
+		)
+		.get();
+	const picksUsedToday = picksToday?.total ?? 0;
+
+	const dailyPickLimit = premium
+		? Number.MAX_SAFE_INTEGER
+		: FREE_DAILY_PICK_LIMIT;
+
+	return {
+		tier: premium ? 'premium' : 'free',
+		dailyPickLimit,
+		picksUsedToday,
+		picksRemaining: Math.max(0, dailyPickLimit - picksUsedToday),
+		canUseLlmRerank: premium,
+		canUseMultiRegion: premium,
+		regionLock: premium ? null : FREE_REGION_LOCK,
+	};
+};
+
+export const recordPick = async (
+	db: Database,
+	householdId: string
+): Promise<void> => {
+	await db
+		.insert(pickUsage)
+		.values({ id: newId('pickusage'), householdId, pickedAt: new Date() });
+};

--- a/services/api/src/hono/lib/featureFlags.ts
+++ b/services/api/src/hono/lib/featureFlags.ts
@@ -1,0 +1,24 @@
+import { settings, type Database } from '@pairflix/db';
+import { eq } from 'drizzle-orm';
+import { getEntitlements } from './entitlements';
+
+/** Reads `settings` directly on every call rather than caching -- unlike the current Express
+ * process, a Worker isolate doesn't reliably live long enough for an in-memory TTL cache to pay
+ * for itself, and a `settings` read is a single indexed row lookup. */
+export const isLlmRerankEnabled = async (db: Database): Promise<boolean> => {
+	const row = await db
+		.select({ value: settings.value })
+		.from(settings)
+		.where(eq(settings.key, 'recommendation.llm_rerank'))
+		.get();
+	return typeof row?.value === 'boolean' ? row.value : false;
+};
+
+export const isLlmRerankEnabledForHousehold = async (
+	db: Database,
+	householdId: string
+): Promise<boolean> => {
+	if (!(await isLlmRerankEnabled(db))) return false;
+	const entitlements = await getEntitlements(db, householdId);
+	return entitlements.canUseLlmRerank;
+};

--- a/services/api/src/hono/lib/genres.ts
+++ b/services/api/src/hono/lib/genres.ts
@@ -1,0 +1,34 @@
+import type { Mood } from '@pairflix/lib.validation';
+
+/** TMDb movie genre id -> name. Also used to bridge id-keyed `taste_profiles.weights.genres` into
+ * the name-keyed input `lib/tasteSummary.ts` (and, transitively, the LLM prompt) expect. */
+export const GENRE_NAMES: Record<number, string> = {
+	28: 'action',
+	12: 'adventure',
+	16: 'animation',
+	35: 'comedy',
+	80: 'crime',
+	99: 'documentary',
+	18: 'drama',
+	10751: 'family',
+	14: 'fantasy',
+	36: 'history',
+	27: 'horror',
+	10402: 'music',
+	9648: 'mystery',
+	10749: 'romance',
+	878: 'sci-fi',
+	53: 'thriller',
+	10752: 'war',
+	37: 'western',
+};
+
+export const MOOD_FILTERS: Record<Mood, { genres: number[]; label: string }> = {
+	funny: { genres: [35], label: 'comedy' },
+	dark: { genres: [80, 53], label: 'dark crime/thriller' },
+	feelgood: { genres: [10751, 35], label: 'feel-good' },
+	tense: { genres: [53, 27], label: 'tense thriller/horror' },
+	romantic: { genres: [10749], label: 'romance' },
+	thoughtful: { genres: [18], label: 'thoughtful drama' },
+	action: { genres: [28, 12], label: 'action/adventure' },
+};

--- a/services/api/src/hono/lib/household.ts
+++ b/services/api/src/hono/lib/household.ts
@@ -180,14 +180,18 @@ export const acceptInvite = async (
 		.get();
 	if (!invite) throw new InviteInvalidError();
 
-	if (!(await isMember(db, invite.householdId, userId))) {
-		await db.insert(householdMembers).values({
+	// onConflictDoNothing rather than an isMember check-then-insert: the check and the insert
+	// aren't atomic, so a concurrent accept (double-click, retry) could pass the check twice and
+	// hit the (householdId, userId) primary key on the second insert.
+	await db
+		.insert(householdMembers)
+		.values({
 			householdId: invite.householdId,
 			userId,
 			role: 'member',
 			joinedAt: new Date(),
-		});
-	}
+		})
+		.onConflictDoNothing();
 
 	await db
 		.update(householdInvites)

--- a/services/api/src/hono/lib/household.ts
+++ b/services/api/src/hono/lib/household.ts
@@ -1,0 +1,198 @@
+import {
+	households,
+	householdInvites,
+	householdMembers,
+	type Database,
+	type HouseholdInviteRow,
+} from '@pairflix/db';
+import { and, count, eq, gt, inArray, isNull } from 'drizzle-orm';
+import { newId, randomToken } from './id';
+
+const INVITE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
+export const isMember = async (
+	db: Database,
+	householdId: string,
+	userId: string
+): Promise<boolean> => {
+	const row = await db
+		.select({ userId: householdMembers.userId })
+		.from(householdMembers)
+		.where(
+			and(
+				eq(householdMembers.householdId, householdId),
+				eq(householdMembers.userId, userId)
+			)
+		)
+		.get();
+	return row !== undefined;
+};
+
+export const isOwner = async (
+	db: Database,
+	householdId: string,
+	userId: string
+): Promise<boolean> => {
+	const row = await db
+		.select({ userId: householdMembers.userId })
+		.from(householdMembers)
+		.where(
+			and(
+				eq(householdMembers.householdId, householdId),
+				eq(householdMembers.userId, userId),
+				eq(householdMembers.role, 'owner')
+			)
+		)
+		.get();
+	return row !== undefined;
+};
+
+export type HouseholdSummary = {
+	id: string;
+	name: string | null;
+	role: 'owner' | 'member';
+	joinedAt: Date;
+	memberCount: number;
+};
+
+export const listForUser = async (
+	db: Database,
+	userId: string
+): Promise<HouseholdSummary[]> => {
+	const memberships = await db
+		.select({
+			householdId: householdMembers.householdId,
+			role: householdMembers.role,
+			joinedAt: householdMembers.joinedAt,
+		})
+		.from(householdMembers)
+		.where(eq(householdMembers.userId, userId));
+	if (memberships.length === 0) return [];
+
+	const householdIds = memberships.map(m => m.householdId);
+	const [rows, counts] = await Promise.all([
+		db.select().from(households).where(inArray(households.id, householdIds)),
+		db
+			.select({ householdId: householdMembers.householdId, total: count() })
+			.from(householdMembers)
+			.where(inArray(householdMembers.householdId, householdIds))
+			.groupBy(householdMembers.householdId),
+	]);
+	const householdById = new Map(rows.map(h => [h.id, h]));
+	const countByHousehold = new Map(counts.map(c => [c.householdId, c.total]));
+
+	return memberships.flatMap(m => {
+		const household = householdById.get(m.householdId);
+		if (!household) return [];
+		return [
+			{
+				id: household.id,
+				name: household.name,
+				role: m.role,
+				joinedAt: m.joinedAt,
+				memberCount: countByHousehold.get(m.householdId) ?? 1,
+			},
+		];
+	});
+};
+
+export const createForOwner = async (
+	db: Database,
+	ownerUserId: string,
+	name: string | null
+): Promise<HouseholdSummary> => {
+	const householdId = newId('household');
+	const now = new Date();
+	await db.batch([
+		db
+			.insert(households)
+			.values({ id: householdId, name, createdAt: now, updatedAt: now }),
+		db.insert(householdMembers).values({
+			householdId,
+			userId: ownerUserId,
+			role: 'owner',
+			joinedAt: now,
+		}),
+	]);
+	return {
+		id: householdId,
+		name,
+		role: 'owner',
+		joinedAt: now,
+		memberCount: 1,
+	};
+};
+
+export type InviteSummary = {
+	id: string;
+	token: string;
+	invitedEmail: string | null;
+	expiresAt: Date;
+	acceptedAt: Date | null;
+};
+
+export const createInvite = async (
+	db: Database,
+	householdId: string,
+	invitedBy: string,
+	invitedEmail: string | null
+): Promise<InviteSummary> => {
+	const id = newId('invite');
+	const token = randomToken();
+	const now = new Date();
+	const expiresAt = new Date(now.getTime() + INVITE_TTL_MS);
+	await db.insert(householdInvites).values({
+		id,
+		householdId,
+		token,
+		invitedEmail,
+		invitedBy,
+		expiresAt,
+		createdAt: now,
+	});
+	return { id, token, invitedEmail, expiresAt, acceptedAt: null };
+};
+
+export class InviteInvalidError extends Error {
+	constructor() {
+		super('invite_invalid_or_expired');
+		this.name = 'InviteInvalidError';
+	}
+}
+
+/** Idempotent -- accepting an invite for a household the user already belongs to just marks the
+ * invite consumed without creating a duplicate membership. */
+export const acceptInvite = async (
+	db: Database,
+	token: string,
+	userId: string
+): Promise<{ householdId: string }> => {
+	const invite: HouseholdInviteRow | undefined = await db
+		.select()
+		.from(householdInvites)
+		.where(
+			and(
+				eq(householdInvites.token, token),
+				isNull(householdInvites.acceptedAt),
+				gt(householdInvites.expiresAt, new Date())
+			)
+		)
+		.get();
+	if (!invite) throw new InviteInvalidError();
+
+	if (!(await isMember(db, invite.householdId, userId))) {
+		await db.insert(householdMembers).values({
+			householdId: invite.householdId,
+			userId,
+			role: 'member',
+			joinedAt: new Date(),
+		});
+	}
+
+	await db
+		.update(householdInvites)
+		.set({ acceptedAt: new Date(), acceptedBy: userId })
+		.where(eq(householdInvites.id, invite.id));
+
+	return { householdId: invite.householdId };
+};

--- a/services/api/src/hono/lib/llm.ts
+++ b/services/api/src/hono/lib/llm.ts
@@ -1,9 +1,4 @@
-import type { Database } from '@pairflix/db';
 import type { Bindings } from '../types';
-import {
-	isLlmRerankEnabled,
-	isLlmRerankEnabledForHousehold,
-} from './featureFlags';
 
 /**
  * LLM re-rank client -- fetch-based (Workers-native, no SDK), matching `lib/email.ts` and
@@ -13,8 +8,12 @@ import {
  * reasoning `lib/tmdb.ts` used to drop its watch-providers cache), and `console.warn` instead of
  * `auditLogService`, matching the logging convention already used elsewhere in this port.
  *
- * `maybeRerank` is the integration point for `lib/recommendation.ts`: it never throws, and a
- * `null` return means the caller must fall back to its pure-ML top-1 pick.
+ * `rerankCandidates` throws `LLMUnavailable` on any failure (not configured, network error, bad
+ * response shape) -- deciding whether to call it at all (feature flag, premium entitlement) and
+ * catching that failure to fall back to a pure-ML pick are both `lib/recommendation.ts`'s job, not
+ * this module's: the caller already has to check eligibility once to size its candidate hydration,
+ * so a self-checking wrapper here would just re-read the same `settings`/`subscriptions` rows on
+ * every call.
  */
 
 const MODEL = 'claude-sonnet-4-6';
@@ -93,15 +92,6 @@ export type LlmRerankInput = {
 	tasteProfiles: LlmTasteProfile[];
 	mood: string;
 	minutes: number;
-};
-
-/** Context passed to `maybeRerank`. `householdId` gates the per-household premium check; when
- * omitted only the global `recommendation.llm_rerank` flag is checked. */
-export type LlmRerankContext = {
-	mood: string;
-	minutes: number;
-	tasteProfiles: LlmTasteProfile[];
-	householdId?: string;
 };
 
 export class LLMUnavailable extends Error {
@@ -193,6 +183,10 @@ const extractUsage = (usage: AnthropicMessageResponse['usage']): LlmUsage => {
 	return result;
 };
 
+/** Throws `LLMUnavailable` if not configured or the call fails for any reason. On success,
+ * `pickTmdbId`/`alternatesTmdbIds` are expected (not guaranteed) to be drawn from
+ * `input.candidates` -- the model is instructed to do so, but callers should still validate
+ * before surfacing. */
 export const rerankCandidates = async (
 	env: Bindings,
 	input: LlmRerankInput
@@ -270,41 +264,5 @@ export const rerankCandidates = async (
 		throw new LLMUnavailable('Anthropic call failed', err);
 	} finally {
 		clearTimeout(timeout);
-	}
-};
-
-/**
- * Integration point for `lib/recommendation.ts`.
- *
- * Contract: returns `null` if the LLM rerank flag is off or the call fails for any reason --
- * callers MUST fall back to their pure-ML top-1 pick when this returns `null`. When a result is
- * returned, `pickTmdbId`/`alternatesTmdbIds` are expected (not guaranteed) to be drawn from the
- * input candidate list -- the model is instructed to do so, but callers should still validate
- * before surfacing.
- */
-export const maybeRerank = async (
-	env: Bindings,
-	db: Database,
-	candidates: LlmCandidate[],
-	ctx: LlmRerankContext
-): Promise<LlmRerankResult | null> => {
-	try {
-		const enabled = ctx.householdId
-			? await isLlmRerankEnabledForHousehold(db, ctx.householdId)
-			: await isLlmRerankEnabled(db);
-		if (!enabled) return null;
-
-		return await rerankCandidates(env, {
-			candidates,
-			tasteProfiles: ctx.tasteProfiles,
-			mood: ctx.mood,
-			minutes: ctx.minutes,
-		});
-	} catch (err) {
-		console.warn(
-			'[llm] rerank unavailable',
-			err instanceof Error ? err.message : 'Unknown error'
-		);
-		return null;
 	}
 };

--- a/services/api/src/hono/lib/llm.ts
+++ b/services/api/src/hono/lib/llm.ts
@@ -1,0 +1,310 @@
+import type { Database } from '@pairflix/db';
+import type { Bindings } from '../types';
+import {
+	isLlmRerankEnabled,
+	isLlmRerankEnabledForHousehold,
+} from './featureFlags';
+
+/**
+ * LLM re-rank client -- fetch-based (Workers-native, no SDK), matching `lib/email.ts` and
+ * CLAUDE.md's "Called from the Worker over fetch" instruction. Ported from the current Express
+ * `llm.service.ts`. Two deliberate simplifications vs. that version: no in-memory LRU response
+ * cache (a Worker isolate doesn't reliably live long enough for one to pay for itself -- same
+ * reasoning `lib/tmdb.ts` used to drop its watch-providers cache), and `console.warn` instead of
+ * `auditLogService`, matching the logging convention already used elsewhere in this port.
+ *
+ * `maybeRerank` is the integration point for `lib/recommendation.ts`: it never throws, and a
+ * `null` return means the caller must fall back to its pure-ML top-1 pick.
+ */
+
+const MODEL = 'claude-sonnet-4-6';
+const MAX_TOKENS = 512;
+const TIMEOUT_MS = 8_000;
+const ANTHROPIC_API_URL = 'https://api.anthropic.com/v1/messages';
+const ANTHROPIC_VERSION = '2023-06-01';
+
+const SYSTEM_PROMPT = [
+	'You are a film-pick reasoner for a couples movie app.',
+	'You receive 10 candidate films pre-filtered by an ML scorer and short taste',
+	'blurbs for each household member. Pick ONE film both people are likely to',
+	'enjoy together for the given mood and available minutes, plus up to 2',
+	'alternates. Prefer shared genre overlap and respect dislikes. Keep the',
+	'rationale to one short sentence shown on the card. Always call the',
+	'submit_pick tool. Never reply in prose.',
+].join(' ');
+
+const SUBMIT_PICK_TOOL = {
+	name: 'submit_pick',
+	description:
+		'Submit the final pick, up to 2 alternates, and a one-sentence rationale.',
+	input_schema: {
+		type: 'object',
+		properties: {
+			pick_tmdb_id: {
+				type: 'integer',
+				description: 'tmdb_id of the chosen film from the candidate list',
+			},
+			alternates_tmdb_ids: {
+				type: 'array',
+				items: { type: 'integer' },
+				maxItems: 2,
+				description: 'Up to 2 alternate tmdb_ids from the candidate list',
+			},
+			rationale: {
+				type: 'string',
+				description: 'One short sentence explaining the pick',
+			},
+		},
+		required: ['pick_tmdb_id', 'alternates_tmdb_ids', 'rationale'],
+		additionalProperties: false,
+	},
+};
+
+export type LlmTasteProfile = {
+	userId: string;
+	summary: string;
+};
+
+export type LlmCandidate = {
+	tmdbId: number;
+	title: string;
+	year: number;
+	runtime: number;
+	overview: string;
+	genres: string[];
+};
+
+export type LlmUsage = {
+	inputTokens: number;
+	outputTokens: number;
+	cacheReadInputTokens?: number;
+	cacheCreationInputTokens?: number;
+};
+
+export type LlmRerankResult = {
+	pickTmdbId: number;
+	alternatesTmdbIds: number[];
+	rationale: string;
+	rawUsage: LlmUsage;
+};
+
+export type LlmRerankInput = {
+	candidates: LlmCandidate[];
+	tasteProfiles: LlmTasteProfile[];
+	mood: string;
+	minutes: number;
+};
+
+/** Context passed to `maybeRerank`. `householdId` gates the per-household premium check; when
+ * omitted only the global `recommendation.llm_rerank` flag is checked. */
+export type LlmRerankContext = {
+	mood: string;
+	minutes: number;
+	tasteProfiles: LlmTasteProfile[];
+	householdId?: string;
+};
+
+export class LLMUnavailable extends Error {
+	readonly cause?: unknown;
+
+	constructor(message: string, cause?: unknown) {
+		super(message);
+		this.name = 'LLMUnavailable';
+		if (cause !== undefined) {
+			this.cause = cause;
+		}
+	}
+}
+
+type SubmitPickInput = {
+	pick_tmdb_id: number;
+	alternates_tmdb_ids: number[];
+	rationale: string;
+};
+
+const isSubmitPickInput = (value: unknown): value is SubmitPickInput => {
+	if (typeof value !== 'object' || value === null) return false;
+	// Narrow unknown to an indexable object after the typeof/null guard above.
+	const v = value as Record<string, unknown>;
+	return (
+		typeof v.pick_tmdb_id === 'number' &&
+		Array.isArray(v.alternates_tmdb_ids) &&
+		v.alternates_tmdb_ids.every(id => typeof id === 'number') &&
+		typeof v.rationale === 'string'
+	);
+};
+
+type AnthropicMessageResponse = {
+	content: Array<{ type: string; name?: string; input?: unknown }>;
+	usage: {
+		input_tokens: number;
+		output_tokens: number;
+		cache_read_input_tokens?: number;
+		cache_creation_input_tokens?: number;
+	};
+};
+
+const renderTasteBlock = (profiles: LlmTasteProfile[]): string => {
+	const lines = profiles.map(
+		(p, i) => `Member ${i + 1} (${p.userId}): ${p.summary}`
+	);
+	return ['Household taste profiles:', ...lines].join('\n');
+};
+
+const renderCandidatesBlock = (
+	candidates: LlmCandidate[],
+	mood: string,
+	minutes: number
+): string => {
+	const header = `Mood: ${mood}\nMax runtime: ${minutes} min\nCandidates:`;
+	const rows = candidates.map(c => {
+		const genres = c.genres.join(', ');
+		return `- ${c.tmdbId} | ${c.title} (${c.year}) | ${c.runtime} min | [${genres}] | ${c.overview}`;
+	});
+	return [header, ...rows, 'Call submit_pick with your choice.'].join('\n');
+};
+
+const extractToolUse = (
+	content: AnthropicMessageResponse['content']
+): SubmitPickInput => {
+	const block = content.find(
+		b => b.type === 'tool_use' && b.name === 'submit_pick'
+	);
+	if (!block) throw new LLMUnavailable('Model did not call submit_pick tool');
+	if (!isSubmitPickInput(block.input)) {
+		throw new LLMUnavailable(
+			'submit_pick tool call had an unexpected input shape'
+		);
+	}
+	return block.input;
+};
+
+const extractUsage = (usage: AnthropicMessageResponse['usage']): LlmUsage => {
+	const result: LlmUsage = {
+		inputTokens: usage.input_tokens,
+		outputTokens: usage.output_tokens,
+	};
+	if (typeof usage.cache_read_input_tokens === 'number') {
+		result.cacheReadInputTokens = usage.cache_read_input_tokens;
+	}
+	if (typeof usage.cache_creation_input_tokens === 'number') {
+		result.cacheCreationInputTokens = usage.cache_creation_input_tokens;
+	}
+	return result;
+};
+
+export const rerankCandidates = async (
+	env: Bindings,
+	input: LlmRerankInput
+): Promise<LlmRerankResult> => {
+	if (!env.ANTHROPIC_API_KEY) {
+		throw new LLMUnavailable('ANTHROPIC_API_KEY is not set');
+	}
+
+	const tasteBlock = renderTasteBlock(input.tasteProfiles);
+	const candidatesBlock = renderCandidatesBlock(
+		input.candidates,
+		input.mood,
+		input.minutes
+	);
+
+	const controller = new AbortController();
+	const timeout = setTimeout(() => controller.abort(), TIMEOUT_MS);
+	try {
+		const response = await fetch(ANTHROPIC_API_URL, {
+			method: 'POST',
+			headers: {
+				'x-api-key': env.ANTHROPIC_API_KEY,
+				'anthropic-version': ANTHROPIC_VERSION,
+				'content-type': 'application/json',
+			},
+			signal: controller.signal,
+			body: JSON.stringify({
+				model: MODEL,
+				max_tokens: MAX_TOKENS,
+				system: [
+					{
+						type: 'text',
+						text: SYSTEM_PROMPT,
+						cache_control: { type: 'ephemeral' },
+					},
+				],
+				tools: [SUBMIT_PICK_TOOL],
+				tool_choice: { type: 'tool', name: 'submit_pick' },
+				messages: [
+					{
+						role: 'user',
+						content: [
+							{
+								type: 'text',
+								text: tasteBlock,
+								cache_control: { type: 'ephemeral' },
+							},
+							{ type: 'text', text: candidatesBlock },
+						],
+					},
+				],
+			}),
+		});
+
+		if (!response.ok) {
+			const text = await response.text().catch(() => '');
+			throw new LLMUnavailable(
+				`Anthropic API error: ${response.status} ${text}`
+			);
+		}
+
+		// External API response -- fields are validated below via isSubmitPickInput before use,
+		// matching the single-cast convention lib/tmdb.ts's tmdbFetch uses for its own responses.
+		const data = (await response.json()) as AnthropicMessageResponse;
+		const toolInput = extractToolUse(data.content);
+
+		return {
+			pickTmdbId: toolInput.pick_tmdb_id,
+			alternatesTmdbIds: toolInput.alternates_tmdb_ids.slice(0, 2),
+			rationale: toolInput.rationale,
+			rawUsage: extractUsage(data.usage),
+		};
+	} catch (err) {
+		if (err instanceof LLMUnavailable) throw err;
+		throw new LLMUnavailable('Anthropic call failed', err);
+	} finally {
+		clearTimeout(timeout);
+	}
+};
+
+/**
+ * Integration point for `lib/recommendation.ts`.
+ *
+ * Contract: returns `null` if the LLM rerank flag is off or the call fails for any reason --
+ * callers MUST fall back to their pure-ML top-1 pick when this returns `null`. When a result is
+ * returned, `pickTmdbId`/`alternatesTmdbIds` are expected (not guaranteed) to be drawn from the
+ * input candidate list -- the model is instructed to do so, but callers should still validate
+ * before surfacing.
+ */
+export const maybeRerank = async (
+	env: Bindings,
+	db: Database,
+	candidates: LlmCandidate[],
+	ctx: LlmRerankContext
+): Promise<LlmRerankResult | null> => {
+	try {
+		const enabled = ctx.householdId
+			? await isLlmRerankEnabledForHousehold(db, ctx.householdId)
+			: await isLlmRerankEnabled(db);
+		if (!enabled) return null;
+
+		return await rerankCandidates(env, {
+			candidates,
+			tasteProfiles: ctx.tasteProfiles,
+			mood: ctx.mood,
+			minutes: ctx.minutes,
+		});
+	} catch (err) {
+		console.warn(
+			'[llm] rerank unavailable',
+			err instanceof Error ? err.message : 'Unknown error'
+		);
+		return null;
+	}
+};

--- a/services/api/src/hono/lib/pickEvents.ts
+++ b/services/api/src/hono/lib/pickEvents.ts
@@ -1,0 +1,41 @@
+import { pickEvents, type Database } from '@pairflix/db';
+import { newId } from './id';
+
+export type PickEventKind =
+	'proposed' | 'accepted' | 'swapped' | 'dismissed' | 'provider_launched';
+
+export type RecordPickEventInput = {
+	householdId: string;
+	userId?: string | null;
+	tmdbId: number;
+	mediaType: 'movie' | 'tv';
+	kind: PickEventKind;
+	mood?: string | null;
+	minutesBudget?: number | null;
+	providerSlug?: string | null;
+	region?: string | null;
+};
+
+/** Backs the first-pick acceptance-rate KPI (see packages/db/src/schema.ts's `pickEvents` doc
+ * comment) -- every caller that proposes or resolves a pick should record one of these. Left as a
+ * plain awaitable write; callers that want fire-and-forget semantics (e.g. not failing a pick
+ * response over a bookkeeping write) decide that at the route layer, matching how `auth.ts`
+ * handles its own best-effort `lastLogin` write. */
+export const recordPickEvent = async (
+	db: Database,
+	input: RecordPickEventInput
+): Promise<void> => {
+	await db.insert(pickEvents).values({
+		id: newId('pickevent'),
+		householdId: input.householdId,
+		userId: input.userId ?? null,
+		tmdbId: input.tmdbId,
+		mediaType: input.mediaType,
+		kind: input.kind,
+		mood: input.mood ?? null,
+		minutesBudget: input.minutesBudget ?? null,
+		providerSlug: input.providerSlug ?? null,
+		region: input.region ?? null,
+		occurredAt: new Date(),
+	});
+};

--- a/services/api/src/hono/lib/recommendation.ts
+++ b/services/api/src/hono/lib/recommendation.ts
@@ -11,7 +11,12 @@ import type { Bindings } from '../types';
 import { isLlmRerankEnabledForHousehold } from './featureFlags';
 import { GENRE_NAMES, MOOD_FILTERS } from './genres';
 import { newId } from './id';
-import { maybeRerank, type LlmCandidate, type LlmTasteProfile } from './llm';
+import {
+	rerankCandidates,
+	type LlmCandidate,
+	type LlmRerankResult,
+	type LlmTasteProfile,
+} from './llm';
 import { recordPickEvent } from './pickEvents';
 import { summariseTasteProfile } from './tasteSummary';
 import {
@@ -430,12 +435,23 @@ export const pickForHousehold = async (
 			.filter((name): name is string => Boolean(name)),
 	}));
 
-	const llmResult = await maybeRerank(env, db, llmCandidates, {
-		mood: request.mood,
-		minutes: request.minutes,
-		tasteProfiles: tasteProfilesForLlm,
-		householdId,
-	});
+	// llmEligible is already known (checked once above, to size hydration) -- call the Anthropic
+	// client directly instead of through a self-checking wrapper that would re-read the same
+	// settings/subscriptions rows for no reason.
+	let llmResult: LlmRerankResult | null = null;
+	try {
+		llmResult = await rerankCandidates(env, {
+			candidates: llmCandidates,
+			tasteProfiles: tasteProfilesForLlm,
+			mood: request.mood,
+			minutes: request.minutes,
+		});
+	} catch (err) {
+		console.warn(
+			'[recommendation] LLM rerank unavailable',
+			err instanceof Error ? err.message : 'Unknown error'
+		);
+	}
 	if (!llmResult) return mlResult;
 
 	const byTmdbId = new Map(paired.map(p => [p.card.tmdbId, p]));

--- a/services/api/src/hono/lib/recommendation.ts
+++ b/services/api/src/hono/lib/recommendation.ts
@@ -1,0 +1,486 @@
+import {
+	householdMembers,
+	tasteProfiles,
+	watchedTogether,
+	type Database,
+	type TasteProfileRow,
+} from '@pairflix/db';
+import { eq, inArray } from 'drizzle-orm';
+import type { CommitPickRequest, PickRequest } from '@pairflix/lib.validation';
+import type { Bindings } from '../types';
+import { isLlmRerankEnabledForHousehold } from './featureFlags';
+import { GENRE_NAMES, MOOD_FILTERS } from './genres';
+import { newId } from './id';
+import { maybeRerank, type LlmCandidate, type LlmTasteProfile } from './llm';
+import { recordPickEvent } from './pickEvents';
+import { summariseTasteProfile } from './tasteSummary';
+import {
+	discoverMedia,
+	getMovieFullDetails,
+	getTVFullDetails,
+	getWatchProviders,
+	type RegionProviders,
+	type TMDbDiscoverMovie,
+	type TMDbDiscoverTV,
+} from './tmdb';
+
+/**
+ * Ported from the current Express `recommendation.service.ts`, with these deliberate
+ * departures:
+ *
+ * - No in-memory `/discover` candidate cache -- same Worker-isolate reasoning already applied to
+ *   `lib/tmdb.ts` and `lib/llm.ts`. Edge-caching `/discover` (CLAUDE.md) is deferred to the
+ *   providers/history domain.
+ * - `getFinishedTmdbIdsForMembers` (an exclusion source keyed off the personal `WatchlistEntry`
+ *   table) is dropped entirely rather than ported -- that table has no D1 equivalent and the
+ *   personal watchlist it backed is being deleted, not preserved, per the product pivot. The
+ *   household-level `watchedTogether` exclusion set already serves "don't re-recommend something
+ *   this household watched together", which is what the pivoted product actually needs.
+ * - Hydration widens from a fixed top-3 to top-10 when the household is LLM-rerank eligible (see
+ *   `pickForHousehold`), runs its TMDb calls in parallel instead of sequentially, and keeps each
+ *   hydrated card paired with its originating scored candidate throughout -- the Express version
+ *   read `top[0]` for the picked candidate's genre_ids independently of which entry actually
+ *   became `cards[0]`, which silently mismatches once provider filtering drops an earlier
+ *   candidate. Keeping the pairing intact fixes that.
+ * - `providersMatch` and the rationale's provider-name lookup both widen from flatrate-only to
+ *   flatrate+free+ads+rent+buy, matching `providerLaunch.service.ts`'s definition of "available".
+ * - The LLM re-rank (`lib/llm.ts`, previously unwired dead code) is now wired in behind
+ *   `isLlmRerankEnabledForHousehold`, with a validated fall-through to the pure-ML top-1 pick
+ *   whenever it's disabled, ineligible, or fails.
+ *
+ * Known, out-of-scope gap: nothing in this port computes `taste_profiles` rows going forward (the
+ * Express `tasteProfile.service.ts` `recompute*` functions are entirely built on the same
+ * `WatchlistEntry` table being deleted, so there's no straight port). `pickForHousehold` only
+ * reads whatever taste profiles already exist; `mergeProfiles` degrades to mood-only genre
+ * filtering when a household has none, which is the common case pre-launch. Deriving taste
+ * weights from `watchedTogether` instead is a real product decision (what signal, what decay)
+ * left for a follow-up rather than decided inline here.
+ */
+
+export class HouseholdNotFoundError extends Error {
+	constructor() {
+		super('household_not_found');
+		this.name = 'HouseholdNotFoundError';
+	}
+}
+
+export class NoCandidatesError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = 'NoCandidatesError';
+	}
+}
+
+export type RecommendationCard = {
+	tmdbId: number;
+	mediaType: 'movie' | 'tv';
+	title: string;
+	year: number | null;
+	runtime: number | null;
+	overview: string;
+	posterPath: string | null;
+	providers: RegionProviders;
+};
+
+export type RecommendationResult = {
+	pick: RecommendationCard;
+	alternates: RecommendationCard[];
+	rationale: string;
+	score: number;
+};
+
+const gaussian = (x: number, mu: number, sigma: number): number => {
+	const z = (x - mu) / sigma;
+	return Math.exp(-0.5 * z * z);
+};
+
+const mergeProfiles = (profiles: TasteProfileRow[]): Record<number, number> => {
+	if (profiles.length === 0) return {};
+	const allGenreKeys = new Set<string>();
+	for (const p of profiles) {
+		for (const k of Object.keys(p.weights.genres ?? {})) {
+			allGenreKeys.add(k);
+		}
+	}
+
+	const merged: Record<number, number> = {};
+	for (const k of allGenreKeys) {
+		let product = 1;
+		for (const p of profiles) {
+			const w = p.weights.genres?.[k] ?? 0;
+			product *= w;
+		}
+		const id = Number(k);
+		if (!Number.isNaN(id)) merged[id] = product;
+	}
+
+	const max = Math.max(...Object.values(merged), 0);
+	if (max <= 0) return merged;
+	for (const k of Object.keys(merged)) {
+		const id = Number(k);
+		merged[id] = (merged[id] ?? 0) / max;
+	}
+	return merged;
+};
+
+const topMergedGenres = (
+	merged: Record<number, number>,
+	moodGenres: number[],
+	limit = 3
+): number[] => {
+	const sorted = Object.entries(merged)
+		.map(([id, w]) => [Number(id), w] as const)
+		.sort((a, b) => b[1] - a[1])
+		.map(([id]) => id);
+	const top = sorted.slice(0, limit);
+	return Array.from(new Set<number>([...top, ...moodGenres]));
+};
+
+const genreWeightsByName = (
+	idWeights: Record<string, number> | undefined
+): Record<string, number> => {
+	if (!idWeights) return {};
+	const byName: Record<string, number> = {};
+	for (const [idStr, weight] of Object.entries(idWeights)) {
+		const name = GENRE_NAMES[Number(idStr)];
+		if (name) byName[name] = weight;
+	}
+	return byName;
+};
+
+const getYear = (item: TMDbDiscoverMovie | TMDbDiscoverTV): number | null => {
+	// TMDbDiscoverMovie/TV are structurally disjoint on these two date fields; the caller doesn't
+	// have a mediaType to discriminate on in every use of this helper, so check both fields.
+	const dateStr =
+		(item as TMDbDiscoverMovie).release_date ??
+		(item as TMDbDiscoverTV).first_air_date;
+	if (!dateStr) return null;
+	const year = parseInt(dateStr.slice(0, 4), 10);
+	return Number.isNaN(year) ? null : year;
+};
+
+const getTitle = (
+	item: TMDbDiscoverMovie | TMDbDiscoverTV,
+	mediaType: 'movie' | 'tv'
+): string =>
+	mediaType === 'movie'
+		? (item as TMDbDiscoverMovie).title // mediaType is caller-supplied, so it safely discriminates the union
+		: (item as TMDbDiscoverTV).name;
+
+const scoreCandidate = (
+	item: TMDbDiscoverMovie | TMDbDiscoverTV,
+	runtime: number | null,
+	mergedGenres: Record<number, number>,
+	moodGenres: number[],
+	targetMinutes: number,
+	currentYear: number
+): number => {
+	const genreIds = item.genre_ids ?? [];
+
+	let genreSum = 0;
+	let genreCount = 0;
+	for (const g of genreIds) {
+		const w = mergedGenres[g];
+		if (w !== undefined) {
+			genreSum += w;
+			genreCount += 1;
+		}
+	}
+	const genreMatch = genreCount > 0 ? genreSum / genreCount : 0;
+
+	const runtimeFit =
+		runtime !== null && runtime > 0
+			? gaussian(runtime, targetMinutes - 10, 25)
+			: 0.5;
+
+	const moodHit = genreIds.some(g => moodGenres.includes(g)) ? 1 : 0;
+
+	const year = getYear(item);
+	const yearsOld = year !== null ? Math.max(0, currentYear - year) : 20;
+	const recencyBonus = Math.max(0, 1 - yearsOld / 30);
+
+	return (
+		0.5 * genreMatch + 0.2 * runtimeFit + 0.15 * moodHit + 0.15 * recencyBonus
+	);
+};
+
+const providersMatch = (
+	providers: RegionProviders,
+	wanted: string[]
+): boolean => {
+	if (wanted.length === 0) return true;
+	const available = [
+		...(providers.flatrate ?? []),
+		...(providers.free ?? []),
+		...(providers.ads ?? []),
+		...(providers.rent ?? []),
+		...(providers.buy ?? []),
+	];
+	const wantedNorm = wanted.map(p => p.toLowerCase().replace(/[^a-z0-9]/g, ''));
+	return available.some(p => {
+		const name = p.provider_name.toLowerCase().replace(/[^a-z0-9]/g, '');
+		return wantedNorm.some(w => name.includes(w) || w.includes(name));
+	});
+};
+
+const buildRationale = (
+	moodLabel: string,
+	pickGenres: number[],
+	mergedGenres: Record<number, number>,
+	targetMinutes: number,
+	runtime: number | null,
+	providerName: string | null
+): string => {
+	const sharedGenre = pickGenres
+		.map(g => ({ g, w: mergedGenres[g] ?? 0, name: GENRE_NAMES[g] }))
+		.filter(x => x.w > 0.3 && x.name)
+		.sort((a, b) => b.w - a.w)[0];
+
+	const parts: string[] = [];
+	if (sharedGenre) {
+		parts.push(`Both of you lean ${sharedGenre.name}`);
+	} else {
+		parts.push(`Matches your ${moodLabel} mood`);
+	}
+	if (runtime !== null && runtime > 0) {
+		parts.push(`fits your ${targetMinutes}-minute slot at ${runtime} min`);
+	}
+	if (providerName) {
+		parts.push(`available on ${providerName}`);
+	}
+	return `${parts.join('; ')}.`;
+};
+
+const hydrate = async (
+	env: Bindings,
+	item: TMDbDiscoverMovie | TMDbDiscoverTV,
+	mediaType: 'movie' | 'tv',
+	region: string,
+	providersFilter?: string[]
+): Promise<RecommendationCard | null> => {
+	let runtime: number | null;
+	try {
+		if (mediaType === 'movie') {
+			const full = await getMovieFullDetails(env, item.id);
+			runtime = full.runtime ?? null;
+		} else {
+			const full = await getTVFullDetails(env, item.id);
+			runtime = full.episode_run_time?.[0] ?? null;
+		}
+	} catch {
+		runtime = null;
+	}
+
+	let providers: RegionProviders = {};
+	if (providersFilter && providersFilter.length > 0) {
+		try {
+			providers = await getWatchProviders(env, item.id, mediaType, region);
+		} catch {
+			providers = {};
+		}
+		if (!providersMatch(providers, providersFilter)) {
+			return null;
+		}
+	}
+
+	return {
+		tmdbId: item.id,
+		mediaType,
+		title: getTitle(item, mediaType),
+		year: getYear(item),
+		runtime,
+		overview: item.overview,
+		posterPath: item.poster_path,
+		providers,
+	};
+};
+
+const pickProviderName = (providers: RegionProviders): string | null =>
+	providers.flatrate?.[0]?.provider_name ??
+	providers.free?.[0]?.provider_name ??
+	providers.ads?.[0]?.provider_name ??
+	providers.rent?.[0]?.provider_name ??
+	providers.buy?.[0]?.provider_name ??
+	null;
+
+export const pickForHousehold = async (
+	env: Bindings,
+	db: Database,
+	householdId: string,
+	request: PickRequest
+): Promise<RecommendationResult> => {
+	const region = request.region ?? 'GB';
+	const moodCfg = MOOD_FILTERS[request.mood];
+
+	const members = await db
+		.select({ userId: householdMembers.userId })
+		.from(householdMembers)
+		.where(eq(householdMembers.householdId, householdId));
+	if (members.length === 0) {
+		throw new HouseholdNotFoundError();
+	}
+	const memberIds = members.map(m => m.userId);
+
+	const profiles = await db
+		.select()
+		.from(tasteProfiles)
+		.where(inArray(tasteProfiles.userId, memberIds));
+	const merged = mergeProfiles(profiles);
+	const genres = topMergedGenres(merged, moodCfg.genres, 3);
+
+	const watchedRows = await db
+		.select({ tmdbId: watchedTogether.tmdbId })
+		.from(watchedTogether)
+		.where(eq(watchedTogether.householdId, householdId));
+	const excluded = new Set<number>([
+		...watchedRows.map(w => w.tmdbId),
+		...(request.excludeTmdbIds ?? []),
+	]);
+
+	const discoverResp = await discoverMedia(env, {
+		mediaType: 'movie',
+		genres,
+		withRuntimeLte: request.minutes,
+		voteCountGte: 200,
+		region,
+	});
+	const filtered = (discoverResp.results ?? []).filter(
+		c => !excluded.has(c.id)
+	);
+	if (filtered.length === 0) {
+		throw new NoCandidatesError('No candidates found for these inputs');
+	}
+
+	const currentYear = new Date().getFullYear();
+	const scored = filtered
+		.map(item => ({
+			item,
+			// /discover responses don't carry runtime; use null so the runtime component contributes
+			// a neutral 0.5 instead of the gaussian peak -- real runtime is fetched during hydration
+			// below, for display only, and never re-scored.
+			score: scoreCandidate(
+				item,
+				null,
+				merged,
+				moodCfg.genres,
+				request.minutes,
+				currentYear
+			),
+		}))
+		.sort((a, b) =>
+			b.score !== a.score
+				? b.score - a.score
+				: b.item.vote_average - a.item.vote_average
+		);
+
+	const llmEligible = await isLlmRerankEnabledForHousehold(db, householdId);
+	const top = scored.slice(0, llmEligible ? 10 : 3);
+
+	const hydrated = await Promise.all(
+		top.map(async entry => ({
+			entry,
+			card: await hydrate(env, entry.item, 'movie', region, request.providers),
+		}))
+	);
+	const paired = hydrated.filter(
+		(h): h is { entry: (typeof top)[number]; card: RecommendationCard } =>
+			h.card !== null
+	);
+	if (paired.length === 0) {
+		throw new NoCandidatesError('No candidates matched the provider filter');
+	}
+
+	const cards = paired.map(p => p.card);
+	const mlPick = paired[0]!;
+	const mlResult: RecommendationResult = {
+		pick: mlPick.card,
+		alternates: cards.slice(1, 3),
+		rationale: buildRationale(
+			moodCfg.label,
+			mlPick.entry.item.genre_ids ?? [],
+			merged,
+			request.minutes,
+			mlPick.card.runtime,
+			pickProviderName(mlPick.card.providers)
+		),
+		score: mlPick.entry.score,
+	};
+
+	if (!llmEligible || paired.length < 2) {
+		return mlResult;
+	}
+
+	const tasteProfilesForLlm: LlmTasteProfile[] = profiles.map(p => ({
+		userId: p.userId,
+		summary: summariseTasteProfile({
+			userId: p.userId,
+			genreWeights: genreWeightsByName(p.weights.genres),
+			preferredRuntime: p.weights.runtime_pref ?? null,
+		}),
+	}));
+
+	const llmCandidates: LlmCandidate[] = paired.map(p => ({
+		tmdbId: p.card.tmdbId,
+		title: p.card.title,
+		year: p.card.year ?? currentYear,
+		runtime: p.card.runtime ?? 0,
+		overview: p.card.overview,
+		genres: (p.entry.item.genre_ids ?? [])
+			.map(id => GENRE_NAMES[id])
+			.filter((name): name is string => Boolean(name)),
+	}));
+
+	const llmResult = await maybeRerank(env, db, llmCandidates, {
+		mood: request.mood,
+		minutes: request.minutes,
+		tasteProfiles: tasteProfilesForLlm,
+		householdId,
+	});
+	if (!llmResult) return mlResult;
+
+	const byTmdbId = new Map(paired.map(p => [p.card.tmdbId, p]));
+	const llmPick = byTmdbId.get(llmResult.pickTmdbId);
+	if (!llmPick) return mlResult;
+
+	const llmAlternates = llmResult.alternatesTmdbIds
+		.map(id => byTmdbId.get(id)?.card)
+		.filter((c): c is RecommendationCard => c !== undefined)
+		.slice(0, 2);
+
+	return {
+		pick: llmPick.card,
+		alternates: llmAlternates,
+		rationale: llmResult.rationale,
+		score: llmPick.entry.score,
+	};
+};
+
+export const commitPick = async (
+	db: Database,
+	householdId: string,
+	userId: string,
+	tmdbId: number,
+	request: CommitPickRequest
+): Promise<{ id: string }> => {
+	const id = newId('watchedtogether');
+	await db.insert(watchedTogether).values({
+		id,
+		householdId,
+		tmdbId,
+		mediaType: request.mediaType,
+		watchedAt: new Date(),
+		enjoyed: null,
+		moodAtPick: request.mood ?? null,
+		minutesBudgetAtPick: request.minutes ?? null,
+	});
+	await recordPickEvent(db, {
+		householdId,
+		userId,
+		tmdbId,
+		mediaType: request.mediaType,
+		kind: 'accepted',
+		mood: request.mood ?? null,
+		minutesBudget: request.minutes ?? null,
+	});
+	return { id };
+};

--- a/services/api/src/hono/lib/tasteSummary.ts
+++ b/services/api/src/hono/lib/tasteSummary.ts
@@ -1,0 +1,62 @@
+/**
+ * Deterministic, no-LLM summariser for a taste profile -- produces the short blurb the LLM
+ * re-ranker (lib/llm.ts) consumes as cached prompt context. Determinism matters: identical input
+ * must produce identical output so the Anthropic prompt cache hits.
+ */
+export type TasteProfileSummaryInput = {
+	userId: string;
+	/** genre name -> weight in [0, 1] (does not need to sum to 1) */
+	genreWeights?: Record<string, number>;
+	/** preferred runtime in minutes */
+	preferredRuntime?: number | null;
+	likes?: string[];
+	dislikes?: string[];
+};
+
+const asPercent = (n: number): number => Math.round(n * 100);
+
+const topGenres = (
+	weights: Record<string, number> | undefined,
+	limit = 2
+): [string, number][] => {
+	if (!weights) return [];
+	const entries = Object.entries(weights).filter(([, w]) => w > 0);
+	entries.sort((a, b) =>
+		b[1] !== a[1] ? b[1] - a[1] : a[0].localeCompare(b[0])
+	);
+	return entries.slice(0, limit);
+};
+
+export const summariseTasteProfile = (
+	profile: TasteProfileSummaryInput
+): string => {
+	const parts: string[] = [];
+
+	const top = topGenres(profile.genreWeights, 2);
+	if (top.length === 1) {
+		const [genre, weight] = top[0]!;
+		parts.push(`Leans ${genre} (${asPercent(weight)}%).`);
+	} else if (top.length >= 2) {
+		const [genre1, weight1] = top[0]!;
+		const [genre2, weight2] = top[1]!;
+		parts.push(
+			`Leans ${genre1} (${asPercent(weight1)}%) and ${genre2} (${asPercent(weight2)}%).`
+		);
+	}
+
+	if (typeof profile.preferredRuntime === 'number') {
+		parts.push(`Prefers ~${Math.round(profile.preferredRuntime)} min films.`);
+	}
+
+	const likes = (profile.likes ?? []).slice().sort();
+	const dislikes = (profile.dislikes ?? []).slice().sort();
+	if (likes.length > 0 && dislikes.length > 0) {
+		parts.push(`Likes ${likes.join(', ')}, avoids ${dislikes.join(', ')}.`);
+	} else if (likes.length > 0) {
+		parts.push(`Likes ${likes.join(', ')}.`);
+	} else if (dislikes.length > 0) {
+		parts.push(`Avoids ${dislikes.join(', ')}.`);
+	}
+
+	return parts.join(' ');
+};

--- a/services/api/src/hono/lib/tmdb.ts
+++ b/services/api/src/hono/lib/tmdb.ts
@@ -1,0 +1,163 @@
+import type { Bindings } from '../types';
+
+/**
+ * TMDb client -- fetch-based (Workers-native, no SDK). Ported from the current Express
+ * `tmdb.service.ts`; deliberately dropped its in-memory `Map`-based watch-providers cache since a
+ * per-isolate cache doesn't reliably persist across requests on Workers anyway. No replacement
+ * cache yet -- edge-caching `/discover` and `/watch/providers` (CLAUDE.md) is deferred to the
+ * providers/history domain, which needs to decide a Workers-appropriate mechanism (e.g. the Cache
+ * API or a `content` table read-through) rather than inventing one here for a single call site.
+ */
+const TMDB_BASE_URL = 'https://api.themoviedb.org/3';
+const SAFE_ENDPOINT = /^\/[a-z][a-z_]*(?:\/[a-z0-9_]+)*$/;
+
+const tmdbFetch = async <T>(
+	env: Bindings,
+	endpoint: string,
+	params: Record<string, string> = {}
+): Promise<T> => {
+	// Allowlist the endpoint path so a caller can never construct a URL that escapes the TMDb
+	// origin. Query parameters are still URL-encoded below.
+	if (!SAFE_ENDPOINT.test(endpoint)) {
+		throw new Error(`Invalid TMDb endpoint: ${endpoint}`);
+	}
+
+	const searchParams = new URLSearchParams({
+		api_key: env.TMDB_API_KEY ?? '',
+		...params,
+	});
+
+	const response = await fetch(`${TMDB_BASE_URL}${endpoint}?${searchParams}`);
+	if (!response.ok) {
+		throw new Error(
+			`TMDb API error: ${response.status} ${response.statusText}`
+		);
+	}
+	// External API response, not runtime-validated -- callers only read the handful of fields
+	// their own TMDb*/RegionProviders types declare.
+	return response.json() as Promise<T>;
+};
+
+export type TMDbResponse<T> = { results?: T[]; status_message?: string };
+
+export type TMDbDiscoverMovie = {
+	id: number;
+	title: string;
+	overview: string;
+	poster_path: string | null;
+	release_date?: string;
+	vote_average: number;
+	vote_count: number;
+	genre_ids: number[];
+	popularity: number;
+};
+
+export type TMDbDiscoverTV = {
+	id: number;
+	name: string;
+	overview: string;
+	poster_path: string | null;
+	first_air_date?: string;
+	vote_average: number;
+	vote_count: number;
+	genre_ids: number[];
+	popularity: number;
+};
+
+export type TMDbDiscoverParams = {
+	mediaType: 'movie' | 'tv';
+	genres: number[];
+	withRuntimeLte?: number;
+	voteCountGte?: number;
+	region?: string;
+	page?: number;
+	sortBy?: string;
+};
+
+export const discoverMedia = async (
+	env: Bindings,
+	params: TMDbDiscoverParams
+): Promise<TMDbResponse<TMDbDiscoverMovie | TMDbDiscoverTV>> => {
+	const queryParams: Record<string, string> = {
+		with_genres: params.genres.join(','),
+		'vote_count.gte': (params.voteCountGte ?? 200).toString(),
+		sort_by: params.sortBy ?? 'popularity.desc',
+		page: (params.page ?? 1).toString(),
+		include_adult: 'false',
+	};
+	if (params.withRuntimeLte && params.mediaType === 'movie') {
+		queryParams['with_runtime.lte'] = params.withRuntimeLte.toString();
+	}
+	if (params.region) {
+		queryParams.region = params.region;
+		queryParams.watch_region = params.region;
+	}
+
+	return tmdbFetch<TMDbResponse<TMDbDiscoverMovie | TMDbDiscoverTV>>(
+		env,
+		`/discover/${params.mediaType}`,
+		queryParams
+	);
+};
+
+export type TMDbMovieFull = {
+	id: number;
+	title: string;
+	overview: string;
+	poster_path: string | null;
+	runtime?: number | null;
+	release_date?: string;
+};
+
+export type TMDbTVFull = {
+	id: number;
+	name: string;
+	overview: string;
+	poster_path: string | null;
+	episode_run_time?: number[];
+	first_air_date?: string;
+};
+
+export const getMovieFullDetails = (
+	env: Bindings,
+	movieId: number
+): Promise<TMDbMovieFull> => tmdbFetch<TMDbMovieFull>(env, `/movie/${movieId}`);
+
+export const getTVFullDetails = (
+	env: Bindings,
+	tvId: number
+): Promise<TMDbTVFull> => tmdbFetch<TMDbTVFull>(env, `/tv/${tvId}`);
+
+export type TMDbProvider = {
+	provider_id: number;
+	provider_name: string;
+	logo_path: string;
+	display_priority?: number;
+};
+
+export type RegionProviders = {
+	link?: string;
+	flatrate?: TMDbProvider[];
+	free?: TMDbProvider[];
+	ads?: TMDbProvider[];
+	buy?: TMDbProvider[];
+	rent?: TMDbProvider[];
+};
+
+type WatchProvidersResponse = {
+	id?: number;
+	results?: Record<string, RegionProviders>;
+};
+
+export const getWatchProviders = async (
+	env: Bindings,
+	tmdbId: number,
+	mediaType: 'movie' | 'tv',
+	region: string
+): Promise<RegionProviders> => {
+	const data = await tmdbFetch<WatchProvidersResponse>(
+		env,
+		`/${mediaType}/${tmdbId}/watch/providers`
+	);
+	return data.results?.[region] ?? {};
+};

--- a/services/api/src/hono/middleware/entitlements.ts
+++ b/services/api/src/hono/middleware/entitlements.ts
@@ -1,0 +1,58 @@
+import { createDb } from '@pairflix/db';
+import { createMiddleware } from 'hono/factory';
+import { getEntitlements, recordPick } from '../lib/entitlements';
+import type { AppEnv } from '../types';
+
+/**
+ * Computes entitlements once and stores them on context for `enforcePickQuota` (and the pick
+ * route handler, which applies `entitlements.regionLock` over the request's own region) to
+ * reuse -- the current Express app recomputes entitlements independently in both of its
+ * equivalent middleware. Never rejects by itself.
+ *
+ * Must run after `requireHouseholdMember`; must run before `enforcePickQuota`.
+ */
+export const enforceRegionLock = createMiddleware<AppEnv>(async (c, next) => {
+	const householdId = c.req.param('id');
+	if (!householdId) return c.json({ error: 'household_id_required' }, 400);
+	const db = createDb(c.env.DB);
+	const entitlements = await getEntitlements(db, householdId);
+	c.set('entitlements', entitlements);
+	return next();
+});
+
+/**
+ * Rejects with 402 once the household's daily free-tier pick quota is exhausted. On a
+ * successful (< 300) response, records the pick usage via `waitUntil` so the bookkeeping write
+ * doesn't hold up the response.
+ *
+ * Must run after `enforceRegionLock`; falls back to computing entitlements itself if used
+ * without it.
+ */
+export const enforcePickQuota = createMiddleware<AppEnv>(async (c, next) => {
+	const householdId = c.req.param('id');
+	if (!householdId) return c.json({ error: 'household_id_required' }, 400);
+	const db = createDb(c.env.DB);
+	const entitlements =
+		c.get('entitlements') ?? (await getEntitlements(db, householdId));
+
+	if (entitlements.picksRemaining <= 0) {
+		return c.json(
+			{
+				error: 'pick_quota_exceeded',
+				upgradeUrl: '/billing/mock-checkout',
+				entitlements,
+			},
+			402
+		);
+	}
+
+	await next();
+
+	if (c.res.status < 300) {
+		c.executionCtx.waitUntil(
+			recordPick(db, householdId).catch(err => {
+				console.error('[entitlements] failed to record pick usage', err);
+			})
+		);
+	}
+});

--- a/services/api/src/hono/middleware/entitlements.ts
+++ b/services/api/src/hono/middleware/entitlements.ts
@@ -7,7 +7,8 @@ import type { AppEnv } from '../types';
  * Computes entitlements once and stores them on context for `enforcePickQuota` (and the pick
  * route handler, which applies `entitlements.regionLock` over the request's own region) to
  * reuse -- the current Express app recomputes entitlements independently in both of its
- * equivalent middleware. Never rejects by itself.
+ * equivalent middleware. Never rejects for entitlement reasons; the only rejection is a missing
+ * `:id` path param, which would mean this middleware was mounted on the wrong route.
  *
  * Must run after `requireHouseholdMember`; must run before `enforcePickQuota`.
  */

--- a/services/api/src/hono/middleware/household.ts
+++ b/services/api/src/hono/middleware/household.ts
@@ -1,0 +1,32 @@
+import { createDb } from '@pairflix/db';
+import { createMiddleware } from 'hono/factory';
+import { isMember, isOwner } from '../lib/household';
+import type { AppEnv } from '../types';
+
+/** Gate for household-scoped routes keyed by the `:id` path param -- 403s unless the
+ * authenticated user belongs to the household. Must run after `requireAuth`. Consolidates what
+ * the current Express app reimplements separately per route/controller into one check. */
+export const requireHouseholdMember = createMiddleware<AppEnv>(
+	async (c, next) => {
+		const userId = c.get('userId');
+		const householdId = c.req.param('id');
+		if (!householdId) return c.json({ error: 'household_id_required' }, 400);
+		const db = createDb(c.env.DB);
+		const member = userId ? await isMember(db, householdId, userId) : false;
+		if (!member) return c.json({ error: 'not_a_household_member' }, 403);
+		return next();
+	}
+);
+
+/** Gate for owner-only household actions (e.g. creating invites). Must run after `requireAuth`. */
+export const requireHouseholdOwner = createMiddleware<AppEnv>(
+	async (c, next) => {
+		const userId = c.get('userId');
+		const householdId = c.req.param('id');
+		if (!householdId) return c.json({ error: 'household_id_required' }, 400);
+		const db = createDb(c.env.DB);
+		const owner = userId ? await isOwner(db, householdId, userId) : false;
+		if (!owner) return c.json({ error: 'owner_only' }, 403);
+		return next();
+	}
+);

--- a/services/api/src/hono/routes/households.e2e.test.ts
+++ b/services/api/src/hono/routes/households.e2e.test.ts
@@ -1,0 +1,498 @@
+import { env } from 'cloudflare:workers';
+import { createDb, settings, subscriptions } from '@pairflix/db';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+	callApp,
+	createLoggedInUser,
+	postJson,
+	type Cookies,
+} from '../test/test-helpers';
+
+let counter = 0;
+/** A fresh email per test -- isolated storage resets D1 between test *files*, not between tests
+ * within one file. */
+const uniqueEmail = () =>
+	`households-e2e-${Date.now()}-${counter++}@example.com`;
+
+type MockMovie = {
+	id: number;
+	title: string;
+	overview: string;
+	poster_path: string | null;
+	release_date: string;
+	vote_average: number;
+	vote_count: number;
+	genre_ids: number[];
+	popularity: number;
+	runtime: number;
+	providers?: {
+		flatrate?: Array<{
+			provider_id: number;
+			provider_name: string;
+			logo_path: string;
+		}>;
+	};
+};
+
+const MOVIE_A: MockMovie = {
+	id: 101,
+	title: 'The Comedy Hour',
+	overview: 'A very funny movie.',
+	poster_path: null,
+	release_date: '2020-01-01',
+	vote_average: 7.5,
+	vote_count: 500,
+	genre_ids: [35],
+	popularity: 50,
+	runtime: 100,
+};
+const MOVIE_B: MockMovie = {
+	id: 102,
+	title: 'Laughs Ahead',
+	overview: 'Another funny movie.',
+	poster_path: null,
+	release_date: '2019-01-01',
+	vote_average: 7.0,
+	vote_count: 400,
+	genre_ids: [35],
+	popularity: 40,
+	runtime: 95,
+	providers: {
+		flatrate: [
+			{ provider_id: 8, provider_name: 'Netflix', logo_path: '/x.jpg' },
+		],
+	},
+};
+const MOVIE_C: MockMovie = {
+	id: 103,
+	title: 'Chuckles',
+	overview: 'A third comedy.',
+	poster_path: null,
+	release_date: '2021-01-01',
+	vote_average: 6.5,
+	vote_count: 300,
+	genre_ids: [35],
+	popularity: 30,
+	runtime: 110,
+};
+const DEFAULT_MOVIES = [MOVIE_A, MOVIE_B, MOVIE_C];
+
+const jsonResponse = (data: unknown, status = 200): Response =>
+	new Response(JSON.stringify(data), {
+		status,
+		headers: { 'content-type': 'application/json' },
+	});
+
+type MockAnthropic =
+	| { pickTmdbId: number; alternatesTmdbIds: number[]; rationale: string }
+	| 'error';
+
+const REAL_FETCH = globalThis.fetch;
+afterEach(() => {
+	globalThis.fetch = REAL_FETCH;
+});
+
+/** Replaces the global fetch for the rest of the current test so pick/commit flows never hit the
+ * real TMDb/Anthropic APIs -- unreachable from the test sandbox, and non-deterministic even if
+ * reachable. Returns the list of URLs actually requested, so tests can assert on outgoing call
+ * shape (e.g. proving the region-lock override reached TMDb). */
+const mockExternalApis = (
+	movies: MockMovie[],
+	anthropic?: MockAnthropic
+): string[] => {
+	const capturedUrls: string[] = [];
+	globalThis.fetch = (async (input: RequestInfo | URL) => {
+		const url =
+			typeof input === 'string'
+				? input
+				: input instanceof URL
+					? input.toString()
+					: input.url;
+		capturedUrls.push(url);
+		const { hostname, pathname } = new URL(url);
+
+		if (hostname === 'api.themoviedb.org') {
+			if (pathname === '/3/discover/movie')
+				return jsonResponse({ results: movies });
+			const detail = /^\/3\/movie\/(\d+)$/.exec(pathname);
+			if (detail) {
+				const movie = movies.find(m => m.id === Number(detail[1]));
+				if (!movie) return jsonResponse({}, 404);
+				return jsonResponse({
+					id: movie.id,
+					title: movie.title,
+					overview: movie.overview,
+					poster_path: movie.poster_path,
+					runtime: movie.runtime,
+					release_date: movie.release_date,
+				});
+			}
+			const providers = /^\/3\/movie\/(\d+)\/watch\/providers$/.exec(pathname);
+			if (providers) {
+				const movie = movies.find(m => m.id === Number(providers[1]));
+				return jsonResponse({
+					results: movie?.providers ? { GB: movie.providers } : {},
+				});
+			}
+		}
+
+		if (hostname === 'api.anthropic.com' && pathname === '/v1/messages') {
+			if (anthropic === 'error')
+				return jsonResponse({ error: 'mocked failure' }, 500);
+			if (anthropic) {
+				return jsonResponse({
+					content: [
+						{
+							type: 'tool_use',
+							name: 'submit_pick',
+							input: {
+								pick_tmdb_id: anthropic.pickTmdbId,
+								alternates_tmdb_ids: anthropic.alternatesTmdbIds,
+								rationale: anthropic.rationale,
+							},
+						},
+					],
+					usage: { input_tokens: 100, output_tokens: 50 },
+				});
+			}
+		}
+
+		throw new Error(`Unmocked fetch in test: ${url}`);
+	}) as typeof fetch;
+	return capturedUrls;
+};
+
+const createHousehold = async (
+	cookies: Cookies,
+	name?: string
+): Promise<string> => {
+	const result = await postJson<{ household: { id: string } }>(
+		'/api/households',
+		{ name },
+		cookies
+	);
+	if (result.status !== 201) {
+		throw new Error(
+			`createHousehold failed: ${result.status} ${JSON.stringify(result.body)}`
+		);
+	}
+	return result.body.household.id;
+};
+
+const makePremiumWithLlmRerank = async (householdId: string): Promise<void> => {
+	const db = createDb(env.DB);
+	const now = new Date();
+	await db.insert(subscriptions).values({
+		id: `sub_${householdId}`,
+		householdId,
+		tier: 'premium',
+		status: 'active',
+		currentPeriodEnd: new Date(now.getTime() + 30 * 24 * 60 * 60 * 1000),
+		createdAt: now,
+		updatedAt: now,
+	});
+	await db
+		.insert(settings)
+		.values({
+			key: 'recommendation.llm_rerank',
+			value: true,
+			createdAt: now,
+			updatedAt: now,
+		})
+		.onConflictDoUpdate({
+			target: settings.key,
+			set: { value: true, updatedAt: now },
+		});
+};
+
+describe('household CRUD + invites', () => {
+	it('creates a household and lists it for the owner', async () => {
+		const { cookies } = await createLoggedInUser(uniqueEmail());
+		const householdId = await createHousehold(cookies, 'Our Household');
+
+		const listed = await callApp<{
+			households: Array<{ id: string; role: string }>;
+		}>('/api/households', { cookies });
+		expect(listed.status).toBe(200);
+		expect(
+			listed.body.households.some(
+				h => h.id === householdId && h.role === 'owner'
+			)
+		).toBe(true);
+	});
+
+	it('rejects invite creation from a non-owner', async () => {
+		const owner = await createLoggedInUser(uniqueEmail());
+		const other = await createLoggedInUser(uniqueEmail());
+		const householdId = await createHousehold(owner.cookies);
+
+		const result = await postJson(
+			`/api/households/${householdId}/invites`,
+			{},
+			other.cookies
+		);
+		expect(result.status).toBe(403);
+	});
+
+	it('lets an owner invite another user, who can then accept and becomes a member', async () => {
+		const owner = await createLoggedInUser(uniqueEmail());
+		const invitee = await createLoggedInUser(uniqueEmail());
+		const householdId = await createHousehold(owner.cookies);
+
+		const invite = await postJson<{ invite: { token: string } }>(
+			`/api/households/${householdId}/invites`,
+			{},
+			owner.cookies
+		);
+		expect(invite.status).toBe(201);
+
+		const accept = await postJson<{ householdId: string }>(
+			`/api/households/invites/${invite.body.invite.token}/accept`,
+			{},
+			invitee.cookies
+		);
+		expect(accept.status).toBe(200);
+		expect(accept.body.householdId).toBe(householdId);
+
+		const capturedUrls = mockExternalApis(DEFAULT_MOVIES);
+		const pickResult = await postJson(
+			`/api/households/${householdId}/pick`,
+			{ mood: 'funny', minutes: 120 },
+			invitee.cookies
+		);
+		expect(capturedUrls.length).toBeGreaterThan(0);
+		expect(pickResult.status).toBe(200);
+	});
+
+	it('rejects accepting an invalid or expired invite token', async () => {
+		const { cookies } = await createLoggedInUser(uniqueEmail());
+		const result = await postJson(
+			'/api/households/invites/not-a-real-token/accept',
+			{},
+			cookies
+		);
+		expect(result.status).toBe(410);
+	});
+});
+
+describe('POST /api/households/:id/pick', () => {
+	it('rejects a non-member', async () => {
+		const owner = await createLoggedInUser(uniqueEmail());
+		const outsider = await createLoggedInUser(uniqueEmail());
+		const householdId = await createHousehold(owner.cookies);
+
+		mockExternalApis(DEFAULT_MOVIES);
+		const result = await postJson(
+			`/api/households/${householdId}/pick`,
+			{ mood: 'funny', minutes: 120 },
+			outsider.cookies
+		);
+		expect(result.status).toBe(403);
+	});
+
+	it('returns a recommendation for a member and records a proposed pick event', async () => {
+		const { userId, cookies } = await createLoggedInUser(uniqueEmail());
+		const householdId = await createHousehold(cookies);
+
+		mockExternalApis(DEFAULT_MOVIES);
+		const result = await postJson<{
+			pick: { tmdbId: number; mediaType: string };
+			alternates: unknown[];
+			rationale: string;
+			score: number;
+		}>(
+			`/api/households/${householdId}/pick`,
+			{ mood: 'funny', minutes: 120 },
+			cookies
+		);
+
+		expect(result.status).toBe(200);
+		expect(DEFAULT_MOVIES.map(m => m.id)).toContain(result.body.pick.tmdbId);
+		expect(result.body.pick.mediaType).toBe('movie');
+		expect(typeof result.body.rationale).toBe('string');
+		expect(result.body.rationale.length).toBeGreaterThan(0);
+
+		const event = await env.DB.prepare(
+			"SELECT kind, user_id FROM pick_events WHERE household_id = ?1 AND kind = 'proposed' ORDER BY occurred_at DESC LIMIT 1"
+		)
+			.bind(householdId)
+			.first<{ kind: string; user_id: string }>();
+		expect(event?.kind).toBe('proposed');
+		expect(event?.user_id).toBe(userId);
+	});
+
+	it('enforces the free-tier daily pick quota', async () => {
+		const { cookies } = await createLoggedInUser(uniqueEmail());
+		const householdId = await createHousehold(cookies);
+
+		for (let i = 0; i < 3; i++) {
+			mockExternalApis(DEFAULT_MOVIES);
+			const ok = await postJson(
+				`/api/households/${householdId}/pick`,
+				{ mood: 'funny', minutes: 120 },
+				cookies
+			);
+			expect(ok.status).toBe(200);
+		}
+
+		mockExternalApis(DEFAULT_MOVIES);
+		const exceeded = await postJson<{ error: string }>(
+			`/api/households/${householdId}/pick`,
+			{ mood: 'funny', minutes: 120 },
+			cookies
+		);
+		expect(exceeded.status).toBe(402);
+		expect(exceeded.body.error).toBe('pick_quota_exceeded');
+	});
+
+	it('silently overrides the region to the free-tier lock', async () => {
+		const { cookies } = await createLoggedInUser(uniqueEmail());
+		const householdId = await createHousehold(cookies);
+
+		const capturedUrls = mockExternalApis(DEFAULT_MOVIES);
+		const result = await postJson(
+			`/api/households/${householdId}/pick`,
+			{ mood: 'funny', minutes: 120, region: 'US' },
+			cookies
+		);
+		expect(result.status).toBe(200);
+
+		const discoverCall = capturedUrls.find(u =>
+			u.includes('/3/discover/movie')
+		);
+		expect(discoverCall).toBeDefined();
+		expect(new URL(discoverCall!).searchParams.get('region')).toBe('GB');
+	});
+
+	it('only returns a candidate matching the requested provider', async () => {
+		const { cookies } = await createLoggedInUser(uniqueEmail());
+		const householdId = await createHousehold(cookies);
+
+		mockExternalApis(DEFAULT_MOVIES);
+		const result = await postJson<{ pick: { tmdbId: number } }>(
+			`/api/households/${householdId}/pick`,
+			{ mood: 'funny', minutes: 120, providers: ['Netflix'] },
+			cookies
+		);
+		expect(result.status).toBe(200);
+		expect(result.body.pick.tmdbId).toBe(MOVIE_B.id);
+	});
+
+	it('returns 404 when every candidate is excluded', async () => {
+		const { cookies } = await createLoggedInUser(uniqueEmail());
+		const householdId = await createHousehold(cookies);
+
+		mockExternalApis(DEFAULT_MOVIES);
+		const result = await postJson(
+			`/api/households/${householdId}/pick`,
+			{
+				mood: 'funny',
+				minutes: 120,
+				excludeTmdbIds: DEFAULT_MOVIES.map(m => m.id),
+			},
+			cookies
+		);
+		expect(result.status).toBe(404);
+	});
+});
+
+describe('POST /api/households/:id/picks/:tmdbId/commit', () => {
+	it('rejects a non-member', async () => {
+		const owner = await createLoggedInUser(uniqueEmail());
+		const outsider = await createLoggedInUser(uniqueEmail());
+		const householdId = await createHousehold(owner.cookies);
+
+		const result = await postJson(
+			`/api/households/${householdId}/picks/${MOVIE_A.id}/commit`,
+			{ mediaType: 'movie' },
+			outsider.cookies
+		);
+		expect(result.status).toBe(403);
+	});
+
+	it('records watched-together and an accepted pick event', async () => {
+		const { userId, cookies } = await createLoggedInUser(uniqueEmail());
+		const householdId = await createHousehold(cookies);
+
+		const result = await postJson<{ recorded: boolean; id: string }>(
+			`/api/households/${householdId}/picks/${MOVIE_A.id}/commit`,
+			{ mediaType: 'movie', mood: 'funny', minutes: 120 },
+			cookies
+		);
+		expect(result.status).toBe(201);
+		expect(result.body.recorded).toBe(true);
+
+		const watched = await env.DB.prepare(
+			'SELECT tmdb_id, media_type FROM watched_together WHERE id = ?1'
+		)
+			.bind(result.body.id)
+			.first<{ tmdb_id: number; media_type: string }>();
+		expect(watched?.tmdb_id).toBe(MOVIE_A.id);
+		expect(watched?.media_type).toBe('movie');
+
+		const event = await env.DB.prepare(
+			"SELECT kind, user_id, tmdb_id FROM pick_events WHERE household_id = ?1 AND kind = 'accepted' ORDER BY occurred_at DESC LIMIT 1"
+		)
+			.bind(householdId)
+			.first<{ kind: string; user_id: string; tmdb_id: number }>();
+		expect(event?.kind).toBe('accepted');
+		expect(event?.user_id).toBe(userId);
+		expect(event?.tmdb_id).toBe(MOVIE_A.id);
+	});
+});
+
+describe('LLM re-rank wiring', () => {
+	it('never calls Anthropic when the flag is off (default)', async () => {
+		const { cookies } = await createLoggedInUser(uniqueEmail());
+		const householdId = await createHousehold(cookies);
+
+		const capturedUrls = mockExternalApis(DEFAULT_MOVIES);
+		const result = await postJson(
+			`/api/households/${householdId}/pick`,
+			{ mood: 'funny', minutes: 120 },
+			cookies
+		);
+		expect(result.status).toBe(200);
+		expect(capturedUrls.some(u => u.includes('api.anthropic.com'))).toBe(false);
+	});
+
+	it('uses the LLM pick and rationale when enabled and premium', async () => {
+		const { cookies } = await createLoggedInUser(uniqueEmail());
+		const householdId = await createHousehold(cookies);
+		await makePremiumWithLlmRerank(householdId);
+
+		mockExternalApis(DEFAULT_MOVIES, {
+			pickTmdbId: MOVIE_C.id,
+			alternatesTmdbIds: [MOVIE_A.id],
+			rationale: 'The LLM picked this one for a specific reason.',
+		});
+		const result = await postJson<{
+			pick: { tmdbId: number };
+			rationale: string;
+		}>(
+			`/api/households/${householdId}/pick`,
+			{ mood: 'funny', minutes: 120 },
+			cookies
+		);
+		expect(result.status).toBe(200);
+		expect(result.body.pick.tmdbId).toBe(MOVIE_C.id);
+		expect(result.body.rationale).toBe(
+			'The LLM picked this one for a specific reason.'
+		);
+	});
+
+	it('falls back to the ML pick when Anthropic fails', async () => {
+		const { cookies } = await createLoggedInUser(uniqueEmail());
+		const householdId = await createHousehold(cookies);
+		await makePremiumWithLlmRerank(householdId);
+
+		mockExternalApis(DEFAULT_MOVIES, 'error');
+		const result = await postJson<{ pick: { tmdbId: number } }>(
+			`/api/households/${householdId}/pick`,
+			{ mood: 'funny', minutes: 120 },
+			cookies
+		);
+		expect(result.status).toBe(200);
+		expect(DEFAULT_MOVIES.map(m => m.id)).toContain(result.body.pick.tmdbId);
+	});
+});

--- a/services/api/src/hono/routes/households.e2e.test.ts
+++ b/services/api/src/hono/routes/households.e2e.test.ts
@@ -453,7 +453,9 @@ describe('LLM re-rank wiring', () => {
 			cookies
 		);
 		expect(result.status).toBe(200);
-		expect(capturedUrls.some(u => u.includes('api.anthropic.com'))).toBe(false);
+		expect(
+			capturedUrls.some(u => new URL(u).hostname === 'api.anthropic.com')
+		).toBe(false);
 	});
 
 	it('uses the LLM pick and rationale when enabled and premium', async () => {

--- a/services/api/src/hono/routes/households.ts
+++ b/services/api/src/hono/routes/households.ts
@@ -53,7 +53,7 @@ householdsRoutes.get('/', async c => {
 householdsRoutes.post('/', async c => {
 	const userId = c.get('userId') as string;
 	const parsed = CreateHouseholdRequestSchema.safeParse(
-		await c.req.json().catch(() => ({}))
+		await c.req.json().catch(() => null)
 	);
 	if (!parsed.success) {
 		return c.json(
@@ -73,7 +73,7 @@ householdsRoutes.post('/:id/invites', requireHouseholdOwner, async c => {
 	const householdId = c.req.param('id');
 	const userId = c.get('userId') as string;
 	const parsed = CreateInviteRequestSchema.safeParse(
-		await c.req.json().catch(() => ({}))
+		await c.req.json().catch(() => null)
 	);
 	if (!parsed.success) {
 		return c.json(

--- a/services/api/src/hono/routes/households.ts
+++ b/services/api/src/hono/routes/households.ts
@@ -1,0 +1,207 @@
+import { createDb } from '@pairflix/db';
+import {
+	CommitPickRequestSchema,
+	CreateHouseholdRequestSchema,
+	CreateInviteRequestSchema,
+	PickRequestSchema,
+	type PickRequest,
+} from '@pairflix/lib.validation';
+import { Hono } from 'hono';
+import {
+	InviteInvalidError,
+	acceptInvite,
+	createForOwner,
+	createInvite,
+	listForUser,
+} from '../lib/household';
+import { recordPickEvent } from '../lib/pickEvents';
+import {
+	HouseholdNotFoundError,
+	NoCandidatesError,
+	commitPick,
+	pickForHousehold,
+} from '../lib/recommendation';
+import {
+	enforcePickQuota,
+	enforceRegionLock,
+} from '../middleware/entitlements';
+import { requireAuth } from '../middleware/auth';
+import {
+	requireHouseholdMember,
+	requireHouseholdOwner,
+} from '../middleware/household';
+import type { AppEnv } from '../types';
+
+/**
+ * Covers what the current Express `household.routes.ts` mounts under `/api/households` (CRUD,
+ * invites, pick, commit) minus what belongs to a later roadmap phase: provider-launch tracking
+ * and pick-event stats (providers/history), `GET /:id/entitlements` (billing/admin). Also mounts
+ * accept-invite, which exists in Express (`householdInvites.routes.ts`) but is never actually
+ * registered on the app router there -- without it, an invite can be created but never accepted.
+ */
+export const householdsRoutes = new Hono<AppEnv>();
+
+householdsRoutes.use('*', requireAuth);
+
+householdsRoutes.get('/', async c => {
+	const userId = c.get('userId') as string;
+	const db = createDb(c.env.DB);
+	const households = await listForUser(db, userId);
+	return c.json({ households });
+});
+
+householdsRoutes.post('/', async c => {
+	const userId = c.get('userId') as string;
+	const parsed = CreateHouseholdRequestSchema.safeParse(
+		await c.req.json().catch(() => ({}))
+	);
+	if (!parsed.success) {
+		return c.json(
+			{
+				error: 'Invalid input',
+				details: parsed.error.issues.map(i => i.message),
+			},
+			400
+		);
+	}
+	const db = createDb(c.env.DB);
+	const household = await createForOwner(db, userId, parsed.data.name || null);
+	return c.json({ household }, 201);
+});
+
+householdsRoutes.post('/:id/invites', requireHouseholdOwner, async c => {
+	const householdId = c.req.param('id');
+	const userId = c.get('userId') as string;
+	const parsed = CreateInviteRequestSchema.safeParse(
+		await c.req.json().catch(() => ({}))
+	);
+	if (!parsed.success) {
+		return c.json(
+			{
+				error: 'Invalid input',
+				details: parsed.error.issues.map(i => i.message),
+			},
+			400
+		);
+	}
+	const db = createDb(c.env.DB);
+	const invite = await createInvite(
+		db,
+		householdId,
+		userId,
+		parsed.data.email ?? null
+	);
+	return c.json({ invite }, 201);
+});
+
+householdsRoutes.post('/invites/:token/accept', async c => {
+	const userId = c.get('userId') as string;
+	const token = c.req.param('token');
+	const db = createDb(c.env.DB);
+	try {
+		const result = await acceptInvite(db, token, userId);
+		return c.json(result);
+	} catch (error) {
+		if (error instanceof InviteInvalidError) {
+			return c.json({ error: 'invite_invalid_or_expired' }, 410);
+		}
+		throw error;
+	}
+});
+
+householdsRoutes.post(
+	'/:id/pick',
+	requireHouseholdMember,
+	enforceRegionLock,
+	enforcePickQuota,
+	async c => {
+		const householdId = c.req.param('id');
+		const userId = c.get('userId') as string;
+		const parsed = PickRequestSchema.safeParse(
+			await c.req.json().catch(() => null)
+		);
+		if (!parsed.success) {
+			return c.json(
+				{
+					error: 'Invalid input',
+					details: parsed.error.issues.map(i => i.message),
+				},
+				400
+			);
+		}
+
+		// Free-tier households get their region silently overridden -- see enforceRegionLock.
+		const entitlements = c.get('entitlements');
+		const request: PickRequest = {
+			...parsed.data,
+			...(entitlements?.regionLock ? { region: entitlements.regionLock } : {}),
+		};
+
+		const db = createDb(c.env.DB);
+		try {
+			const result = await pickForHousehold(c.env, db, householdId, request);
+			c.executionCtx.waitUntil(
+				recordPickEvent(db, {
+					householdId,
+					userId,
+					tmdbId: result.pick.tmdbId,
+					mediaType: result.pick.mediaType,
+					kind: 'proposed',
+					mood: request.mood,
+					minutesBudget: request.minutes,
+					region: request.region ?? null,
+				}).catch(err => {
+					console.warn(
+						'[households] failed to record proposed pick event',
+						err
+					);
+				})
+			);
+			return c.json(result);
+		} catch (error) {
+			if (
+				error instanceof HouseholdNotFoundError ||
+				error instanceof NoCandidatesError
+			) {
+				return c.json({ error: error.message }, 404);
+			}
+			throw error;
+		}
+	}
+);
+
+householdsRoutes.post(
+	'/:id/picks/:tmdbId/commit',
+	requireHouseholdMember,
+	async c => {
+		const householdId = c.req.param('id');
+		const userId = c.get('userId') as string;
+		const tmdbId = Number.parseInt(c.req.param('tmdbId'), 10);
+		if (Number.isNaN(tmdbId)) {
+			return c.json({ error: 'Invalid tmdbId' }, 400);
+		}
+
+		const parsed = CommitPickRequestSchema.safeParse(
+			await c.req.json().catch(() => null)
+		);
+		if (!parsed.success) {
+			return c.json(
+				{
+					error: 'Invalid input',
+					details: parsed.error.issues.map(i => i.message),
+				},
+				400
+			);
+		}
+
+		const db = createDb(c.env.DB);
+		const result = await commitPick(
+			db,
+			householdId,
+			userId,
+			tmdbId,
+			parsed.data
+		);
+		return c.json({ recorded: true, id: result.id }, 201);
+	}
+);

--- a/services/api/src/hono/types.ts
+++ b/services/api/src/hono/types.ts
@@ -18,8 +18,9 @@ export type Bindings = {
 	APP_CLIENT_URL?: string;
 	/** TMDb API key -- titles, discover, and watch-provider lookups (lib/tmdb.ts). */
 	TMDB_API_KEY?: string;
-	/** Premium LLM re-rank (lib/llm.ts) -- absent means `maybeRerank` always returns null, same
-	 * "unconfigured is a valid state" degrade as the current Express `llm.service.ts`. */
+	/** Premium LLM re-rank (lib/llm.ts) -- absent means `rerankCandidates` always throws
+	 * `LLMUnavailable`, which `lib/recommendation.ts` catches to fall back to the pure-ML pick,
+	 * same "unconfigured is a valid state" degrade as the current Express `llm.service.ts`. */
 	ANTHROPIC_API_KEY?: string;
 };
 

--- a/services/api/src/hono/types.ts
+++ b/services/api/src/hono/types.ts
@@ -1,8 +1,9 @@
 import type { D1Database } from '@cloudflare/workers-types';
+import type { Entitlements } from './lib/entitlements';
 
 /** Worker bindings (see wrangler.jsonc) plus environment vars / secrets. Grows as later P3 domains
- * (households/pick, providers/history, billing/admin) land -- only what the auth domain needs so
- * far. */
+ * (providers/history, billing/admin) land -- only what the auth and households/pick domains need
+ * so far. */
 export type Bindings = {
 	DB: D1Database;
 	ENVIRONMENT: string;
@@ -15,11 +16,19 @@ export type Bindings = {
 	EMAIL_FROM?: string;
 	/** Base URL of apps/client -- verification/reset links point here. */
 	APP_CLIENT_URL?: string;
+	/** TMDb API key -- titles, discover, and watch-provider lookups (lib/tmdb.ts). */
+	TMDB_API_KEY?: string;
+	/** Premium LLM re-rank (lib/llm.ts) -- absent means `maybeRerank` always returns null, same
+	 * "unconfigured is a valid state" degrade as the current Express `llm.service.ts`. */
+	ANTHROPIC_API_KEY?: string;
 };
 
 /** Request-scoped values set by middleware. */
 export type Variables = {
 	userId: string | null;
+	/** Set by `middleware/entitlements.ts`'s `enforceRegionLock` so `enforcePickQuota` (and the
+	 * pick route handler, for the region-lock value itself) don't each recompute it. */
+	entitlements?: Entitlements;
 };
 
 export type AppEnv = { Bindings: Bindings; Variables: Variables };

--- a/services/api/vitest.config.mts
+++ b/services/api/vitest.config.mts
@@ -37,6 +37,11 @@ export default defineConfig(async () => {
             // src/hono/lib/crypto.ts). Without this, 2FA enroll/verify 501 (see
             // src/hono/routes/me.ts's fail-fast guard).
             SESSION_SECRET: 'test-session-secret',
+            // households.e2e.test.ts stubs globalThis.fetch, so these never reach a real API --
+            // ANTHROPIC_API_KEY only needs to be non-empty so lib/llm.ts's fail-fast guard doesn't
+            // short-circuit before the stub is called.
+            TMDB_API_KEY: 'test-tmdb-key',
+            ANTHROPIC_API_KEY: 'test-anthropic-key',
           },
         },
       }),


### PR DESCRIPTION
### What's New

- Feature: Ports household CRUD/membership/invites, `POST /:id/pick`, and `POST /:id/picks/:tmdbId/commit` from Express to the Hono Worker (`services/api/src/hono`), continuing the P3 re-platform after the auth domain (#66, #67).
- Feature: Wires the Anthropic LLM re-rank into the recommender for the first time — it existed in Express as fully-built but never-called dead code.
- Fix: `commit` now records a `pick_events` "accepted" row. Express only ever wrote "proposed", silently breaking the first-pick-acceptance-rate KPI.
- Fix: The pick route now checks household membership at all — Express's controller didn't.
- Fix: Mounts accept-invite, which existed in Express (`householdInvites.routes.ts`) but was never registered on the app router, so invites could be created but never accepted.
- Refactor: Consolidates five separate household-membership checks scattered across Express controllers/middleware into one `isMember`/`isOwner` pair (`lib/household.ts`), reused by two new middleware (`requireHouseholdMember`/`requireHouseholdOwner`) and the region-lock/quota middleware.
- Test: 15 new `vitest-pool-workers` integration tests.

---

### Description

Continues the ADR 0001 Cloudflare re-platform (`docs/roadmap.md`, P3) by porting the second domain — households/pick — from the still-deployed Express app to the Hono Worker, one domain at a time, same pattern as the auth domain.

New `services/api/src/hono` files:
- `lib/genres.ts`, `lib/tmdb.ts`, `lib/household.ts`, `lib/entitlements.ts`, `lib/featureFlags.ts`, `lib/tasteSummary.ts`, `lib/llm.ts`, `lib/pickEvents.ts`, `lib/recommendation.ts`
- `middleware/household.ts`, `middleware/entitlements.ts`
- `routes/households.ts`, `routes/households.e2e.test.ts`
- `packages/lib.validation/src/schemas/household.ts` (camelCase request schemas, matching the auth domain's convention, deliberately diverging from Express's snake_case bodies)

**LLM re-rank.** `lib/llm.ts` is a fetch-based port of Express's `llm.service.ts` (same model, prompt, tool-use schema, and prompt-caching layout), dropping its in-memory LRU response cache — a Worker isolate doesn't reliably live long enough for one to pay for itself, same reasoning already applied to `lib/tmdb.ts`'s watch-providers cache. `lib/recommendation.ts` wires it in: households that are flag-enabled and premium hydrate the top 10 scored candidates instead of 3 (parallelized, where Express hydrated sequentially) and pass them to `maybeRerank`, which validates the model's chosen id against what was actually sent and falls back to the pure-ML top-1 pick on any failure — flag off, not premium, API error, or timeout.

**Bugs found and fixed while porting** (beyond the two above): the Express recommender's `pick` and the `pickGenres` used to build its rationale could reference *different* candidates once provider filtering dropped an earlier one, since it read `top[0]` independently of which entry actually became `cards[0]` — the port keeps each hydrated card paired with its originating scored candidate throughout, so the rationale always describes the actual pick. `providersMatch` and the rationale's provider-name lookup both widen from flatrate-only to flatrate+free+ads+rent+buy, matching `providerLaunch.service.ts`'s own definition of "available" elsewhere in the codebase.

**Scoping decisions** (see `docs/roadmap.md` for the full writeup):
- Deferred to a later phase, not ported here: provider-launch tracking, pick-event stats/analytics (providers/history), and `GET /:id/entitlements` (billing/admin).
- `getFinishedTmdbIdsForMembers` (an exclusion source keyed off the personal `WatchlistEntry` table) is dropped rather than ported — that table has no D1 equivalent and the personal watchlist it backed is being deleted, not preserved, per the product pivot. The household-level `watchedTogether` exclusion set already covers what the pivoted product needs.
- **Known gap, not fixed here:** nothing computes `taste_profiles` rows going forward. Express's only writer (`tasteProfile.service.ts`) is itself entirely built on `WatchlistEntry`. The recommender degrades gracefully to mood-only genre filtering when a household has no profiles yet (the common case pre-launch); deriving weights from `watchedTogether` instead is a real product decision (what signal, what decay) left for a follow-up rather than decided inline here.

Also fixed along the way: a genuine `string | undefined` narrowing gap in both new middleware files, caught by `tsconfig.hono.json` (the actual strict config for this tree — the plain `tsconfig.json` used elsewhere in `services/api` excludes `src/hono` entirely).

---

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented parts that are complex or non-obvious
- [x] I have updated relevant documentation
- [x] I have added or updated tests
- [x] No new warnings or errors are introduced
- [x] All tests pass locally

---

### Screenshots

N/A — backend only, no UI changes.

---

### Related Issues / PRs

- Continues #66 / #67 (P3 auth domain).
- Tracked in `docs/roadmap.md` under P3.

---

### Notes for Reviewers

- Full monorepo verification green: `turbo run type-check`, `lint`, `test`, `build` across all 7 workspaces; `wrangler deploy --dry-run` bundles successfully. `services/api`'s Jest suite (Express, untouched) still passes at 292/292; the Hono Vitest suite is now 49/49 (34 pre-existing + 15 new).
- The LLM-rerank e2e tests stub `globalThis.fetch` for the duration of each test (restored in `afterEach`) rather than hitting real TMDb/Anthropic APIs — there's no `fetchMock` export in the installed `@cloudflare/vitest-pool-workers` version, so this is a plain Vitest-level global stub instead of Miniflare-specific mocking.
- The known taste-profile-computation gap (above) seems worth a deliberate look before the providers/history domain, since that's where `watchedTogether`/enjoyment signals most naturally live.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XaZAU6ca9bxsD6vhj8j392)_