### PR TITLE
feat(api,db): port providers/history domain to Hono Worker (P3)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -105,9 +105,16 @@ timeout). The Express `llm.service` remains unwired dead code, retired at cutove
 
 ## Providers & regions
 
-TMDb `/watch/providers` responses are cached into `content.providers` (region-keyed) with a staleness
-check, refreshed by cron. Region is UK-first; detected at the edge from the request, overridable by
-premium multi-region. Provider badges deep-link into Netflix / Prime / Disney+ with affiliate params.
+TMDb `/watch/providers` responses are read-through cached into `content.providers` (region-keyed,
+one row per `(tmdbId, mediaType)`) with a 24h blob-level staleness check -- implemented as the P3
+providers/history domain (`services/api/src/hono/lib/providers.ts`). Caching is lazy/on-demand only;
+there's no cron-driven proactive refresh yet (see Background work, below). Region defaults to GB,
+overridable by premium multi-region wherever a household context exists (`/:id/pick`, `/:id/history`,
+`/:id/picks/:tmdbId/launch`) -- the standalone `GET /api/providers/:tmdbId` has no household to
+resolve entitlements from and is a known, deliberately deferred gap (`docs/roadmap.md`).
+Provider-launch (`lib/providerLaunch.ts`) resolves a provider slug + region to a deep link through
+the same cache; the link is TMDb's own "watch this title" page, not a per-provider affiliate URL --
+there's no affiliate-tagging scheme anywhere in this codebase today.
 
 ## Entitlements & quota
 
@@ -124,9 +131,11 @@ HMAC-verified). Until then the mock checkout stays for demos only.
 
 ## Background work (cron)
 
-A Workers **cron trigger** runs provider-cache refresh and taste-profile recompute. Processing is
-inline to start (no Cloudflare Queues, which need the Workers Paid plan); move to a queue only when
-volume justifies the plan, exactly as creatorgrid defers it.
+Target: a Workers **cron trigger** running provider-cache refresh and taste-profile recompute, so a
+cache miss never blocks a request. Not implemented yet -- today provider caching is entirely
+lazy/on-demand (see Providers & regions, above), matching what the Express version it replaces did.
+Processing would be inline to start (no Cloudflare Queues, which need the Workers Paid plan); move
+to a queue only when volume justifies the plan, exactly as creatorgrid defers it.
 
 ## Deploying
 

--- a/docs/db-schema.md
+++ b/docs/db-schema.md
@@ -238,7 +238,13 @@ export const content = sqliteTable(
     createdAt: integer('created_at', { mode: 'timestamp_ms' }).notNull(),
     updatedAt: integer('updated_at', { mode: 'timestamp_ms' }).notNull(),
   },
-  t => ({ byTmdbId: index('idx_content_tmdb').on(t.tmdbId) })
+  table => [
+    index('idx_content_tmdb').on(table.tmdbId),
+    uniqueIndex('idx_content_tmdb_media_type').on(
+      table.tmdbId,
+      table.mediaType
+    ),
+  ]
 );
 
 export const contentReports = sqliteTable('content_reports', {
@@ -261,7 +267,17 @@ export const contentReports = sqliteTable('content_reports', {
 ```
 
 `ContentProviders` is region-keyed, e.g. `{ GB: { flatrate: [{ provider_id, provider_name, logo_path
-}], rent: [], buy: [] }, last_updated_at: <iso> }`.
+}], free: [], ads: [], rent: [], buy: [], link: <url> }, last_updated_at: <iso> }` -- `free`/`ads`/
+`link` (P3 providers/history) were added so `lib/providerLaunch.ts` can read a title's deep-link
+straight from this cache instead of a third, disconnected TMDb fetch path.
+
+`idx_content_tmdb_media_type` is a **unique** index (P3 providers/history,
+`0002_content_provider_unique_index.sql`) -- the provider-cache read-through path always supplies a
+concrete `mediaType`, so `(tmdbId, mediaType)` is a real upsert target (`onConflictDoUpdate`)
+instead of a plain find-then-create, closing a duplicate-row race under concurrent cache misses for
+the same title. It also gives `lib/history.ts`'s join something correct to match on -- joining on
+`tmdbId` alone (a movie and a TV show can share a numeric TMDb id) risked attaching the wrong
+title/poster to a watched-together row.
 
 ## Freemium
 
@@ -405,6 +421,9 @@ rather than translated 1:1 from the four Sequelize migrations (`phase-a-househol
 `subscriptions-and-pick-usage`, `household-invites`, `pick-events`) — those defined the Postgres shape
 these tables ported from, but D1's own migration history starts clean. `0001_totp_and_rate_limits.sql`
 (P3 auth domain) adds the TOTP columns on `users` and the `rateLimitHits` table above.
+`0002_content_provider_unique_index.sql` (P3 providers/history domain) adds the unique
+`(tmdbId, mediaType)` index on `content` described above -- `ProviderRegion`'s widened shape is a
+JSON-column type change only, no migration needed for it.
 
 `services/api/wrangler.jsonc`'s `d1_databases[].database_id` is a placeholder until a real D1 database
 is provisioned in a Cloudflare account (`wrangler d1 create pairflix-db`) — `--remote` won't work until

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -24,7 +24,9 @@
 - **Two server entry points** (`index.ts` runtime vs orphaned `app.ts`) mount different routes; at
   runtime the **email flows are unreachable** and the user prefix differs. The Hono port collapses
   this to one app and fixes it.
-- **`ProviderBadges` is fed an empty array** on the history page — placeholder wiring.
+- **`ProviderBadges` is fed an empty array** on the history page — the P3 providers/history Hono
+  port fixes the backend cause (the history endpoint now includes provider data), but the frontend
+  still hardcodes `providers={[]}` until it's wired up in P4.
 - **Recommender is movie-only** and runtime-blind (neutral runtime score) despite `movie | tv`
   plumbing.
 - **Billing is mock-only** (no Stripe).
@@ -95,8 +97,50 @@ signal, what decay) left for a follow-up rather than decided inline here.
 commit, and the LLM wiring (including the Anthropic-failure fallback) — the pick path returns a
 title end-to-end on Miniflare, meeting this phase's exit criterion for this domain.
 
-**Pending:** providers/history, billing/admin domains; then collapse the two server entries into
-one and cut over.
+**providers/history — done.** `services/api/src/hono/lib/{providers,providerLaunch,history,
+pickEventStats}.ts`, `routes/providers.ts` (new, standalone `GET /api/providers/:tmdbId`),
+`routes/households.ts` extended with `/:id/history` (GET + PATCH), `/:id/picks/:tmdbId/launch`,
+`/:id/pick-events`, `/:id/pick-events/stats`. The headline change: Express had three disconnected
+paths independently fetching TMDb watch-provider data (a `content`-table cache only the standalone
+endpoint used, an in-process cache only the recommender used and already dropped in the households/
+pick port, and provider-launch's own uncached raw fetch) — now there's one D1-backed read-through
+cache (`lib/providers.ts`) all of them share, widened to carry `free`/`ads`/`link` (Express's
+stored shape dropped all three, which is why provider-launch never read from it).
+
+Fixes two more bugs found while porting: a duplicate-row race in the provider cache under
+concurrent misses for the same title (new unique `(tmdbId, mediaType)` index, migration `0002`),
+and a `tmdbId`-only history join that could attach the wrong title/poster to a watched-together row
+when a movie and a TV show share a numeric TMDb id (now joins on both columns). History's list/PATCH
+responses are also unified to the same shape (Express's PATCH returned a bare row while its GET
+returned a joined one), `PATCH .../history/:watchedId` now accepts `enjoyed: null` to un-rate
+(Express's validator rejected it even though the column is nullable), and history pagination follows
+CLAUDE.md's house `{ data, pagination }` shape rather than Express's flat capped-at-200 list. The
+generic `POST /:id/pick-events` endpoint's `kind` is narrowed to `swapped`/`dismissed` only --
+`proposed`/`accepted` are already auto-recorded by the pick and commit routes, and
+`provider_launched` is only recordable through the TMDb-verified launch endpoint.
+
+**Known gaps, not fixed here:**
+
+- `content` rows created by the provider-cache write path get a placeholder title
+  (`"Untitled movie"`/`"Untitled show"`) — the caching path never fetches real title/poster data,
+  matching Express exactly (a pre-existing gap, not a regression). History entries' `providers`
+  field is real; `title`/`year`/`posterPath` read as the placeholder until something enriches
+  `content` with real metadata -- the natural place is `lib/recommendation.ts`'s hydration step,
+  which already fetches real title/runtime per candidate but doesn't write it back to `content`.
+  Deliberately not bundled into this change; a small, low-risk follow-up.
+- The standalone `GET /api/providers/:tmdbId` has no household context, so it can't apply the
+  free-tier GB region-lock the way `/:id/pick`, `/:id/history`, and `/:id/picks/:tmdbId/launch` now
+  all do -- a free-tier caller can request any region directly through this one endpoint. Closing it
+  needs a product decision (which household's entitlement applies, for a caller in more than one)
+  rather than a silent pick.
+- No cron-driven provider-cache refresh -- caching is lazy/on-demand only (matches Express; the
+  cron trigger `docs/architecture.md` describes was already aspirational, not a ported behavior).
+
+21 new `vitest-pool-workers` tests (provider caching including the movie/tv collision case and a
+TMDb-failure degrade, history list/pagination/thumbs, provider-launch including its recorded
+`pick_events` row, the generic pick-events endpoint's kind restriction, and stats aggregation).
+
+**Pending:** billing/admin domain; then collapse the two server entries into one and cut over.
 **Exit:** each domain has `vitest-pool-workers` integration tests against local D1; the pick path
 returns a title end-to-end on Miniflare.
 

--- a/packages/db/migrations/0002_content_provider_unique_index.sql
+++ b/packages/db/migrations/0002_content_provider_unique_index.sql
@@ -1,0 +1,1 @@
+CREATE UNIQUE INDEX `idx_content_tmdb_media_type` ON `content` (`tmdb_id`,`media_type`);

--- a/packages/db/migrations/meta/0002_snapshot.json
+++ b/packages/db/migrations/meta/0002_snapshot.json
@@ -1,0 +1,1266 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "cdf3a62d-d756-44b8-9aed-53e24bdfa1c5",
+  "prevId": "a8b6d744-9257-4284-9343-b04a149cce5a",
+  "tables": {
+    "audit_logs": {
+      "name": "audit_logs",
+      "columns": {
+        "log_id": {
+          "name": "log_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "level": {
+          "name": "level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "context": {
+          "name": "context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "auth_tokens": {
+      "name": "auth_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "new_email": {
+          "name": "new_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "forced_by_admin": {
+          "name": "forced_by_admin",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_auth_tokens_user": {
+          "name": "idx_auth_tokens_user",
+          "columns": ["user_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "auth_tokens_user_id_users_user_id_fk": {
+          "name": "auth_tokens_user_id_users_user_id_fk",
+          "tableFrom": "auth_tokens",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["user_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "content": {
+      "name": "content",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "tmdb_id": {
+          "name": "tmdb_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "poster_path": {
+          "name": "poster_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reported_count": {
+          "name": "reported_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "removal_reason": {
+          "name": "removal_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "providers": {
+          "name": "providers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_content_tmdb": {
+          "name": "idx_content_tmdb",
+          "columns": ["tmdb_id"],
+          "isUnique": false
+        },
+        "idx_content_tmdb_media_type": {
+          "name": "idx_content_tmdb_media_type",
+          "columns": ["tmdb_id", "media_type"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "content_reports": {
+      "name": "content_reports",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_id": {
+          "name": "content_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_content_reports_content": {
+          "name": "idx_content_reports_content",
+          "columns": ["content_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "content_reports_content_id_content_id_fk": {
+          "name": "content_reports_content_id_content_id_fk",
+          "tableFrom": "content_reports",
+          "tableTo": "content",
+          "columnsFrom": ["content_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "content_reports_user_id_users_user_id_fk": {
+          "name": "content_reports_user_id_users_user_id_fk",
+          "tableFrom": "content_reports",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["user_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "household_invites": {
+      "name": "household_invites",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "household_id": {
+          "name": "household_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "invited_email": {
+          "name": "invited_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "accepted_by": {
+          "name": "accepted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "household_invites_token_unique": {
+          "name": "household_invites_token_unique",
+          "columns": ["token"],
+          "isUnique": true
+        },
+        "idx_household_invites_household": {
+          "name": "idx_household_invites_household",
+          "columns": ["household_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "household_invites_household_id_households_id_fk": {
+          "name": "household_invites_household_id_households_id_fk",
+          "tableFrom": "household_invites",
+          "tableTo": "households",
+          "columnsFrom": ["household_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "household_invites_invited_by_users_user_id_fk": {
+          "name": "household_invites_invited_by_users_user_id_fk",
+          "tableFrom": "household_invites",
+          "tableTo": "users",
+          "columnsFrom": ["invited_by"],
+          "columnsTo": ["user_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "household_invites_accepted_by_users_user_id_fk": {
+          "name": "household_invites_accepted_by_users_user_id_fk",
+          "tableFrom": "household_invites",
+          "tableTo": "users",
+          "columnsFrom": ["accepted_by"],
+          "columnsTo": ["user_id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "household_members": {
+      "name": "household_members",
+      "columns": {
+        "household_id": {
+          "name": "household_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "household_members_household_id_households_id_fk": {
+          "name": "household_members_household_id_households_id_fk",
+          "tableFrom": "household_members",
+          "tableTo": "households",
+          "columnsFrom": ["household_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "household_members_user_id_users_user_id_fk": {
+          "name": "household_members_user_id_users_user_id_fk",
+          "tableFrom": "household_members",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["user_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "household_members_household_id_user_id_pk": {
+          "columns": ["household_id", "user_id"],
+          "name": "household_members_household_id_user_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "households": {
+      "name": "households",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pick_events": {
+      "name": "pick_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "household_id": {
+          "name": "household_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tmdb_id": {
+          "name": "tmdb_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mood": {
+          "name": "mood",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "minutes_budget": {
+          "name": "minutes_budget",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_slug": {
+          "name": "provider_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_pe_household_occurred_at": {
+          "name": "idx_pe_household_occurred_at",
+          "columns": ["household_id", "occurred_at"],
+          "isUnique": false
+        },
+        "idx_pe_household_kind": {
+          "name": "idx_pe_household_kind",
+          "columns": ["household_id", "kind"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "pick_events_household_id_households_id_fk": {
+          "name": "pick_events_household_id_households_id_fk",
+          "tableFrom": "pick_events",
+          "tableTo": "households",
+          "columnsFrom": ["household_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pick_events_user_id_users_user_id_fk": {
+          "name": "pick_events_user_id_users_user_id_fk",
+          "tableFrom": "pick_events",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["user_id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pick_usage": {
+      "name": "pick_usage",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "household_id": {
+          "name": "household_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "picked_at": {
+          "name": "picked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_pick_usage_household_picked_at": {
+          "name": "idx_pick_usage_household_picked_at",
+          "columns": ["household_id", "picked_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "pick_usage_household_id_households_id_fk": {
+          "name": "pick_usage_household_id_households_id_fk",
+          "tableFrom": "pick_usage",
+          "tableTo": "households",
+          "columnsFrom": ["household_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rate_limit_hits": {
+      "name": "rate_limit_hits",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_rate_limit_hits_key": {
+          "name": "idx_rate_limit_hits_key",
+          "columns": ["key"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "device_info": {
+          "name": "device_info",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_sessions_user": {
+          "name": "idx_sessions_user",
+          "columns": ["user_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_user_id_fk": {
+          "name": "sessions_user_id_users_user_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["user_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "settings": {
+      "name": "settings",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'general'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "subscriptions": {
+      "name": "subscriptions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "household_id": {
+          "name": "household_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tier": {
+          "name": "tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'free'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "subscriptions_household_id_unique": {
+          "name": "subscriptions_household_id_unique",
+          "columns": ["household_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "subscriptions_household_id_households_id_fk": {
+          "name": "subscriptions_household_id_households_id_fk",
+          "tableFrom": "subscriptions",
+          "tableTo": "households",
+          "columnsFrom": ["household_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "taste_profiles": {
+      "name": "taste_profiles",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "weights": {
+          "name": "weights",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "taste_profiles_user_id_users_user_id_fk": {
+          "name": "taste_profiles_user_id_users_user_id_fk",
+          "tableFrom": "taste_profiles",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["user_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'user'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "failed_login_attempts": {
+          "name": "failed_login_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "locked_until": {
+          "name": "locked_until",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_login": {
+          "name": "last_login",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "totp_secret": {
+          "name": "totp_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "totp_enabled": {
+          "name": "totp_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "totp_backup_codes": {
+          "name": "totp_backup_codes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preferences": {
+          "name": "preferences",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{\"theme\":\"dark\",\"viewStyle\":\"grid\",\"emailNotifications\":true,\"autoArchiveDays\":30,\"favoriteGenres\":[]}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "columns": ["username"],
+          "isUnique": true
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": ["email"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "watched_together": {
+      "name": "watched_together",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "household_id": {
+          "name": "household_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tmdb_id": {
+          "name": "tmdb_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "watched_at": {
+          "name": "watched_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enjoyed": {
+          "name": "enjoyed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mood_at_pick": {
+          "name": "mood_at_pick",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "minutes_budget_at_pick": {
+          "name": "minutes_budget_at_pick",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_wt_household_watched_at": {
+          "name": "idx_wt_household_watched_at",
+          "columns": ["household_id", "watched_at"],
+          "isUnique": false
+        },
+        "idx_wt_household_tmdb": {
+          "name": "idx_wt_household_tmdb",
+          "columns": ["household_id", "tmdb_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "watched_together_household_id_households_id_fk": {
+          "name": "watched_together_household_id_households_id_fk",
+          "tableFrom": "watched_together",
+          "tableTo": "households",
+          "columnsFrom": ["household_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1786911445062,
       "tag": "0001_totp_and_rate_limits",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "6",
+      "when": 1786961052898,
+      "tag": "0002_content_provider_unique_index",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -4,6 +4,7 @@ import {
   primaryKey,
   sqliteTable,
   text,
+  uniqueIndex,
 } from 'drizzle-orm/sqlite-core';
 
 // Timestamps are `integer(..., { mode: 'timestamp_ms' })` (epoch millis, app-generated via
@@ -239,7 +240,16 @@ export const content = sqliteTable(
     createdAt: integer('created_at', { mode: 'timestamp_ms' }).notNull(),
     updatedAt: integer('updated_at', { mode: 'timestamp_ms' }).notNull(),
   },
-  table => [index('idx_content_tmdb').on(table.tmdbId)]
+  table => [
+    index('idx_content_tmdb').on(table.tmdbId),
+    // The provider-cache read-through path always supplies a concrete mediaType, so this is
+    // effectively "one content row per (tmdbId, mediaType)" for that path -- without it, two
+    // concurrent cache-miss requests for the same title could each create a row.
+    uniqueIndex('idx_content_tmdb_media_type').on(
+      table.tmdbId,
+      table.mediaType
+    ),
+  ]
 );
 
 export type ProviderEntry = {
@@ -250,8 +260,13 @@ export type ProviderEntry = {
 
 export type ProviderRegion = {
   flatrate?: ProviderEntry[];
+  free?: ProviderEntry[];
+  ads?: ProviderEntry[];
   rent?: ProviderEntry[];
   buy?: ProviderEntry[];
+  /** TMDb's own "watch this title" page for this title+region -- used to build provider-launch
+   * deep links without a separate per-provider URL scheme (TMDb doesn't expose one). */
+  link?: string;
 };
 
 export type ContentProviders = {

--- a/packages/lib.validation/src/index.ts
+++ b/packages/lib.validation/src/index.ts
@@ -1,2 +1,3 @@
 export * from './schemas/auth';
 export * from './schemas/household';
+export * from './schemas/providers';

--- a/packages/lib.validation/src/schemas/household.ts
+++ b/packages/lib.validation/src/schemas/household.ts
@@ -24,7 +24,7 @@ export const MoodSchema = z.enum([
 ]);
 export type Mood = z.infer<typeof MoodSchema>;
 
-const RegionSchema = z
+export const RegionSchema = z
   .string()
   .trim()
   .toUpperCase()
@@ -51,3 +51,39 @@ export const CommitPickRequestSchema = z.object({
   minutes: z.number().int().positive().optional(),
 });
 export type CommitPickRequest = z.infer<typeof CommitPickRequestSchema>;
+
+export const HistoryQuerySchema = z.object({
+  page: z.coerce.number().int().min(1).default(1),
+  limit: z.coerce.number().int().min(1).max(100).default(20),
+});
+export type HistoryQuery = z.infer<typeof HistoryQuerySchema>;
+
+export const HistoryPatchRequestSchema = z.object({
+  enjoyed: z.boolean().nullable(),
+});
+export type HistoryPatchRequest = z.infer<typeof HistoryPatchRequestSchema>;
+
+export const ProviderLaunchRequestSchema = z.object({
+  providerSlug: z.string().trim().min(1, 'providerSlug is required'),
+  mediaType: z.enum(['movie', 'tv']),
+  region: RegionSchema.optional(),
+});
+export type ProviderLaunchRequest = z.infer<typeof ProviderLaunchRequestSchema>;
+
+/** `kind` excludes 'proposed'/'accepted' (already recorded automatically by the pick and commit
+ * routes) and 'provider_launched' (only recordable via the TMDb-verified launch endpoint, which
+ * records it itself) -- this generic endpoint is for the funnel outcomes that have no other
+ * write path. */
+export const PickEventRequestSchema = z.object({
+  tmdbId: z.number().int().positive(),
+  mediaType: z.enum(['movie', 'tv']),
+  kind: z.enum(['swapped', 'dismissed']),
+  mood: MoodSchema.optional(),
+  minutesBudget: z.number().int().positive().optional(),
+});
+export type PickEventRequest = z.infer<typeof PickEventRequestSchema>;
+
+export const PickEventStatsQuerySchema = z.object({
+  windowDays: z.coerce.number().int().min(1).max(365).default(30),
+});
+export type PickEventStatsQuery = z.infer<typeof PickEventStatsQuerySchema>;

--- a/packages/lib.validation/src/schemas/household.ts
+++ b/packages/lib.validation/src/schemas/household.ts
@@ -55,6 +55,7 @@ export type CommitPickRequest = z.infer<typeof CommitPickRequestSchema>;
 export const HistoryQuerySchema = z.object({
   page: z.coerce.number().int().min(1).default(1),
   limit: z.coerce.number().int().min(1).max(100).default(20),
+  region: RegionSchema.optional(),
 });
 export type HistoryQuery = z.infer<typeof HistoryQuerySchema>;
 

--- a/packages/lib.validation/src/schemas/providers.ts
+++ b/packages/lib.validation/src/schemas/providers.ts
@@ -1,0 +1,8 @@
+import { z } from 'zod';
+import { RegionSchema } from './household';
+
+export const ProvidersQuerySchema = z.object({
+  mediaType: z.enum(['movie', 'tv']),
+  region: RegionSchema.optional(),
+});
+export type ProvidersQuery = z.infer<typeof ProvidersQuerySchema>;

--- a/services/api/src/hono/index.ts
+++ b/services/api/src/hono/index.ts
@@ -7,6 +7,7 @@ import { authRoutes } from './routes/auth';
 import { healthRoutes } from './routes/health';
 import { householdsRoutes } from './routes/households';
 import { meRoutes } from './routes/me';
+import { providersRoutes } from './routes/providers';
 import type { AppEnv, Bindings } from './types';
 
 const app = new Hono<AppEnv>();
@@ -39,6 +40,7 @@ app.route('/health', healthRoutes);
 app.route('/api/auth', authRoutes);
 app.route('/api/me', meRoutes);
 app.route('/api/households', householdsRoutes);
+app.route('/api/providers', providersRoutes);
 
 app.notFound(c => c.json({ error: 'Not found' }, 404));
 app.onError((error, c) => {

--- a/services/api/src/hono/lib/history.ts
+++ b/services/api/src/hono/lib/history.ts
@@ -1,0 +1,161 @@
+import {
+	watchedTogether,
+	content,
+	type ContentProviders,
+	type Database,
+	type ProviderRegion,
+} from '@pairflix/db';
+import { and, count, desc, eq } from 'drizzle-orm';
+
+/**
+ * Ported from the current Express `history.service.ts`/`history.controller.ts`, with two
+ * deliberate departures:
+ *
+ * - The `content` join matches on both `tmdbId` and `mediaType`, not `tmdbId` alone -- a movie and
+ *   a TV show can share the same numeric TMDb id, so a single-column join risks attaching the
+ *   wrong title/poster to a watched-together row.
+ * - `setEnjoyed` does not port the Express controller's fire-and-forget taste-profile recompute:
+ *   that recompute is built entirely on the `WatchlistEntry` table, which has no D1 equivalent and
+ *   is being deleted, not preserved, per the product pivot. Reintroducing it in any form here is an
+ *   out-of-scope, already-tracked decision for a later pass.
+ */
+
+export type HistoryEntry = {
+	id: string;
+	tmdbId: number;
+	mediaType: 'movie' | 'tv';
+	watchedAt: Date;
+	enjoyed: boolean | null;
+	moodAtPick: string | null;
+	minutesBudgetAtPick: number | null;
+	title: string | null;
+	year: number | null;
+	posterPath: string | null;
+	providers: ProviderRegion;
+};
+
+export type PaginatedHistory = {
+	data: HistoryEntry[];
+	pagination: {
+		page: number;
+		limit: number;
+		total: number;
+		totalPages: number;
+	};
+};
+
+type JoinedHistoryRow = {
+	id: string;
+	tmdbId: number;
+	mediaType: 'movie' | 'tv';
+	watchedAt: Date;
+	enjoyed: boolean | null;
+	moodAtPick: string | null;
+	minutesBudgetAtPick: number | null;
+	title: string | null;
+	year: number | null;
+	posterPath: string | null;
+	providers: ContentProviders | null;
+};
+
+const historyColumns = {
+	id: watchedTogether.id,
+	tmdbId: watchedTogether.tmdbId,
+	mediaType: watchedTogether.mediaType,
+	watchedAt: watchedTogether.watchedAt,
+	enjoyed: watchedTogether.enjoyed,
+	moodAtPick: watchedTogether.moodAtPick,
+	minutesBudgetAtPick: watchedTogether.minutesBudgetAtPick,
+	title: content.title,
+	year: content.year,
+	posterPath: content.posterPath,
+	providers: content.providers,
+};
+
+const historyContentJoin = and(
+	eq(content.tmdbId, watchedTogether.tmdbId),
+	eq(content.mediaType, watchedTogether.mediaType)
+);
+
+const readRegion = (
+	providers: ContentProviders | null,
+	region: string
+): ProviderRegion => {
+	const value = providers?.[region];
+	return value && typeof value === 'object' ? value : {};
+};
+
+const toHistoryEntry = (
+	row: JoinedHistoryRow,
+	region: string
+): HistoryEntry => ({
+	id: row.id,
+	tmdbId: row.tmdbId,
+	mediaType: row.mediaType,
+	watchedAt: row.watchedAt,
+	enjoyed: row.enjoyed,
+	moodAtPick: row.moodAtPick,
+	minutesBudgetAtPick: row.minutesBudgetAtPick,
+	title: row.title,
+	year: row.year,
+	posterPath: row.posterPath,
+	providers: readRegion(row.providers, region),
+});
+
+export const listHistory = async (
+	db: Database,
+	householdId: string,
+	page: number,
+	limit: number,
+	region: string = 'GB'
+): Promise<PaginatedHistory> => {
+	const where = eq(watchedTogether.householdId, householdId);
+
+	const [rows, totalRow] = await Promise.all([
+		db
+			.select(historyColumns)
+			.from(watchedTogether)
+			.leftJoin(content, historyContentJoin)
+			.where(where)
+			.orderBy(desc(watchedTogether.watchedAt))
+			.limit(limit)
+			.offset((page - 1) * limit),
+		db.select({ total: count() }).from(watchedTogether).where(where).get(),
+	]);
+
+	const total = totalRow?.total ?? 0;
+	return {
+		data: rows.map(row => toHistoryEntry(row, region)),
+		pagination: { page, limit, total, totalPages: Math.ceil(total / limit) },
+	};
+};
+
+export const setEnjoyed = async (
+	db: Database,
+	householdId: string,
+	watchedId: string,
+	enjoyed: boolean | null,
+	region: string = 'GB'
+): Promise<HistoryEntry | null> => {
+	const scope = and(
+		eq(watchedTogether.id, watchedId),
+		eq(watchedTogether.householdId, householdId)
+	);
+
+	const updated = await db
+		.update(watchedTogether)
+		.set({ enjoyed })
+		.where(scope)
+		.returning({ id: watchedTogether.id })
+		.get();
+	if (!updated) return null;
+
+	const row = await db
+		.select(historyColumns)
+		.from(watchedTogether)
+		.leftJoin(content, historyContentJoin)
+		.where(scope)
+		.get();
+
+	return row ? toHistoryEntry(row, region) : null;
+};

--- a/services/api/src/hono/lib/pickEventStats.ts
+++ b/services/api/src/hono/lib/pickEventStats.ts
@@ -1,5 +1,5 @@
 import { pickEvents, type Database } from '@pairflix/db';
-import { and, eq, gte } from 'drizzle-orm';
+import { and, count, eq, gte, isNotNull } from 'drizzle-orm';
 import type { PickEventKind } from './pickEvents';
 
 export type PickEventStats = {
@@ -10,24 +10,40 @@ export type PickEventStats = {
 };
 
 /** `provider_launched` events recorded without a `providerSlug` still count toward
- * `totals.provider_launched`, but are silently excluded from `providerClicksBySlug`, which only
- * makes sense keyed by an actual slug. */
+ * `totals.provider_launched`, but are excluded from `providerClicksBySlug`, which only makes
+ * sense keyed by an actual slug -- the `isNotNull` guard on the second query is what does that
+ * exclusion. Aggregates in SQL (`GROUP BY` + `count()`) rather than pulling every matching row
+ * into the Worker to sum in JS -- a premium household has no pick-quota cap, so its event count
+ * over a wide window isn't bounded the way a free household's is. */
 export const getPickEventStats = async (
 	db: Database,
 	householdId: string,
 	windowDays: number
 ): Promise<PickEventStats> => {
 	const since = new Date(Date.now() - windowDays * 24 * 60 * 60 * 1000);
+	const inWindow = and(
+		eq(pickEvents.householdId, householdId),
+		gte(pickEvents.occurredAt, since)
+	);
 
-	const events = await db
-		.select({ kind: pickEvents.kind, providerSlug: pickEvents.providerSlug })
-		.from(pickEvents)
-		.where(
-			and(
-				eq(pickEvents.householdId, householdId),
-				gte(pickEvents.occurredAt, since)
+	const [totalsRows, providerRows] = await Promise.all([
+		db
+			.select({ kind: pickEvents.kind, total: count() })
+			.from(pickEvents)
+			.where(inWindow)
+			.groupBy(pickEvents.kind),
+		db
+			.select({ providerSlug: pickEvents.providerSlug, total: count() })
+			.from(pickEvents)
+			.where(
+				and(
+					inWindow,
+					eq(pickEvents.kind, 'provider_launched'),
+					isNotNull(pickEvents.providerSlug)
+				)
 			)
-		);
+			.groupBy(pickEvents.providerSlug),
+	]);
 
 	const totals: Record<PickEventKind, number> = {
 		proposed: 0,
@@ -36,14 +52,13 @@ export const getPickEventStats = async (
 		dismissed: 0,
 		provider_launched: 0,
 	};
-	const providerClicksBySlug: Record<string, number> = {};
+	for (const row of totalsRows) {
+		totals[row.kind] = row.total;
+	}
 
-	for (const event of events) {
-		totals[event.kind] += 1;
-		if (event.kind === 'provider_launched' && event.providerSlug) {
-			providerClicksBySlug[event.providerSlug] =
-				(providerClicksBySlug[event.providerSlug] ?? 0) + 1;
-		}
+	const providerClicksBySlug: Record<string, number> = {};
+	for (const row of providerRows) {
+		if (row.providerSlug) providerClicksBySlug[row.providerSlug] = row.total;
 	}
 
 	const responded = totals.accepted + totals.swapped + totals.dismissed;

--- a/services/api/src/hono/lib/pickEventStats.ts
+++ b/services/api/src/hono/lib/pickEventStats.ts
@@ -1,0 +1,54 @@
+import { pickEvents, type Database } from '@pairflix/db';
+import { and, eq, gte } from 'drizzle-orm';
+import type { PickEventKind } from './pickEvents';
+
+export type PickEventStats = {
+	windowDays: number;
+	totals: Record<PickEventKind, number>;
+	firstPickAcceptanceRate: number | null;
+	providerClicksBySlug: Record<string, number>;
+};
+
+/** `provider_launched` events recorded without a `providerSlug` still count toward
+ * `totals.provider_launched`, but are silently excluded from `providerClicksBySlug`, which only
+ * makes sense keyed by an actual slug. */
+export const getPickEventStats = async (
+	db: Database,
+	householdId: string,
+	windowDays: number
+): Promise<PickEventStats> => {
+	const since = new Date(Date.now() - windowDays * 24 * 60 * 60 * 1000);
+
+	const events = await db
+		.select({ kind: pickEvents.kind, providerSlug: pickEvents.providerSlug })
+		.from(pickEvents)
+		.where(
+			and(
+				eq(pickEvents.householdId, householdId),
+				gte(pickEvents.occurredAt, since)
+			)
+		);
+
+	const totals: Record<PickEventKind, number> = {
+		proposed: 0,
+		accepted: 0,
+		swapped: 0,
+		dismissed: 0,
+		provider_launched: 0,
+	};
+	const providerClicksBySlug: Record<string, number> = {};
+
+	for (const event of events) {
+		totals[event.kind] += 1;
+		if (event.kind === 'provider_launched' && event.providerSlug) {
+			providerClicksBySlug[event.providerSlug] =
+				(providerClicksBySlug[event.providerSlug] ?? 0) + 1;
+		}
+	}
+
+	const responded = totals.accepted + totals.swapped + totals.dismissed;
+	const firstPickAcceptanceRate =
+		responded > 0 ? totals.accepted / responded : null;
+
+	return { windowDays, totals, firstPickAcceptanceRate, providerClicksBySlug };
+};

--- a/services/api/src/hono/lib/pickEvents.ts
+++ b/services/api/src/hono/lib/pickEvents.ts
@@ -24,9 +24,10 @@ export type RecordPickEventInput = {
 export const recordPickEvent = async (
 	db: Database,
 	input: RecordPickEventInput
-): Promise<void> => {
+): Promise<{ id: string }> => {
+	const id = newId('pickevent');
 	await db.insert(pickEvents).values({
-		id: newId('pickevent'),
+		id,
 		householdId: input.householdId,
 		userId: input.userId ?? null,
 		tmdbId: input.tmdbId,
@@ -38,4 +39,5 @@ export const recordPickEvent = async (
 		region: input.region ?? null,
 		occurredAt: new Date(),
 	});
+	return { id };
 };

--- a/services/api/src/hono/lib/providerLaunch.ts
+++ b/services/api/src/hono/lib/providerLaunch.ts
@@ -1,0 +1,61 @@
+import type { Database } from '@pairflix/db';
+import type { Bindings } from '../types';
+import { getCachedProviders } from './providers';
+
+/**
+ * Ported from Express's `providerLaunch.service.ts`. Reads through `lib/providers.ts`'s cache
+ * instead of hitting TMDb raw on every launch click, unlike the Express version it replaces.
+ * `regional.link` is TMDb's own "watch this title" page for the title+region (sourced from
+ * JustWatch) -- not a per-provider deep link, so there's no per-provider URL to construct here.
+ */
+
+const normalize = (value: string): string =>
+	value.toLowerCase().replace(/[^a-z0-9]/g, '');
+
+export class ProviderNotAvailableError extends Error {
+	constructor(providerSlug: string, region: string) {
+		super(`Provider ${providerSlug} not available in ${region}`);
+		this.name = 'ProviderNotAvailableError';
+	}
+}
+
+export type ResolvedLaunch = {
+	url: string;
+	providerName: string;
+	region: string;
+};
+
+export const resolveProviderLaunch = async (
+	env: Bindings,
+	db: Database,
+	tmdbId: number,
+	mediaType: 'movie' | 'tv',
+	providerSlug: string,
+	region: string
+): Promise<ResolvedLaunch> => {
+	const wanted = normalize(providerSlug);
+	const regional = await getCachedProviders(env, db, tmdbId, mediaType, region);
+
+	const candidates = [
+		...(regional.flatrate ?? []),
+		...(regional.free ?? []),
+		...(regional.ads ?? []),
+		...(regional.rent ?? []),
+		...(regional.buy ?? []),
+	];
+
+	const match = candidates.find(p => {
+		const normalized = normalize(p.provider_name);
+		return (
+			normalized === wanted ||
+			normalized.includes(wanted) ||
+			wanted.includes(normalized)
+		);
+	});
+
+	if (!match || !regional.link) {
+		throw new ProviderNotAvailableError(providerSlug, region);
+	}
+
+	return { url: regional.link, providerName: match.provider_name, region };
+};

--- a/services/api/src/hono/lib/providers.ts
+++ b/services/api/src/hono/lib/providers.ts
@@ -1,0 +1,124 @@
+import {
+	content,
+	type ContentProviders,
+	type Database,
+	type ProviderRegion,
+} from '@pairflix/db';
+import { and, eq } from 'drizzle-orm';
+import type { Bindings } from '../types';
+import { newId } from './id';
+import { getAllWatchProviders } from './tmdb';
+
+/**
+ * Read-through cache over the `content` table, ported from the current Express
+ * `providers.service.ts`. One deliberate departure: it widens the cached shape to
+ * flatrate/free/ads/rent/buy/link (Express's stored shape drops free/ads/link) so
+ * `lib/providerLaunch.ts` can read from this same cache instead of hitting TMDb raw on every
+ * launch click -- today three separate, disconnected paths all fetch watch-providers
+ * independently (this cache, the pick recommender's own uncached `lib/tmdb.ts` call, and
+ * Express's provider-launch, which fetched raw). Unifying providers/launch here is this
+ * domain's job; leaving the recommender's hydration step as-is is a separate, lower-risk
+ * follow-up not worth bundling into this change.
+ *
+ * Staleness is checked at the blob level (one `last_updated_at` covering every region a refresh
+ * populated), matching Express -- not a correctness bug, just less precise than a per-region
+ * timestamp would be, and simpler to reason about.
+ */
+
+const STALE_AFTER_MS = 24 * 60 * 60 * 1000;
+const DEFAULT_REGION = 'GB';
+
+const isStale = (providers: ContentProviders, maxAgeMs: number): boolean => {
+	const updatedAt = providers.last_updated_at;
+	if (!updatedAt) return true;
+	const updatedAtMs = new Date(updatedAt).getTime();
+	if (Number.isNaN(updatedAtMs)) return true;
+	return Date.now() - updatedAtMs > maxAgeMs;
+};
+
+const readRegion = (
+	providers: ContentProviders | undefined,
+	region: string
+): ProviderRegion | null => {
+	const value = providers?.[region];
+	return value && typeof value === 'object' ? value : null;
+};
+
+const titleFromMediaType = (mediaType: 'movie' | 'tv'): string =>
+	mediaType === 'movie' ? 'Untitled movie' : 'Untitled show';
+
+const refreshProviders = async (
+	env: Bindings,
+	db: Database,
+	tmdbId: number,
+	mediaType: 'movie' | 'tv'
+): Promise<ContentProviders> => {
+	const all = await getAllWatchProviders(env, tmdbId, mediaType);
+	const providers: ContentProviders = {
+		last_updated_at: new Date().toISOString(),
+	};
+	for (const [region, regional] of Object.entries(all)) {
+		providers[region] = regional;
+	}
+
+	const now = new Date();
+	await db
+		.insert(content)
+		.values({
+			id: newId('content'),
+			title: titleFromMediaType(mediaType),
+			type: mediaType === 'movie' ? 'movie' : 'show',
+			status: 'active',
+			tmdbId,
+			mediaType,
+			providers,
+			createdAt: now,
+			updatedAt: now,
+		})
+		// Only providers/updatedAt change on a refresh -- title/type/status are whatever a
+		// moderator or the initial cache-miss set them to, never silently overwritten (in
+		// particular, this must never un-flag content a moderator already removed).
+		.onConflictDoUpdate({
+			target: [content.tmdbId, content.mediaType],
+			set: { providers, updatedAt: now },
+		});
+
+	return providers;
+};
+
+/** Best-effort: a TMDb failure degrades to whatever's already cached (even if stale), or an
+ * empty result -- never throws, matching CLAUDE.md's "provider data is best-effort... degrade
+ * gracefully" and the same pattern `lib/recommendation.ts`'s hydration step already uses. */
+export const getCachedProviders = async (
+	env: Bindings,
+	db: Database,
+	tmdbId: number,
+	mediaType: 'movie' | 'tv',
+	region: string = DEFAULT_REGION
+): Promise<ProviderRegion> => {
+	const existing = await db
+		.select({ providers: content.providers })
+		.from(content)
+		.where(and(eq(content.tmdbId, tmdbId), eq(content.mediaType, mediaType)))
+		.get();
+
+	const cachedRegion = readRegion(existing?.providers, region);
+	if (
+		existing?.providers &&
+		!isStale(existing.providers, STALE_AFTER_MS) &&
+		cachedRegion
+	) {
+		return cachedRegion;
+	}
+
+	try {
+		const refreshed = await refreshProviders(env, db, tmdbId, mediaType);
+		return readRegion(refreshed, region) ?? {};
+	} catch (err) {
+		console.warn(
+			'[providers] refresh failed, falling back to cached/empty',
+			err instanceof Error ? err.message : 'Unknown error'
+		);
+		return cachedRegion ?? {};
+	}
+};

--- a/services/api/src/hono/lib/tmdb.ts
+++ b/services/api/src/hono/lib/tmdb.ts
@@ -3,10 +3,11 @@ import type { Bindings } from '../types';
 /**
  * TMDb client -- fetch-based (Workers-native, no SDK). Ported from the current Express
  * `tmdb.service.ts`; deliberately dropped its in-memory `Map`-based watch-providers cache since a
- * per-isolate cache doesn't reliably persist across requests on Workers anyway. No replacement
- * cache yet -- edge-caching `/discover` and `/watch/providers` (CLAUDE.md) is deferred to the
- * providers/history domain, which needs to decide a Workers-appropriate mechanism (e.g. the Cache
- * API or a `content` table read-through) rather than inventing one here for a single call site.
+ * per-isolate cache doesn't reliably persist across requests on Workers anyway. Everything in this
+ * file is an uncached, direct-to-TMDb primitive; `lib/providers.ts`'s `content`-table read-through
+ * cache is the Workers-appropriate replacement, built on top of `getAllWatchProviders` below --
+ * `discoverMedia`/`getMovieFullDetails`/`getTVFullDetails` (used by the recommender's candidate
+ * scan, which needs fresh results every call) are left uncached.
  */
 const TMDB_BASE_URL = 'https://api.themoviedb.org/3';
 const SAFE_ENDPOINT = /^\/[a-z][a-z_]*(?:\/[a-z0-9_]+)*$/;
@@ -149,15 +150,24 @@ type WatchProvidersResponse = {
 	results?: Record<string, RegionProviders>;
 };
 
+export const getAllWatchProviders = async (
+	env: Bindings,
+	tmdbId: number,
+	mediaType: 'movie' | 'tv'
+): Promise<Record<string, RegionProviders>> => {
+	const data = await tmdbFetch<WatchProvidersResponse>(
+		env,
+		`/${mediaType}/${tmdbId}/watch/providers`
+	);
+	return data.results ?? {};
+};
+
 export const getWatchProviders = async (
 	env: Bindings,
 	tmdbId: number,
 	mediaType: 'movie' | 'tv',
 	region: string
 ): Promise<RegionProviders> => {
-	const data = await tmdbFetch<WatchProvidersResponse>(
-		env,
-		`/${mediaType}/${tmdbId}/watch/providers`
-	);
-	return data.results?.[region] ?? {};
+	const all = await getAllWatchProviders(env, tmdbId, mediaType);
+	return all[region] ?? {};
 };

--- a/services/api/src/hono/routes/households.e2e.test.ts
+++ b/services/api/src/hono/routes/households.e2e.test.ts
@@ -31,6 +31,7 @@ type MockMovie = {
 			provider_name: string;
 			logo_path: string;
 		}>;
+		link?: string;
 	};
 };
 
@@ -61,6 +62,7 @@ const MOVIE_B: MockMovie = {
 		flatrate: [
 			{ provider_id: 8, provider_name: 'Netflix', logo_path: '/x.jpg' },
 		],
+		link: 'https://www.themoviedb.org/movie/102/watch?locale=GB',
 	},
 };
 const MOVIE_C: MockMovie = {
@@ -496,5 +498,316 @@ describe('LLM re-rank wiring', () => {
 		);
 		expect(result.status).toBe(200);
 		expect(DEFAULT_MOVIES.map(m => m.id)).toContain(result.body.pick.tmdbId);
+	});
+});
+
+describe('GET /api/households/:id/history', () => {
+	it('rejects a non-member', async () => {
+		const owner = await createLoggedInUser(uniqueEmail());
+		const outsider = await createLoggedInUser(uniqueEmail());
+		const householdId = await createHousehold(owner.cookies);
+
+		const result = await callApp(`/api/households/${householdId}/history`, {
+			cookies: outsider.cookies,
+		});
+		expect(result.status).toBe(403);
+	});
+
+	it('returns an empty page when nothing has been watched yet', async () => {
+		const { cookies } = await createLoggedInUser(uniqueEmail());
+		const householdId = await createHousehold(cookies);
+
+		const result = await callApp<{
+			data: unknown[];
+			pagination: {
+				page: number;
+				limit: number;
+				total: number;
+				totalPages: number;
+			};
+		}>(`/api/households/${householdId}/history`, { cookies });
+		expect(result.status).toBe(200);
+		expect(result.body.data).toEqual([]);
+		expect(result.body.pagination).toEqual({
+			page: 1,
+			limit: 20,
+			total: 0,
+			totalPages: 0,
+		});
+	});
+
+	it('includes joined providers for a committed pick', async () => {
+		const { cookies } = await createLoggedInUser(uniqueEmail());
+		const householdId = await createHousehold(cookies);
+
+		mockExternalApis(DEFAULT_MOVIES);
+		const providersLookup = await callApp(
+			`/api/providers/${MOVIE_B.id}?mediaType=movie`,
+			{ cookies }
+		);
+		expect(providersLookup.status).toBe(200);
+
+		const commit = await postJson(
+			`/api/households/${householdId}/picks/${MOVIE_B.id}/commit`,
+			{ mediaType: 'movie' },
+			cookies
+		);
+		expect(commit.status).toBe(201);
+
+		const history = await callApp<{
+			data: Array<{
+				tmdbId: number;
+				title: string | null;
+				providers: { flatrate?: unknown[] };
+			}>;
+		}>(`/api/households/${householdId}/history`, { cookies });
+		expect(history.status).toBe(200);
+		expect(history.body.data).toHaveLength(1);
+		expect(history.body.data[0]?.tmdbId).toBe(MOVIE_B.id);
+		// Title is a placeholder ("Untitled movie") rather than MOVIE_B.title -- the provider-cache
+		// write path never fetches real title/poster data (a pre-existing gap ported faithfully
+		// from Express, see docs/roadmap.md). This test asserts the providers join, which is the
+		// actual behavior this domain adds.
+		expect(history.body.data[0]?.providers.flatrate?.length).toBeGreaterThan(0);
+	});
+
+	it('paginates', async () => {
+		const { cookies } = await createLoggedInUser(uniqueEmail());
+		const householdId = await createHousehold(cookies);
+
+		for (const movie of DEFAULT_MOVIES) {
+			const commit = await postJson(
+				`/api/households/${householdId}/picks/${movie.id}/commit`,
+				{ mediaType: 'movie' },
+				cookies
+			);
+			expect(commit.status).toBe(201);
+		}
+
+		const page1 = await callApp<{
+			data: unknown[];
+			pagination: { total: number; totalPages: number };
+		}>(`/api/households/${householdId}/history?page=1&limit=2`, { cookies });
+		expect(page1.status).toBe(200);
+		expect(page1.body.data).toHaveLength(2);
+		expect(page1.body.pagination.total).toBe(3);
+		expect(page1.body.pagination.totalPages).toBe(2);
+
+		const page2 = await callApp<{ data: unknown[] }>(
+			`/api/households/${householdId}/history?page=2&limit=2`,
+			{ cookies }
+		);
+		expect(page2.status).toBe(200);
+		expect(page2.body.data).toHaveLength(1);
+	});
+});
+
+describe('PATCH /api/households/:id/history/:watchedId', () => {
+	it('rejects a non-member', async () => {
+		const owner = await createLoggedInUser(uniqueEmail());
+		const outsider = await createLoggedInUser(uniqueEmail());
+		const householdId = await createHousehold(owner.cookies);
+		const commit = await postJson<{ id: string }>(
+			`/api/households/${householdId}/picks/${MOVIE_A.id}/commit`,
+			{ mediaType: 'movie' },
+			owner.cookies
+		);
+
+		const result = await postJson(
+			`/api/households/${householdId}/history/${commit.body.id}`,
+			{ enjoyed: true },
+			outsider.cookies,
+			{ method: 'PATCH' }
+		);
+		expect(result.status).toBe(403);
+	});
+
+	it('sets and clears enjoyed', async () => {
+		const { cookies } = await createLoggedInUser(uniqueEmail());
+		const householdId = await createHousehold(cookies);
+		const commit = await postJson<{ id: string }>(
+			`/api/households/${householdId}/picks/${MOVIE_A.id}/commit`,
+			{ mediaType: 'movie' },
+			cookies
+		);
+
+		const thumbsUp = await postJson<{ entry: { enjoyed: boolean | null } }>(
+			`/api/households/${householdId}/history/${commit.body.id}`,
+			{ enjoyed: true },
+			cookies,
+			{ method: 'PATCH' }
+		);
+		expect(thumbsUp.status).toBe(200);
+		expect(thumbsUp.body.entry.enjoyed).toBe(true);
+
+		const cleared = await postJson<{ entry: { enjoyed: boolean | null } }>(
+			`/api/households/${householdId}/history/${commit.body.id}`,
+			{ enjoyed: null },
+			cookies,
+			{ method: 'PATCH' }
+		);
+		expect(cleared.status).toBe(200);
+		expect(cleared.body.entry.enjoyed).toBeNull();
+	});
+
+	it('returns 404 for an unknown watchedId', async () => {
+		const { cookies } = await createLoggedInUser(uniqueEmail());
+		const householdId = await createHousehold(cookies);
+
+		const result = await postJson(
+			`/api/households/${householdId}/history/not-a-real-id`,
+			{ enjoyed: true },
+			cookies,
+			{ method: 'PATCH' }
+		);
+		expect(result.status).toBe(404);
+	});
+});
+
+describe('POST /api/households/:id/picks/:tmdbId/launch', () => {
+	it('rejects a non-member', async () => {
+		const owner = await createLoggedInUser(uniqueEmail());
+		const outsider = await createLoggedInUser(uniqueEmail());
+		const householdId = await createHousehold(owner.cookies);
+
+		mockExternalApis(DEFAULT_MOVIES);
+		const result = await postJson(
+			`/api/households/${householdId}/picks/${MOVIE_B.id}/launch`,
+			{ providerSlug: 'netflix', mediaType: 'movie' },
+			outsider.cookies
+		);
+		expect(result.status).toBe(403);
+	});
+
+	it('resolves a deep link and records a provider_launched event', async () => {
+		const { userId, cookies } = await createLoggedInUser(uniqueEmail());
+		const householdId = await createHousehold(cookies);
+
+		mockExternalApis(DEFAULT_MOVIES);
+		const result = await postJson<{
+			url: string;
+			providerName: string;
+			region: string;
+		}>(
+			`/api/households/${householdId}/picks/${MOVIE_B.id}/launch`,
+			{ providerSlug: 'netflix', mediaType: 'movie' },
+			cookies
+		);
+		expect(result.status).toBe(200);
+		expect(result.body.providerName).toBe('Netflix');
+		expect(result.body.url).toBe(MOVIE_B.providers?.link);
+		expect(result.body.region).toBe('GB');
+
+		const event = await env.DB.prepare(
+			"SELECT kind, user_id, provider_slug FROM pick_events WHERE household_id = ?1 AND kind = 'provider_launched' ORDER BY occurred_at DESC LIMIT 1"
+		)
+			.bind(householdId)
+			.first<{ kind: string; user_id: string; provider_slug: string }>();
+		expect(event?.kind).toBe('provider_launched');
+		expect(event?.user_id).toBe(userId);
+		expect(event?.provider_slug).toBe('netflix');
+	});
+
+	it('returns 404 when the provider is not available', async () => {
+		const { cookies } = await createLoggedInUser(uniqueEmail());
+		const householdId = await createHousehold(cookies);
+
+		mockExternalApis(DEFAULT_MOVIES);
+		const result = await postJson(
+			`/api/households/${householdId}/picks/${MOVIE_A.id}/launch`,
+			{ providerSlug: 'some_provider_not_offered', mediaType: 'movie' },
+			cookies
+		);
+		expect(result.status).toBe(404);
+	});
+});
+
+describe('POST /api/households/:id/pick-events', () => {
+	it('rejects a non-member', async () => {
+		const owner = await createLoggedInUser(uniqueEmail());
+		const outsider = await createLoggedInUser(uniqueEmail());
+		const householdId = await createHousehold(owner.cookies);
+
+		const result = await postJson(
+			`/api/households/${householdId}/pick-events`,
+			{ tmdbId: MOVIE_A.id, mediaType: 'movie', kind: 'dismissed' },
+			outsider.cookies
+		);
+		expect(result.status).toBe(403);
+	});
+
+	it('records a swapped or dismissed event', async () => {
+		const { cookies } = await createLoggedInUser(uniqueEmail());
+		const householdId = await createHousehold(cookies);
+
+		const result = await postJson<{ recorded: boolean; id: string }>(
+			`/api/households/${householdId}/pick-events`,
+			{ tmdbId: MOVIE_A.id, mediaType: 'movie', kind: 'dismissed' },
+			cookies
+		);
+		expect(result.status).toBe(201);
+		expect(result.body.recorded).toBe(true);
+	});
+
+	it('rejects a kind that has its own dedicated write path', async () => {
+		const { cookies } = await createLoggedInUser(uniqueEmail());
+		const householdId = await createHousehold(cookies);
+
+		const result = await postJson(
+			`/api/households/${householdId}/pick-events`,
+			{ tmdbId: MOVIE_A.id, mediaType: 'movie', kind: 'accepted' },
+			cookies
+		);
+		expect(result.status).toBe(400);
+	});
+});
+
+describe('GET /api/households/:id/pick-events/stats', () => {
+	it('rejects a non-member', async () => {
+		const owner = await createLoggedInUser(uniqueEmail());
+		const outsider = await createLoggedInUser(uniqueEmail());
+		const householdId = await createHousehold(owner.cookies);
+
+		const result = await callApp(
+			`/api/households/${householdId}/pick-events/stats`,
+			{ cookies: outsider.cookies }
+		);
+		expect(result.status).toBe(403);
+	});
+
+	it('aggregates totals, acceptance rate, and provider clicks', async () => {
+		const { cookies } = await createLoggedInUser(uniqueEmail());
+		const householdId = await createHousehold(cookies);
+
+		await postJson(
+			`/api/households/${householdId}/picks/${MOVIE_A.id}/commit`,
+			{ mediaType: 'movie' },
+			cookies
+		);
+		await postJson(
+			`/api/households/${householdId}/pick-events`,
+			{ tmdbId: MOVIE_C.id, mediaType: 'movie', kind: 'dismissed' },
+			cookies
+		);
+		mockExternalApis(DEFAULT_MOVIES);
+		await postJson(
+			`/api/households/${householdId}/picks/${MOVIE_B.id}/launch`,
+			{ providerSlug: 'netflix', mediaType: 'movie' },
+			cookies
+		);
+
+		const stats = await callApp<{
+			windowDays: number;
+			totals: Record<string, number>;
+			firstPickAcceptanceRate: number | null;
+			providerClicksBySlug: Record<string, number>;
+		}>(`/api/households/${householdId}/pick-events/stats`, { cookies });
+		expect(stats.status).toBe(200);
+		expect(stats.body.windowDays).toBe(30);
+		expect(stats.body.totals.accepted).toBe(1);
+		expect(stats.body.totals.dismissed).toBe(1);
+		expect(stats.body.totals.provider_launched).toBe(1);
+		expect(stats.body.firstPickAcceptanceRate).toBe(0.5);
+		expect(stats.body.providerClicksBySlug.netflix).toBe(1);
 	});
 });

--- a/services/api/src/hono/routes/households.ts
+++ b/services/api/src/hono/routes/households.ts
@@ -3,10 +3,16 @@ import {
 	CommitPickRequestSchema,
 	CreateHouseholdRequestSchema,
 	CreateInviteRequestSchema,
+	HistoryPatchRequestSchema,
+	HistoryQuerySchema,
+	PickEventRequestSchema,
+	PickEventStatsQuerySchema,
 	PickRequestSchema,
+	ProviderLaunchRequestSchema,
 	type PickRequest,
 } from '@pairflix/lib.validation';
 import { Hono } from 'hono';
+import { listHistory, setEnjoyed } from '../lib/history';
 import {
 	InviteInvalidError,
 	acceptInvite,
@@ -15,6 +21,11 @@ import {
 	listForUser,
 } from '../lib/household';
 import { recordPickEvent } from '../lib/pickEvents';
+import { getPickEventStats } from '../lib/pickEventStats';
+import {
+	ProviderNotAvailableError,
+	resolveProviderLaunch,
+} from '../lib/providerLaunch';
 import {
 	HouseholdNotFoundError,
 	NoCandidatesError,
@@ -34,10 +45,16 @@ import type { AppEnv } from '../types';
 
 /**
  * Covers what the current Express `household.routes.ts` mounts under `/api/households` (CRUD,
- * invites, pick, commit) minus what belongs to a later roadmap phase: provider-launch tracking
- * and pick-event stats (providers/history), `GET /:id/entitlements` (billing/admin). Also mounts
- * accept-invite, which exists in Express (`householdInvites.routes.ts`) but is never actually
- * registered on the app router there -- without it, an invite can be created but never accepted.
+ * invites, pick, commit, provider-launch, pick-events) plus `history.routes.ts`'s two routes --
+ * minus `GET /:id/entitlements`, which stays deferred to billing/admin. Also mounts accept-invite,
+ * which exists in Express (`householdInvites.routes.ts`) but is never actually registered on the
+ * app router there -- without it, an invite can be created but never accepted.
+ *
+ * `/:id/history` and `/:id/picks/:tmdbId/launch` both run `enforceRegionLock` even though neither
+ * is the pick endpoint -- they're the other two places a caller picks which region's provider data
+ * to see, so the same free-tier GB-lock applies. The standalone `GET /api/providers/:tmdbId`
+ * (routes/providers.ts) has no household context to resolve entitlements from and is a known,
+ * deliberately deferred gap -- see docs/roadmap.md.
  */
 export const householdsRoutes = new Hono<AppEnv>();
 
@@ -203,5 +220,192 @@ householdsRoutes.post(
 			parsed.data
 		);
 		return c.json({ recorded: true, id: result.id }, 201);
+	}
+);
+
+householdsRoutes.get(
+	'/:id/history',
+	requireHouseholdMember,
+	enforceRegionLock,
+	async c => {
+		const householdId = c.req.param('id');
+		const parsed = HistoryQuerySchema.safeParse(c.req.query());
+		if (!parsed.success) {
+			return c.json(
+				{
+					error: 'Invalid input',
+					details: parsed.error.issues.map(i => i.message),
+				},
+				400
+			);
+		}
+
+		const entitlements = c.get('entitlements');
+		const region = entitlements?.regionLock ?? parsed.data.region ?? 'GB';
+
+		const db = createDb(c.env.DB);
+		const result = await listHistory(
+			db,
+			householdId,
+			parsed.data.page,
+			parsed.data.limit,
+			region
+		);
+		return c.json(result);
+	}
+);
+
+householdsRoutes.patch(
+	'/:id/history/:watchedId',
+	requireHouseholdMember,
+	enforceRegionLock,
+	async c => {
+		const householdId = c.req.param('id');
+		const watchedId = c.req.param('watchedId');
+		const parsed = HistoryPatchRequestSchema.safeParse(
+			await c.req.json().catch(() => null)
+		);
+		if (!parsed.success) {
+			return c.json(
+				{
+					error: 'Invalid input',
+					details: parsed.error.issues.map(i => i.message),
+				},
+				400
+			);
+		}
+
+		const entitlements = c.get('entitlements');
+		const region = entitlements?.regionLock ?? 'GB';
+
+		const db = createDb(c.env.DB);
+		const entry = await setEnjoyed(
+			db,
+			householdId,
+			watchedId,
+			parsed.data.enjoyed,
+			region
+		);
+		if (!entry) return c.json({ error: 'Not found' }, 404);
+		return c.json({ entry });
+	}
+);
+
+householdsRoutes.post(
+	'/:id/picks/:tmdbId/launch',
+	requireHouseholdMember,
+	enforceRegionLock,
+	async c => {
+		const householdId = c.req.param('id');
+		const userId = c.get('userId') as string;
+		const tmdbId = Number.parseInt(c.req.param('tmdbId'), 10);
+		if (Number.isNaN(tmdbId)) {
+			return c.json({ error: 'Invalid tmdbId' }, 400);
+		}
+
+		const parsed = ProviderLaunchRequestSchema.safeParse(
+			await c.req.json().catch(() => null)
+		);
+		if (!parsed.success) {
+			return c.json(
+				{
+					error: 'Invalid input',
+					details: parsed.error.issues.map(i => i.message),
+				},
+				400
+			);
+		}
+
+		const entitlements = c.get('entitlements');
+		const region = entitlements?.regionLock ?? parsed.data.region ?? 'GB';
+
+		const db = createDb(c.env.DB);
+		try {
+			const resolved = await resolveProviderLaunch(
+				c.env,
+				db,
+				tmdbId,
+				parsed.data.mediaType,
+				parsed.data.providerSlug,
+				region
+			);
+			c.executionCtx.waitUntil(
+				recordPickEvent(db, {
+					householdId,
+					userId,
+					tmdbId,
+					mediaType: parsed.data.mediaType,
+					kind: 'provider_launched',
+					providerSlug: parsed.data.providerSlug,
+					region,
+				}).catch(err => {
+					console.warn(
+						'[households] failed to record provider_launched pick event',
+						err
+					);
+				})
+			);
+			return c.json(resolved);
+		} catch (error) {
+			if (error instanceof ProviderNotAvailableError) {
+				return c.json({ error: 'provider_not_available' }, 404);
+			}
+			throw error;
+		}
+	}
+);
+
+householdsRoutes.post('/:id/pick-events', requireHouseholdMember, async c => {
+	const householdId = c.req.param('id');
+	const userId = c.get('userId') as string;
+	const parsed = PickEventRequestSchema.safeParse(
+		await c.req.json().catch(() => null)
+	);
+	if (!parsed.success) {
+		return c.json(
+			{
+				error: 'Invalid input',
+				details: parsed.error.issues.map(i => i.message),
+			},
+			400
+		);
+	}
+
+	const db = createDb(c.env.DB);
+	const result = await recordPickEvent(db, {
+		householdId,
+		userId,
+		tmdbId: parsed.data.tmdbId,
+		mediaType: parsed.data.mediaType,
+		kind: parsed.data.kind,
+		mood: parsed.data.mood,
+		minutesBudget: parsed.data.minutesBudget,
+	});
+	return c.json({ recorded: true, id: result.id }, 201);
+});
+
+householdsRoutes.get(
+	'/:id/pick-events/stats',
+	requireHouseholdMember,
+	async c => {
+		const householdId = c.req.param('id');
+		const parsed = PickEventStatsQuerySchema.safeParse(c.req.query());
+		if (!parsed.success) {
+			return c.json(
+				{
+					error: 'Invalid input',
+					details: parsed.error.issues.map(i => i.message),
+				},
+				400
+			);
+		}
+
+		const db = createDb(c.env.DB);
+		const stats = await getPickEventStats(
+			db,
+			householdId,
+			parsed.data.windowDays
+		);
+		return c.json(stats);
 	}
 );

--- a/services/api/src/hono/routes/providers.e2e.test.ts
+++ b/services/api/src/hono/routes/providers.e2e.test.ts
@@ -1,0 +1,173 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { callApp, createLoggedInUser } from '../test/test-helpers';
+
+let counter = 0;
+/** A fresh tmdbId per test that populates the cache -- D1 storage isn't reset between tests
+ * within one file, and `content` rows are keyed by (tmdbId, mediaType). */
+const uniqueTmdbId = () => 900_000 + counter++;
+const uniqueEmail = () => `providers-e2e-${Date.now()}-${counter}@example.com`;
+
+const jsonResponse = (data: unknown, status = 200): Response =>
+	new Response(JSON.stringify(data), {
+		status,
+		headers: { 'content-type': 'application/json' },
+	});
+
+const REAL_FETCH = globalThis.fetch;
+afterEach(() => {
+	globalThis.fetch = REAL_FETCH;
+});
+
+type MockWatchProviders = {
+	link?: string;
+	flatrate?: Array<{
+		provider_id: number;
+		provider_name: string;
+		logo_path: string;
+	}>;
+};
+
+/** Mocks only the TMDb watch-providers endpoint -- this domain never calls /discover or
+ * /movie/:id, unlike the households/pick recommender. */
+const mockTmdbProviders = (
+	byRegion: Record<string, MockWatchProviders>
+): string[] => {
+	const capturedUrls: string[] = [];
+	globalThis.fetch = (async (input: RequestInfo | URL) => {
+		const url =
+			typeof input === 'string'
+				? input
+				: input instanceof URL
+					? input.toString()
+					: input.url;
+		capturedUrls.push(url);
+		const { hostname, pathname } = new URL(url);
+		if (
+			hostname === 'api.themoviedb.org' &&
+			/^\/3\/(movie|tv)\/\d+\/watch\/providers$/.test(pathname)
+		) {
+			return jsonResponse({ results: byRegion });
+		}
+		throw new Error(`Unmocked fetch in test: ${url}`);
+	}) as typeof fetch;
+	return capturedUrls;
+};
+
+describe('GET /api/providers/:tmdbId', () => {
+	it('returns provider data for the requested region', async () => {
+		const { cookies } = await createLoggedInUser(uniqueEmail());
+		const tmdbId = uniqueTmdbId();
+		mockTmdbProviders({
+			GB: {
+				flatrate: [
+					{ provider_id: 8, provider_name: 'Netflix', logo_path: '/x.jpg' },
+				],
+				link: `https://www.themoviedb.org/movie/${tmdbId}/watch?locale=GB`,
+			},
+		});
+
+		const result = await callApp<{
+			region: string;
+			providers: { flatrate?: unknown[] };
+		}>(`/api/providers/${tmdbId}?mediaType=movie`, { cookies });
+		expect(result.status).toBe(200);
+		expect(result.body.region).toBe('GB');
+		expect(result.body.providers.flatrate).toHaveLength(1);
+	});
+
+	it('caches -- a second call within the freshness window does not refetch TMDb', async () => {
+		const { cookies } = await createLoggedInUser(uniqueEmail());
+		const tmdbId = uniqueTmdbId();
+		const capturedUrls = mockTmdbProviders({
+			GB: {
+				flatrate: [
+					{ provider_id: 8, provider_name: 'Netflix', logo_path: '/x.jpg' },
+				],
+			},
+		});
+
+		const first = await callApp(`/api/providers/${tmdbId}?mediaType=movie`, {
+			cookies,
+		});
+		expect(first.status).toBe(200);
+		expect(capturedUrls).toHaveLength(1);
+
+		const second = await callApp(`/api/providers/${tmdbId}?mediaType=movie`, {
+			cookies,
+		});
+		expect(second.status).toBe(200);
+		expect(capturedUrls).toHaveLength(1);
+	});
+
+	it('keeps movie and tv caches separate for the same tmdbId', async () => {
+		const { cookies } = await createLoggedInUser(uniqueEmail());
+		const tmdbId = uniqueTmdbId();
+		let callCount = 0;
+		globalThis.fetch = (async (input: RequestInfo | URL) => {
+			const url =
+				typeof input === 'string'
+					? input
+					: input instanceof URL
+						? input.toString()
+						: input.url;
+			callCount += 1;
+			const isTv = new URL(url).pathname.includes('/tv/');
+			return jsonResponse({
+				results: {
+					GB: {
+						flatrate: [
+							{
+								provider_id: isTv ? 2 : 8,
+								provider_name: isTv ? 'Disney Plus' : 'Netflix',
+								logo_path: '/x.jpg',
+							},
+						],
+					},
+				},
+			});
+		}) as typeof fetch;
+
+		const movie = await callApp<{
+			providers: { flatrate?: Array<{ provider_name: string }> };
+		}>(`/api/providers/${tmdbId}?mediaType=movie`, { cookies });
+		const tv = await callApp<{
+			providers: { flatrate?: Array<{ provider_name: string }> };
+		}>(`/api/providers/${tmdbId}?mediaType=tv`, { cookies });
+
+		expect(movie.body.providers.flatrate?.[0]?.provider_name).toBe('Netflix');
+		expect(tv.body.providers.flatrate?.[0]?.provider_name).toBe('Disney Plus');
+		expect(callCount).toBe(2);
+	});
+
+	it('degrades to an empty result rather than failing when TMDb errors', async () => {
+		const { cookies } = await createLoggedInUser(uniqueEmail());
+		const tmdbId = uniqueTmdbId();
+		globalThis.fetch = (async () =>
+			jsonResponse({ error: 'boom' }, 500)) as typeof fetch;
+
+		const result = await callApp<{ providers: Record<string, unknown> }>(
+			`/api/providers/${tmdbId}?mediaType=movie`,
+			{ cookies }
+		);
+		expect(result.status).toBe(200);
+		expect(result.body.providers).toEqual({});
+	});
+
+	it('rejects an invalid tmdbId', async () => {
+		const { cookies } = await createLoggedInUser(uniqueEmail());
+		const result = await callApp(
+			'/api/providers/not-a-number?mediaType=movie',
+			{
+				cookies,
+			}
+		);
+		expect(result.status).toBe(400);
+	});
+
+	it('rejects a missing mediaType', async () => {
+		const { cookies } = await createLoggedInUser(uniqueEmail());
+		const tmdbId = uniqueTmdbId();
+		const result = await callApp(`/api/providers/${tmdbId}`, { cookies });
+		expect(result.status).toBe(400);
+	});
+});

--- a/services/api/src/hono/routes/providers.ts
+++ b/services/api/src/hono/routes/providers.ts
@@ -1,0 +1,47 @@
+import { createDb } from '@pairflix/db';
+import { ProvidersQuerySchema } from '@pairflix/lib.validation';
+import { Hono } from 'hono';
+import { getCachedProviders } from '../lib/providers';
+import { requireAuth } from '../middleware/auth';
+import type { AppEnv } from '../types';
+
+/**
+ * Standalone provider lookup by TMDb id -- not household-scoped (matching the Express endpoint
+ * this replaces), so it can't apply a household's entitlements the way `/households/:id/pick` and
+ * `/households/:id/history` do. Known, deliberately deferred gap: a free-tier caller can request
+ * any region here even though those two household-scoped paths restrict them to GB -- closing it
+ * needs a product decision on how a caller's entitlement should resolve with no household context
+ * (which household, if the caller belongs to more than one?). See docs/roadmap.md.
+ */
+export const providersRoutes = new Hono<AppEnv>();
+
+providersRoutes.use('*', requireAuth);
+
+providersRoutes.get('/:tmdbId', async c => {
+	const tmdbId = Number.parseInt(c.req.param('tmdbId'), 10);
+	if (Number.isNaN(tmdbId)) {
+		return c.json({ error: 'Invalid tmdbId' }, 400);
+	}
+
+	const parsed = ProvidersQuerySchema.safeParse(c.req.query());
+	if (!parsed.success) {
+		return c.json(
+			{
+				error: 'Invalid input',
+				details: parsed.error.issues.map(i => i.message),
+			},
+			400
+		);
+	}
+
+	const region = parsed.data.region ?? 'GB';
+	const db = createDb(c.env.DB);
+	const providers = await getCachedProviders(
+		c.env,
+		db,
+		tmdbId,
+		parsed.data.mediaType,
+		region
+	);
+	return c.json({ region, providers });
+});


### PR DESCRIPTION
### What's New

- Feature: Ports the providers/history domain (Express → Hono Worker), continuing the P3 re-platform after auth (#66, #67) and households/pick (#68).
- Feature: Unifies three previously-disconnected TMDb watch-provider fetch paths (a DB-backed cache only the standalone providers endpoint used, an in-process cache only the recommender used, and provider-launch's uncached raw fetch) into one D1-backed read-through cache shared by all of them.
- Fix: Closes a duplicate-row race in the provider cache under concurrent cache misses for the same title (new unique `(tmdbId, mediaType)` index).
- Fix: History's title/poster join now matches on `(tmdbId, mediaType)`, not `tmdbId` alone — a movie and a TV show can share a numeric TMDb id, so the single-column join it replaces risked attaching the wrong title to a watched-together row.
- Refactor: `lib/pickEventStats.ts` aggregates in SQL (`GROUP BY` + `count()`) rather than pulling every matching row into the Worker, per Copilot review on an earlier push to this PR.
- Test: 21 new `vitest-pool-workers` integration tests.

---

### Description

New `services/api/src/hono` files:
- `lib/providers.ts` — `getCachedProviders`, the shared read-through cache (24h blob-level staleness, matching Express; degrades to cached/empty rather than throwing on a TMDb failure, matching CLAUDE.md's "provider data is best-effort... degrade gracefully" and the pattern already used in `lib/recommendation.ts`'s hydration step).
- `lib/providerLaunch.ts` — resolves a provider slug + region to a deep link via the shared cache. There's no per-provider URL scheme anywhere in this codebase — the link is TMDb's own region "watch this title" page, identical regardless of which provider matched.
- `lib/history.ts` — watch-together listing (paginated, per CLAUDE.md's house `{ data, pagination }` shape rather than Express's flat capped-at-200 list) and thumbs (`enjoyed: true | false | null`). List and PATCH now return the same joined shape — Express's PATCH returned a bare row while its GET returned a joined one. PATCH accepts `enjoyed: null` to un-rate, which Express's validator rejected despite the column being nullable. No taste-profile-recompute side effect ported — that was built entirely on the `WatchlistEntry` table the D1 schema drops, same already-tracked gap as the households/pick domain's taste-profile note.
- `lib/pickEventStats.ts` — household-scoped pick-funnel analytics (totals per event kind, first-pick acceptance rate, provider clicks by slug) over the existing `pick_events` table.
- `routes/providers.ts` (new file) — standalone `GET /api/providers/:tmdbId`, matching Express's non-household-scoped shape.
- `routes/households.ts` extended with `GET/PATCH .../history`, `POST .../picks/:tmdbId/launch`, `POST .../pick-events`, `GET .../pick-events/stats`.

**`packages/db`**: adds a unique `(tmdbId, mediaType)` index on `content` (migration `0002`) and widens the stored `ProviderRegion` shape to carry `free`/`ads`/`link` (the shape it replaces dropped all three, which is why provider-launch never read from the cache in Express — it hit TMDb raw instead).

**Region entitlements.** `/:id/history` and `/:id/picks/:tmdbId/launch` both now run `enforceRegionLock`, same as `/:id/pick` — free-tier households get the same GB lock on these two as they already do on picking. The standalone `GET /api/providers/:tmdbId` has no household context to resolve entitlements from, so it can't apply that lock; documented as a known, deliberately deferred gap (needs a product decision on which household's entitlement should apply for a caller in more than one).

**Pick-events scoping.** The generic `POST /:id/pick-events` endpoint's `kind` is restricted to `swapped`/`dismissed` — `proposed` is already auto-recorded by the pick route and `accepted` by commit (from the households/pick PR), and `provider_launched` is only recordable through the TMDb-verified launch endpoint, which records it itself.

**Known gap, not fixed here:** `content` rows created by the provider-cache write path get a placeholder title (`"Untitled movie"`/`"Untitled show"`) — the caching path never fetches real title/poster data, matching Express exactly (pre-existing, not a regression). History's `providers` field is real; `title`/`year`/`posterPath` read as the placeholder until something enriches `content` with real metadata. The natural place is `lib/recommendation.ts`'s hydration step, which already fetches real title/runtime per candidate but doesn't write it back — deliberately not bundled into this change. See `docs/roadmap.md` for this and the other deferred items.

---

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented parts that are complex or non-obvious
- [x] I have updated relevant documentation
- [x] I have added or updated tests
- [x] No new warnings or errors are introduced
- [x] All tests pass locally

---

### Screenshots

N/A — backend only, no UI changes.

---

### Related Issues / PRs

- Continues #66 / #67 (P3 auth domain) and #68 (P3 households/pick domain).
- Tracked in `docs/roadmap.md` under P3. Only billing/admin remains before P3's server-entry-point collapse and cutover.

---

### Notes for Reviewers

- Full monorepo verification green: `turbo run type-check`, `lint`, `test`, `build` across all 8 workspaces; `wrangler deploy --dry-run` bundles successfully. `services/api`'s Jest suite (Express, untouched) still passes at 292/292; the Hono Vitest suite is now 70/70 (49 pre-existing + 21 new).
- This PR was built up incrementally across two pushes (visible in the commit history) rather than opened only once finished, so CI/CodeQL ran against each increment. Both pushes are now folded into one complete, reviewable domain.
- Three known, documented gaps deliberately not fixed in this pass (see `docs/roadmap.md`'s "providers/history — done" section for full reasoning): the placeholder-title issue above, the standalone providers endpoint's region-entitlement gap, and no cron-driven provider-cache refresh (caching is lazy/on-demand only, matching Express — the cron trigger `docs/architecture.md` describes was already aspirational, not a ported behavior).