### PR TITLE
feat(api): port billing/admin domain to Hono Worker (P3)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -125,9 +125,32 @@ current_period_end > now`.
 
 ## Billing
 
-Deferred. When enabled, port creatorgrid's test-mode Stripe pattern (`lib/stripe.ts` +
-`routes/billing.ts`, "unconfigured is a valid state" — endpoints 501 until a key is set, webhook is
-HMAC-verified). Until then the mock checkout stays for demos only.
+Real Stripe is still deferred (CLAUDE.md). What's implemented as the P3 billing/admin domain
+(`services/api/src/hono/lib/billing.ts`) is Pairflix's existing mock pattern, household-scoped
+under `/households/:id/billing/*` (owner-only): `checkout` returns a fake URL with no DB write,
+`mock-activate` unconditionally flips the household to premium for 30 days behind a
+`BILLING_MOCK_ENABLED` var ("unconfigured is a valid state" — enabled outside `production`,
+matching the pattern CLAUDE.md's Stripe section describes; 404s when disabled, so it isn't
+discoverable outside dev/demo use), and `cancel` sets `status: 'canceled'` without touching
+`current_period_end`. There's no webhook yet — the current one is a no-op stub with no signature
+verification and no DB effect, so it isn't ported; it lands for real, HMAC-verified, alongside
+actual Stripe.
+
+## Admin
+
+Implemented as the P3 billing/admin domain (`services/api/src/hono/routes/admin.ts`), mounted at
+`/api/admin` behind `requireAdmin` (role + TOTP, same session as everyone else — no separate admin
+login). Covers user management (CRUD, a single consolidated status-change endpoint that revokes
+sessions and emails the user on suspend/ban, forced password reset, locked-accounts using the same
+threshold `/auth/login` enforces, session termination that's genuinely immediate since a Hono
+session row is the live credential), audit logs, settings
+(`services/api/src/hono/lib/adminSettings.ts` -- generic key/value CRUD over `settings`, matching
+`lib/featureFlags.ts`'s existing no-cache read pattern), and content moderation over
+`content`/`content_reports`. Express's larger
+stats/activity surface mostly isn't ported -- it read the `activity_log`/`matches`/
+`watchlist_entries` tables the re-platform drops, or Postgres/Node-process introspection with no
+Workers equivalent -- replaced with one `GET /api/admin/dashboard-stats` built from tables that
+still exist.
 
 ## Background work (cron)
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -140,7 +140,53 @@ generic `POST /:id/pick-events` endpoint's `kind` is narrowed to `swapped`/`dism
 TMDb-failure degrade, history list/pagination/thumbs, provider-launch including its recorded
 `pick_events` row, the generic pick-events endpoint's kind restriction, and stats aggregation).
 
-**Pending:** billing/admin domain; then collapse the two server entries into one and cut over.
+**billing/admin — done.** The last P3 domain. `services/api/src/hono/lib/{adminUsers,adminContent,
+adminAuditLogs,adminSettings,adminDashboard,billing}.ts`, `routes/admin.ts` (new, mounted at
+`/api/admin` behind `requireAdmin`), `routes/households.ts` extended with `/:id/entitlements` and
+`/:id/billing/{checkout,cancel,mock-activate}` (household-scoped and owner-gated, replacing
+Express's flat `/api/billing/*` + body `household_id` shape). No new migration -- every table this
+domain touches (`content`, `content_reports`, `audit_logs`, `settings`, `subscriptions`, `sessions`)
+already had the columns it needed, several with doc comments in `packages/db/src/schema.ts` already
+anticipating this port.
+
+Most of Express's admin surface ports faithfully: user management, audit logs, content moderation.
+Two things don't:
+
+- The separate admin JWT login/validate-token/refresh/logout endpoints are dropped entirely --
+  confirmed structurally identical to regular auth (same `JWT_SECRET`, same `authenticateToken`),
+  fully subsumed by the session-cookie + `requireAdmin` (role + TOTP) gate every other admin route
+  already uses.
+- 8 of Express's 12 stats/activity endpoints are dropped -- backed by the `activity_log` table the
+  re-platform drops, or Postgres/Node-process introspection (`pg_stat_activity`, `os.*`,
+  `process.memoryUsage()`) with no D1/Workers-isolate equivalent at all; several of those numbers
+  are already hardcoded random fallbacks in Express, not real telemetry. Replaced with one new
+  `GET /api/admin/dashboard-stats` built from tables that still exist post-pivot (users, households,
+  subscriptions, audit-log errors) rather than porting dead or unportable code.
+
+Also fixes several bugs found while porting: the two competing Express status-change endpoints
+(`status`/`status-enhanced`, with materially different side effects) are consolidated into one that
+always does the fuller behavior; `listUsers`/`listContent`'s `sortBy` is whitelisted instead of
+splicing the query string into the ORM's order clause; `getLockedAccounts` uses the real login
+lockout threshold (`FAILED_ATTEMPT_LIMIT`, now shared from `lib/session.ts`) instead of Express's
+drifted hardcoded `3`; `forcePasswordReset` only moves a user to `pending` from `active`/`inactive`,
+not unconditionally (Express's version would silently un-suspend/un-ban an account); dismissing a
+content report only decrements `reportedCount` once, not on every repeat dismissal; and an
+admin-supplied status-change `reason` is HTML-escaped before it reaches an email body (a real
+Copilot review finding on this PR). Terminating a user's session is also now genuinely enforced --
+a Hono `sessions` row is the live credential `sessionMiddleware` checks on every request, unlike
+Express's `user_sessions` rows, which were never consulted by its own auth middleware.
+
+**Known gap, not fixed here:** the automatic daily audit-log retention sweep (Express: a
+`node-cron` job) isn't ported -- a stateless Worker has no equivalent always-running process for it.
+`POST /api/admin/audit-logs/rotation` covers the manual/on-demand half; the automatic half needs a
+Cloudflare Cron Trigger, same "not implemented yet" status as the provider-cache refresh cron noted
+below.
+
+22 new `vitest-pool-workers` tests (`admin.e2e.test.ts`, new, plus `households.e2e.test.ts`
+extended) covering the auth gate, each of the behavior fixes above, and the billing/entitlements
+roundtrip (mock-activate flips a household to premium, cancel reverts it).
+
+**Pending:** collapse the two server entries into one and cut over (P5).
 **Exit:** each domain has `vitest-pool-workers` integration tests against local D1; the pick path
 returns a title end-to-end on Miniflare.
 

--- a/packages/lib.validation/src/index.ts
+++ b/packages/lib.validation/src/index.ts
@@ -1,3 +1,4 @@
+export * from './schemas/admin';
 export * from './schemas/auth';
 export * from './schemas/household';
 export * from './schemas/providers';

--- a/packages/lib.validation/src/schemas/admin.ts
+++ b/packages/lib.validation/src/schemas/admin.ts
@@ -1,0 +1,126 @@
+import { z } from 'zod';
+import { EmailSchema, StrongPasswordSchema, UsernameSchema } from './auth';
+
+const UserRoleSchema = z.enum(['user', 'admin']);
+const UserStatusSchema = z.enum([
+  'active',
+  'inactive',
+  'pending',
+  'suspended',
+  'banned',
+]);
+
+export const AdminPaginationQuerySchema = z.object({
+  page: z.coerce.number().int().min(1).default(1),
+  limit: z.coerce.number().int().min(1).max(100).default(20),
+});
+export type AdminPaginationQuery = z.infer<typeof AdminPaginationQuerySchema>;
+
+export const AdminUserListQuerySchema = AdminPaginationQuerySchema.extend({
+  search: z.string().trim().min(1).optional(),
+  role: UserRoleSchema.optional(),
+  status: UserStatusSchema.optional(),
+  sortBy: z.enum(['createdAt', 'username', 'email', 'lastLogin']).optional(),
+  sortOrder: z.enum(['asc', 'desc']).optional(),
+});
+export type AdminUserListQuery = z.infer<typeof AdminUserListQuerySchema>;
+
+export const AdminUsersExportQuerySchema = z.object({
+  role: UserRoleSchema.optional(),
+  status: UserStatusSchema.optional(),
+});
+export type AdminUsersExportQuery = z.infer<typeof AdminUsersExportQuerySchema>;
+
+export const AdminCreateUserRequestSchema = z.object({
+  username: UsernameSchema,
+  email: EmailSchema,
+  password: StrongPasswordSchema,
+  role: UserRoleSchema.optional(),
+  status: UserStatusSchema.optional(),
+});
+export type AdminCreateUserRequest = z.infer<
+  typeof AdminCreateUserRequestSchema
+>;
+
+export const AdminUpdateUserRequestSchema = z.object({
+  username: UsernameSchema.optional(),
+  email: EmailSchema.optional(),
+  role: UserRoleSchema.optional(),
+  status: UserStatusSchema.optional(),
+});
+export type AdminUpdateUserRequest = z.infer<
+  typeof AdminUpdateUserRequestSchema
+>;
+
+export const AdminChangeStatusRequestSchema = z.object({
+  status: UserStatusSchema,
+  reason: z.string().trim().max(500).optional(),
+});
+export type AdminChangeStatusRequest = z.infer<
+  typeof AdminChangeStatusRequestSchema
+>;
+
+export const AdminResetPasswordRequestSchema = z.object({
+  sendEmail: z.boolean().default(true),
+});
+export type AdminResetPasswordRequest = z.infer<
+  typeof AdminResetPasswordRequestSchema
+>;
+
+export const AdminAuditLogQuerySchema = z.object({
+  page: z.coerce.number().int().min(1).default(1),
+  limit: z.coerce.number().int().min(1).max(500).default(100),
+});
+export type AdminAuditLogQuery = z.infer<typeof AdminAuditLogQuerySchema>;
+
+const RetentionDaysSchema = z.object({
+  info: z.number().int().positive().optional(),
+  warn: z.number().int().positive().optional(),
+  error: z.number().int().positive().optional(),
+  debug: z.number().int().positive().optional(),
+});
+
+export const AdminAuditLogRotationRequestSchema = z.object({
+  retentionDays: RetentionDaysSchema.optional(),
+});
+export type AdminAuditLogRotationRequest = z.infer<
+  typeof AdminAuditLogRotationRequestSchema
+>;
+
+/** A nested object matching `lib/adminSettings.ts`'s `SettingsTree` shape -- validated structurally
+ * as "an object" here; the leaf-level flattening/type handling happens in the lib layer, which
+ * already owns the one place that shape is interpreted. */
+export const AdminSettingsPatchRequestSchema = z.record(
+  z.string(),
+  z.unknown()
+);
+export type AdminSettingsPatchRequest = z.infer<
+  typeof AdminSettingsPatchRequestSchema
+>;
+
+const ContentTypeSchema = z.enum(['movie', 'show', 'episode']);
+const ContentStatusSchema = z.enum(['active', 'pending', 'flagged', 'removed']);
+
+export const AdminContentListQuerySchema = AdminPaginationQuerySchema.extend({
+  search: z.string().trim().min(1).optional(),
+  type: ContentTypeSchema.optional(),
+  status: ContentStatusSchema.optional(),
+  sortBy: z.enum(['reportedCount', 'createdAt', 'title']).optional(),
+  sortOrder: z.enum(['asc', 'desc']).optional(),
+});
+export type AdminContentListQuery = z.infer<typeof AdminContentListQuerySchema>;
+
+export const AdminUpdateContentRequestSchema = z.object({
+  title: z.string().trim().min(1).max(500).optional(),
+  status: ContentStatusSchema.optional(),
+});
+export type AdminUpdateContentRequest = z.infer<
+  typeof AdminUpdateContentRequestSchema
+>;
+
+export const AdminRemoveContentRequestSchema = z.object({
+  reason: z.string().trim().max(500).optional(),
+});
+export type AdminRemoveContentRequest = z.infer<
+  typeof AdminRemoveContentRequestSchema
+>;

--- a/services/api/src/hono/index.ts
+++ b/services/api/src/hono/index.ts
@@ -3,6 +3,7 @@ import { cors } from 'hono/cors';
 import { secureHeaders } from 'hono/secure-headers';
 import { sessionMiddleware } from './middleware/auth';
 import { csrfMiddleware } from './middleware/csrf';
+import { adminRoutes } from './routes/admin';
 import { authRoutes } from './routes/auth';
 import { healthRoutes } from './routes/health';
 import { householdsRoutes } from './routes/households';
@@ -41,6 +42,7 @@ app.route('/api/auth', authRoutes);
 app.route('/api/me', meRoutes);
 app.route('/api/households', householdsRoutes);
 app.route('/api/providers', providersRoutes);
+app.route('/api/admin', adminRoutes);
 
 app.notFound(c => c.json({ error: 'Not found' }, 404));
 app.onError((error, c) => {

--- a/services/api/src/hono/lib/adminAuditLogs.ts
+++ b/services/api/src/hono/lib/adminAuditLogs.ts
@@ -1,0 +1,132 @@
+import { auditLogs, type Database } from '@pairflix/db';
+import { and, asc, count, desc, eq, lt, max, min } from 'drizzle-orm';
+
+export type AuditLogEntry = {
+	id: string;
+	level: 'info' | 'warn' | 'error' | 'debug';
+	message: string;
+	context: Record<string, unknown> | null;
+	source: string;
+	createdAt: Date;
+};
+
+export const listAuditLogs = async (
+	db: Database,
+	opts: { level?: AuditLogEntry['level']; page?: number; limit?: number }
+): Promise<{
+	data: AuditLogEntry[];
+	pagination: {
+		page: number;
+		limit: number;
+		total: number;
+		totalPages: number;
+	};
+}> => {
+	const page = opts.page ?? 1;
+	const limit = opts.limit ?? 100;
+	const where = opts.level ? eq(auditLogs.level, opts.level) : undefined;
+
+	const [data, totalRow] = await Promise.all([
+		db
+			.select()
+			.from(auditLogs)
+			.where(where)
+			.orderBy(desc(auditLogs.createdAt))
+			.limit(limit)
+			.offset((page - 1) * limit),
+		db.select({ total: count() }).from(auditLogs).where(where).get(),
+	]);
+
+	const total = totalRow?.total ?? 0;
+	return {
+		data,
+		pagination: { page, limit, total, totalPages: Math.ceil(total / limit) },
+	};
+};
+
+export const getLogSources = async (db: Database): Promise<string[]> => {
+	const rows = await db
+		.selectDistinct({ source: auditLogs.source })
+		.from(auditLogs)
+		.orderBy(asc(auditLogs.source));
+	return rows.map(row => row.source);
+};
+
+export type AuditLogStats = {
+	total: number;
+	byLevel: Record<'info' | 'warn' | 'error' | 'debug', number>;
+	oldestAt: Date | null;
+	newestAt: Date | null;
+};
+
+export const getAuditLogStats = async (
+	db: Database
+): Promise<AuditLogStats> => {
+	const [totalRow, levelRows, rangeRow] = await Promise.all([
+		db.select({ total: count() }).from(auditLogs).get(),
+		db
+			.select({ level: auditLogs.level, total: count() })
+			.from(auditLogs)
+			.groupBy(auditLogs.level),
+		db
+			.select({
+				oldest: min(auditLogs.createdAt),
+				newest: max(auditLogs.createdAt),
+			})
+			.from(auditLogs)
+			.get(),
+	]);
+
+	const byLevel: AuditLogStats['byLevel'] = {
+		info: 0,
+		warn: 0,
+		error: 0,
+		debug: 0,
+	};
+	for (const row of levelRows) {
+		byLevel[row.level] = row.total;
+	}
+
+	return {
+		total: totalRow?.total ?? 0,
+		byLevel,
+		oldestAt: rangeRow?.oldest ?? null,
+		newestAt: rangeRow?.newest ?? null,
+	};
+};
+
+const DEFAULT_RETENTION_DAYS: Record<AuditLogEntry['level'], number> = {
+	info: 30,
+	debug: 7,
+	warn: 90,
+	error: 365,
+};
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+const LEVELS: AuditLogEntry['level'][] = ['info', 'warn', 'error', 'debug'];
+
+export const cleanupOldLogs = async (
+	db: Database,
+	retentionDaysOverride?: Partial<Record<AuditLogEntry['level'], number>>
+): Promise<Record<AuditLogEntry['level'], number>> => {
+	const deleted: Record<AuditLogEntry['level'], number> = {
+		info: 0,
+		warn: 0,
+		error: 0,
+		debug: 0,
+	};
+
+	for (const level of LEVELS) {
+		const retentionDays =
+			retentionDaysOverride?.[level] ?? DEFAULT_RETENTION_DAYS[level];
+		const cutoff = new Date(Date.now() - retentionDays * MS_PER_DAY);
+		const rows = await db
+			.delete(auditLogs)
+			.where(and(eq(auditLogs.level, level), lt(auditLogs.createdAt, cutoff)))
+			.returning({ id: auditLogs.id });
+		deleted[level] = rows.length;
+	}
+
+	return deleted;
+};

--- a/services/api/src/hono/lib/adminContent.ts
+++ b/services/api/src/hono/lib/adminContent.ts
@@ -1,0 +1,213 @@
+import { content, contentReports, users, type Database } from '@pairflix/db';
+import { and, asc, count, desc, eq, like, sql } from 'drizzle-orm';
+
+/**
+ * Admin content-moderation queries, ported from the current Express admin content controller.
+ * `content` doubles as a TMDb provider-availability cache and this moderation registry (see
+ * packages/db/src/schema.ts) -- every write here only ever touches the moderation columns
+ * (title/type/status/reportedCount/removalReason), mirroring lib/providers.ts's own promise from
+ * the other side never to touch these.
+ *
+ * Two deliberate departures from the Express version, both bug fixes:
+ * - `listContent`'s `sortBy` is whitelisted against a fixed column lookup rather than spliced
+ *   straight into `.orderBy()` -- the Express version passes the raw query-string value straight
+ *   into the ORM's order clause with zero validation.
+ * - `dismissReport` only decrements `content.reportedCount` when the report's status was still
+ *   `pending` before the dismiss -- the Express version decrements unconditionally on every
+ *   dismiss call, understating the count relative to actually-open reports on repeat calls.
+ */
+
+export type AdminContentSummary = {
+	id: string;
+	title: string;
+	type: 'movie' | 'show' | 'episode';
+	status: 'active' | 'pending' | 'flagged' | 'removed';
+	reportedCount: number;
+	removalReason: string | null;
+	createdAt: Date;
+	updatedAt: Date;
+};
+
+const contentSummaryColumns = {
+	id: content.id,
+	title: content.title,
+	type: content.type,
+	status: content.status,
+	reportedCount: content.reportedCount,
+	removalReason: content.removalReason,
+	createdAt: content.createdAt,
+	updatedAt: content.updatedAt,
+};
+
+const contentSortColumns = {
+	reportedCount: content.reportedCount,
+	createdAt: content.createdAt,
+	title: content.title,
+};
+
+export const listContent = async (
+	db: Database,
+	opts: {
+		page?: number;
+		limit?: number;
+		search?: string;
+		type?: 'movie' | 'show' | 'episode';
+		status?: AdminContentSummary['status'];
+		sortBy?: 'reportedCount' | 'createdAt' | 'title';
+		sortOrder?: 'asc' | 'desc';
+	}
+): Promise<{
+	data: AdminContentSummary[];
+	pagination: {
+		page: number;
+		limit: number;
+		total: number;
+		totalPages: number;
+	};
+}> => {
+	const page = opts.page ?? 1;
+	const limit = opts.limit ?? 20;
+	const sortColumn = contentSortColumns[opts.sortBy ?? 'reportedCount'];
+	const orderFn = opts.sortOrder === 'asc' ? asc : desc;
+
+	const where = and(
+		opts.search ? like(content.title, `%${opts.search}%`) : undefined,
+		opts.type ? eq(content.type, opts.type) : undefined,
+		opts.status ? eq(content.status, opts.status) : undefined
+	);
+
+	const [rows, totalRow] = await Promise.all([
+		db
+			.select(contentSummaryColumns)
+			.from(content)
+			.where(where)
+			.orderBy(orderFn(sortColumn))
+			.limit(limit)
+			.offset((page - 1) * limit),
+		db.select({ total: count() }).from(content).where(where).get(),
+	]);
+
+	const total = totalRow?.total ?? 0;
+	return {
+		data: rows,
+		pagination: { page, limit, total, totalPages: Math.ceil(total / limit) },
+	};
+};
+
+export type ContentReportWithReporter = {
+	id: string;
+	reason: string;
+	details: string | null;
+	status: 'pending' | 'dismissed' | 'resolved';
+	createdAt: Date;
+	updatedAt: Date;
+	reporterUsername: string;
+};
+
+export const getContentReports = async (
+	db: Database,
+	contentId: string
+): Promise<ContentReportWithReporter[]> => {
+	const rows = await db
+		.select({
+			id: contentReports.id,
+			reason: contentReports.reason,
+			details: contentReports.details,
+			status: contentReports.status,
+			createdAt: contentReports.createdAt,
+			updatedAt: contentReports.updatedAt,
+			reporterUsername: users.username,
+		})
+		.from(contentReports)
+		.innerJoin(users, eq(contentReports.userId, users.id))
+		.where(eq(contentReports.contentId, contentId))
+		.orderBy(desc(contentReports.createdAt));
+	return rows;
+};
+
+export const updateContent = async (
+	db: Database,
+	contentId: string,
+	input: Partial<{ title: string; status: AdminContentSummary['status'] }>
+): Promise<AdminContentSummary | null> => {
+	const updated = await db
+		.update(content)
+		.set({ ...input, updatedAt: new Date() })
+		.where(eq(content.id, contentId))
+		.returning(contentSummaryColumns)
+		.get();
+	return updated ?? null;
+};
+
+export const flagContent = async (
+	db: Database,
+	contentId: string
+): Promise<AdminContentSummary | null> => {
+	const updated = await db
+		.update(content)
+		.set({ status: 'flagged', updatedAt: new Date() })
+		.where(eq(content.id, contentId))
+		.returning(contentSummaryColumns)
+		.get();
+	return updated ?? null;
+};
+
+export const approveContent = async (
+	db: Database,
+	contentId: string
+): Promise<AdminContentSummary | null> => {
+	const updated = await db
+		.update(content)
+		.set({ status: 'active', updatedAt: new Date() })
+		.where(eq(content.id, contentId))
+		.returning(contentSummaryColumns)
+		.get();
+	return updated ?? null;
+};
+
+export const removeContent = async (
+	db: Database,
+	contentId: string,
+	reason?: string
+): Promise<AdminContentSummary | null> => {
+	const updated = await db
+		.update(content)
+		.set({
+			status: 'removed',
+			removalReason: reason ?? null,
+			updatedAt: new Date(),
+		})
+		.where(eq(content.id, contentId))
+		.returning(contentSummaryColumns)
+		.get();
+	return updated ?? null;
+};
+
+export const dismissReport = async (
+	db: Database,
+	reportId: string
+): Promise<{ id: string; status: 'dismissed' } | null> => {
+	const report = await db
+		.select({
+			contentId: contentReports.contentId,
+			status: contentReports.status,
+		})
+		.from(contentReports)
+		.where(eq(contentReports.id, reportId))
+		.get();
+	if (!report) return null;
+
+	await db
+		.update(contentReports)
+		.set({ status: 'dismissed', updatedAt: new Date() })
+		.where(eq(contentReports.id, reportId));
+
+	if (report.status === 'pending') {
+		await db
+			.update(content)
+			.set({ reportedCount: sql`max(${content.reportedCount} - 1, 0)` })
+			.where(eq(content.id, report.contentId));
+	}
+
+	return { id: reportId, status: 'dismissed' };
+};

--- a/services/api/src/hono/lib/adminDashboard.ts
+++ b/services/api/src/hono/lib/adminDashboard.ts
@@ -1,0 +1,58 @@
+import {
+	users,
+	households,
+	subscriptions,
+	auditLogs,
+	type Database,
+} from '@pairflix/db';
+import { and, count, eq, gte } from 'drizzle-orm';
+
+export type DashboardStats = {
+	totalUsers: number;
+	activeUsers: number;
+	totalHouseholds: number;
+	premiumHouseholds: number;
+	recentErrorCount: number;
+};
+
+export const getDashboardStats = async (
+	db: Database
+): Promise<DashboardStats> => {
+	const since = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+
+	const [usersRow, activeRow, householdsRow, premiumRow, errorsRow] =
+		await Promise.all([
+			db.select({ total: count() }).from(users).get(),
+			db
+				.select({ total: count() })
+				.from(users)
+				.where(gte(users.lastLogin, since))
+				.get(),
+			db.select({ total: count() }).from(households).get(),
+			db
+				.select({ total: count() })
+				.from(subscriptions)
+				.where(
+					and(
+						eq(subscriptions.tier, 'premium'),
+						eq(subscriptions.status, 'active')
+					)
+				)
+				.get(),
+			db
+				.select({ total: count() })
+				.from(auditLogs)
+				.where(
+					and(eq(auditLogs.level, 'error'), gte(auditLogs.createdAt, since))
+				)
+				.get(),
+		]);
+
+	return {
+		totalUsers: usersRow?.total ?? 0,
+		activeUsers: activeRow?.total ?? 0,
+		totalHouseholds: householdsRow?.total ?? 0,
+		premiumHouseholds: premiumRow?.total ?? 0,
+		recentErrorCount: errorsRow?.total ?? 0,
+	};
+};

--- a/services/api/src/hono/lib/adminSettings.ts
+++ b/services/api/src/hono/lib/adminSettings.ts
@@ -1,0 +1,67 @@
+import { settings, type Database } from '@pairflix/db';
+
+/** A nested object, e.g. { general: { siteName: 'Pairflix' }, recommendation: { llm_rerank: true } } --
+ * compiled by splitting each row's dot-path `key` and building the nested structure. */
+export type SettingsTree = Record<string, unknown>;
+
+const isPlainObject = (value: unknown): value is Record<string, unknown> =>
+	typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const setPath = (
+	tree: SettingsTree,
+	path: string[],
+	value: unknown
+): SettingsTree => {
+	const [key, ...rest] = path;
+	if (key === undefined) return tree;
+	if (rest.length === 0) return { ...tree, [key]: value };
+	const child = tree[key];
+	return {
+		...tree,
+		[key]: setPath(isPlainObject(child) ? child : {}, rest, value),
+	};
+};
+
+export const getSettings = async (db: Database): Promise<SettingsTree> => {
+	const rows = await db.select().from(settings);
+	return rows.reduce<SettingsTree>(
+		(tree, row) => setPath(tree, row.key.split('.'), row.value),
+		{}
+	);
+};
+
+const flattenLeaves = (
+	tree: SettingsTree,
+	prefix: string[] = []
+): { key: string; value: unknown }[] =>
+	Object.entries(tree).flatMap(([segment, value]) => {
+		const path = [...prefix, segment];
+		return isPlainObject(value)
+			? flattenLeaves(value, path)
+			: [{ key: path.join('.'), value }];
+	});
+
+export const updateSettings = async (
+	db: Database,
+	patch: SettingsTree
+): Promise<SettingsTree> => {
+	const now = new Date();
+
+	for (const { key, value } of flattenLeaves(patch)) {
+		await db
+			.insert(settings)
+			.values({
+				key,
+				value,
+				category: key.split('.')[0] ?? 'general',
+				createdAt: now,
+				updatedAt: now,
+			})
+			.onConflictDoUpdate({
+				target: settings.key,
+				set: { value, updatedAt: now },
+			});
+	}
+
+	return getSettings(db);
+};

--- a/services/api/src/hono/lib/adminUsers.ts
+++ b/services/api/src/hono/lib/adminUsers.ts
@@ -1,0 +1,433 @@
+import { users, sessions, authTokens, type Database } from '@pairflix/db';
+import { and, asc, count, desc, eq, gte, like, or } from 'drizzle-orm';
+import { hashPassword } from './crypto';
+import { newId, randomToken } from './id';
+import { FAILED_ATTEMPT_LIMIT, revokeAllSessions } from './session';
+
+/**
+ * Ported from the current Express admin user-management endpoints, with these deliberate
+ * departures:
+ *
+ * - `listUsers`'s `sortBy` is whitelisted through `sortColumns` below instead of splicing the
+ *   query string straight into `.orderBy()` -- the current Express admin panel takes `sortBy`
+ *   unvalidated from the request and passes it straight into the ORM's order clause.
+ * - `getLockedAccounts` reuses `FAILED_ATTEMPT_LIMIT` from `./session` (the same threshold
+ *   `/login` actually enforces) instead of a separate hardcoded `3`, which is what the current
+ *   Express admin panel's locked-accounts view uses.
+ * - `forcePasswordReset` only moves `status` to `'pending'` when the account is currently
+ *   `'active'` or `'inactive'` -- the current Express version overwrites `status`
+ *   unconditionally, which would silently un-suspend/un-ban an account as a side effect of a
+ *   password-reset action.
+ * - `exportUsersCsv` quotes every field and escapes embedded quotes; the current Express version
+ *   writes fields unquoted.
+ *
+ * No email sending here -- functions that issue a token return it to the route layer, which
+ * sends the email using the tokens/data returned.
+ */
+
+const adminUserColumns = {
+	id: users.id,
+	username: users.username,
+	email: users.email,
+	role: users.role,
+	status: users.status,
+	emailVerified: users.emailVerified,
+	failedLoginAttempts: users.failedLoginAttempts,
+	lockedUntil: users.lockedUntil,
+	lastLogin: users.lastLogin,
+	createdAt: users.createdAt,
+};
+
+const TOKEN_TTL_MS = 24 * 60 * 60 * 1000;
+
+export type AdminUserSummary = {
+	id: string;
+	username: string;
+	email: string;
+	role: 'user' | 'admin';
+	status: 'active' | 'inactive' | 'pending' | 'suspended' | 'banned';
+	emailVerified: boolean;
+	failedLoginAttempts: number;
+	lockedUntil: Date | null;
+	lastLogin: Date | null;
+	createdAt: Date;
+};
+
+const sortColumns = {
+	createdAt: users.createdAt,
+	username: users.username,
+	email: users.email,
+	lastLogin: users.lastLogin,
+};
+
+export const listUsers = async (
+	db: Database,
+	opts: {
+		page?: number;
+		limit?: number;
+		search?: string;
+		role?: 'user' | 'admin';
+		status?: AdminUserSummary['status'];
+		sortBy?: 'createdAt' | 'username' | 'email' | 'lastLogin';
+		sortOrder?: 'asc' | 'desc';
+	}
+): Promise<{
+	data: AdminUserSummary[];
+	pagination: {
+		page: number;
+		limit: number;
+		total: number;
+		totalPages: number;
+	};
+}> => {
+	const page = opts.page ?? 1;
+	const limit = opts.limit ?? 20;
+	const sortColumn = sortColumns[opts.sortBy ?? 'createdAt'];
+	const orderBy = opts.sortOrder === 'asc' ? asc(sortColumn) : desc(sortColumn);
+
+	const where = and(
+		opts.role ? eq(users.role, opts.role) : undefined,
+		opts.status ? eq(users.status, opts.status) : undefined,
+		opts.search
+			? or(
+					like(users.username, `%${opts.search}%`),
+					like(users.email, `%${opts.search}%`)
+				)
+			: undefined
+	);
+
+	const [data, totalRow] = await Promise.all([
+		db
+			.select(adminUserColumns)
+			.from(users)
+			.where(where)
+			.orderBy(orderBy)
+			.limit(limit)
+			.offset((page - 1) * limit),
+		db.select({ total: count() }).from(users).where(where).get(),
+	]);
+
+	const total = totalRow?.total ?? 0;
+	return {
+		data,
+		pagination: { page, limit, total, totalPages: Math.ceil(total / limit) },
+	};
+};
+
+export const getUserById = async (
+	db: Database,
+	userId: string
+): Promise<AdminUserSummary | null> => {
+	const row = await db
+		.select(adminUserColumns)
+		.from(users)
+		.where(eq(users.id, userId))
+		.get();
+	return row ?? null;
+};
+
+export class EmailTakenError extends Error {
+	constructor() {
+		super('email_taken');
+		this.name = 'EmailTakenError';
+	}
+}
+
+export class UsernameTakenError extends Error {
+	constructor() {
+		super('username_taken');
+		this.name = 'UsernameTakenError';
+	}
+}
+
+export const createUser = async (
+	db: Database,
+	input: {
+		username: string;
+		email: string;
+		password: string;
+		role?: 'user' | 'admin';
+		status?: AdminUserSummary['status'];
+	}
+): Promise<AdminUserSummary> => {
+	const existingEmail = await db
+		.select({ id: users.id })
+		.from(users)
+		.where(eq(users.email, input.email))
+		.get();
+	if (existingEmail) throw new EmailTakenError();
+
+	const existingUsername = await db
+		.select({ id: users.id })
+		.from(users)
+		.where(eq(users.username, input.username))
+		.get();
+	if (existingUsername) throw new UsernameTakenError();
+
+	const id = newId('user');
+	const role = input.role ?? 'user';
+	const status = input.status ?? 'active';
+	const now = new Date();
+	await db.insert(users).values({
+		id,
+		username: input.username,
+		email: input.email,
+		passwordHash: await hashPassword(input.password),
+		role,
+		status,
+		emailVerified: false,
+		failedLoginAttempts: 0,
+		createdAt: now,
+		updatedAt: now,
+	});
+
+	return {
+		id,
+		username: input.username,
+		email: input.email,
+		role,
+		status,
+		emailVerified: false,
+		failedLoginAttempts: 0,
+		lockedUntil: null,
+		lastLogin: null,
+		createdAt: now,
+	};
+};
+
+export const updateUser = async (
+	db: Database,
+	userId: string,
+	input: Partial<{
+		username: string;
+		email: string;
+		role: 'user' | 'admin';
+		status: AdminUserSummary['status'];
+	}>
+): Promise<AdminUserSummary | null> => {
+	const updated = await db
+		.update(users)
+		.set({ ...input, updatedAt: new Date() })
+		.where(eq(users.id, userId))
+		.returning(adminUserColumns)
+		.get();
+	return updated ?? null;
+};
+
+export const deleteUser = async (
+	db: Database,
+	userId: string
+): Promise<boolean> => {
+	const deleted = await db
+		.delete(users)
+		.where(eq(users.id, userId))
+		.returning({ id: users.id });
+	return deleted.length > 0;
+};
+
+export const resetPassword = async (
+	db: Database,
+	userId: string
+): Promise<{ newPassword: string } | null> => {
+	const newPassword = crypto.randomUUID().replace(/-/g, '').slice(0, 16);
+	const updated = await db
+		.update(users)
+		.set({
+			passwordHash: await hashPassword(newPassword),
+			updatedAt: new Date(),
+		})
+		.where(eq(users.id, userId))
+		.returning({ id: users.id })
+		.get();
+	if (!updated) return null;
+	return { newPassword };
+};
+
+export const forcePasswordReset = async (
+	db: Database,
+	userId: string
+): Promise<{ token: string } | null> => {
+	const user = await db
+		.select({ id: users.id, status: users.status })
+		.from(users)
+		.where(eq(users.id, userId))
+		.get();
+	if (!user) return null;
+
+	const token = randomToken();
+	const now = new Date();
+	await db.insert(authTokens).values({
+		id: token,
+		userId,
+		purpose: 'password_reset',
+		forcedByAdmin: true,
+		expiresAt: new Date(now.getTime() + TOKEN_TTL_MS),
+		createdAt: now,
+	});
+
+	if (user.status === 'active' || user.status === 'inactive') {
+		await db
+			.update(users)
+			.set({ status: 'pending', updatedAt: now })
+			.where(eq(users.id, userId));
+	}
+
+	return { token };
+};
+
+export const resendVerification = async (
+	db: Database,
+	userId: string
+): Promise<{ token: string } | 'already_verified' | 'not_found'> => {
+	const user = await db
+		.select({ id: users.id, emailVerified: users.emailVerified })
+		.from(users)
+		.where(eq(users.id, userId))
+		.get();
+	if (!user) return 'not_found';
+	if (user.emailVerified) return 'already_verified';
+
+	await db
+		.delete(authTokens)
+		.where(
+			and(eq(authTokens.userId, userId), eq(authTokens.purpose, 'verify_email'))
+		);
+
+	const token = randomToken();
+	await db.insert(authTokens).values({
+		id: token,
+		userId,
+		purpose: 'verify_email',
+		expiresAt: new Date(Date.now() + TOKEN_TTL_MS),
+		createdAt: new Date(),
+	});
+
+	return { token };
+};
+
+export const getLockedAccounts = async (
+	db: Database,
+	opts: { page?: number; limit?: number }
+): Promise<{
+	data: AdminUserSummary[];
+	pagination: {
+		page: number;
+		limit: number;
+		total: number;
+		totalPages: number;
+	};
+}> => {
+	const page = opts.page ?? 1;
+	const limit = opts.limit ?? 20;
+	const where = or(
+		gte(users.lockedUntil, new Date()),
+		gte(users.failedLoginAttempts, FAILED_ATTEMPT_LIMIT)
+	);
+
+	const [data, totalRow] = await Promise.all([
+		db
+			.select(adminUserColumns)
+			.from(users)
+			.where(where)
+			.orderBy(desc(users.failedLoginAttempts))
+			.limit(limit)
+			.offset((page - 1) * limit),
+		db.select({ total: count() }).from(users).where(where).get(),
+	]);
+
+	const total = totalRow?.total ?? 0;
+	return {
+		data,
+		pagination: { page, limit, total, totalPages: Math.ceil(total / limit) },
+	};
+};
+
+export const unlockUser = async (
+	db: Database,
+	userId: string
+): Promise<AdminUserSummary | null> => {
+	const updated = await db
+		.update(users)
+		.set({ failedLoginAttempts: 0, lockedUntil: null, updatedAt: new Date() })
+		.where(eq(users.id, userId))
+		.returning(adminUserColumns)
+		.get();
+	return updated ?? null;
+};
+
+export type AdminSessionSummary = {
+	id: string;
+	ipAddress: string | null;
+	userAgent: string | null;
+	deviceInfo: string | null;
+	createdAt: Date;
+	expiresAt: Date;
+};
+
+export const listUserSessions = async (
+	db: Database,
+	userId: string
+): Promise<AdminSessionSummary[]> => {
+	return db
+		.select({
+			id: sessions.id,
+			ipAddress: sessions.ipAddress,
+			userAgent: sessions.userAgent,
+			deviceInfo: sessions.deviceInfo,
+			createdAt: sessions.createdAt,
+			expiresAt: sessions.expiresAt,
+		})
+		.from(sessions)
+		.where(eq(sessions.userId, userId))
+		.orderBy(desc(sessions.createdAt));
+};
+
+export const terminateUserSession = async (
+	db: Database,
+	userId: string,
+	sessionId: string
+): Promise<boolean> => {
+	const deleted = await db
+		.delete(sessions)
+		.where(and(eq(sessions.id, sessionId), eq(sessions.userId, userId)))
+		.returning({ id: sessions.id });
+	return deleted.length > 0;
+};
+
+export const terminateAllUserSessions = async (
+	db: Database,
+	userId: string
+): Promise<number> => {
+	return revokeAllSessions(db, userId);
+};
+
+const csvField = (value: string): string => `"${value.replace(/"/g, '""')}"`;
+
+export const exportUsersCsv = async (
+	db: Database,
+	opts: { role?: 'user' | 'admin'; status?: AdminUserSummary['status'] }
+): Promise<string> => {
+	const where = and(
+		opts.role ? eq(users.role, opts.role) : undefined,
+		opts.status ? eq(users.status, opts.status) : undefined
+	);
+
+	const rows = await db.select(adminUserColumns).from(users).where(where);
+
+	const header = 'User ID,Username,Email,Status,Role,Created At,Last Login';
+	const lines = rows.map(row =>
+		[
+			row.id,
+			row.username,
+			row.email,
+			row.status,
+			row.role,
+			row.createdAt.toISOString(),
+			row.lastLogin ? row.lastLogin.toISOString() : 'Never',
+		]
+			.map(csvField)
+			.join(',')
+	);
+
+	return [header, ...lines].join('\n');
+};

--- a/services/api/src/hono/lib/billing.ts
+++ b/services/api/src/hono/lib/billing.ts
@@ -1,0 +1,75 @@
+import { subscriptions, type Database } from '@pairflix/db';
+import { eq } from 'drizzle-orm';
+import type { Bindings } from '../types';
+import { newId } from './id';
+
+const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
+
+export type CheckoutSession = { checkoutUrl: string };
+
+export const startCheckout = (
+	householdId: string,
+	tier: 'premium' = 'premium'
+): CheckoutSession => {
+	// TODO: replace with stripe.checkout.sessions.create(...) when Stripe goes live.
+	return {
+		checkoutUrl: `/billing/mock-checkout?household=${householdId}&tier=${tier}`,
+	};
+};
+
+export const isBillingMockEnabled = (env: Bindings): boolean => {
+	if (env.BILLING_MOCK_ENABLED === undefined) {
+		return env.ENVIRONMENT !== 'production';
+	}
+	return env.BILLING_MOCK_ENABLED === 'true';
+};
+
+export const cancelSubscription = async (
+	db: Database,
+	householdId: string
+): Promise<boolean> => {
+	const sub = await db
+		.select({ id: subscriptions.id })
+		.from(subscriptions)
+		.where(eq(subscriptions.householdId, householdId))
+		.get();
+	if (!sub) return false;
+
+	// currentPeriodEnd is left untouched -- access persists until the existing period rolls over.
+	await db
+		.update(subscriptions)
+		.set({ status: 'canceled', updatedAt: new Date() })
+		.where(eq(subscriptions.householdId, householdId));
+	return true;
+};
+
+/** No payment gate here -- the caller already checked `isBillingMockEnabled` and household
+ * ownership before invoking this; mirrors Express's deliberate no-gate demo behavior. */
+export const mockActivatePremium = async (
+	db: Database,
+	householdId: string
+): Promise<void> => {
+	const now = new Date();
+	const currentPeriodEnd = new Date(now.getTime() + THIRTY_DAYS_MS);
+
+	await db
+		.insert(subscriptions)
+		.values({
+			id: newId('sub'),
+			householdId,
+			tier: 'premium',
+			status: 'active',
+			currentPeriodEnd,
+			createdAt: now,
+			updatedAt: now,
+		})
+		.onConflictDoUpdate({
+			target: subscriptions.householdId,
+			set: {
+				tier: 'premium',
+				status: 'active',
+				currentPeriodEnd,
+				updatedAt: now,
+			},
+		});
+};

--- a/services/api/src/hono/lib/email.ts
+++ b/services/api/src/hono/lib/email.ts
@@ -71,3 +71,24 @@ export const sendPasswordResetEmail = async (
 		html: `<p>Reset your password:</p><p><a href="${link}">${link}</a></p><p>This link expires in 1 hour. If you didn't request this, ignore this email.</p>`,
 	});
 };
+
+/** Notifies a user their account status changed at an admin's hand -- suspend/ban/reactivate are
+ * the statuses worth a user-facing explanation; other transitions (e.g. 'pending') don't come
+ * through this admin-initiated path. */
+export const sendAccountStatusEmail = async (
+	env: Bindings,
+	email: string,
+	status: 'active' | 'suspended' | 'banned',
+	reason?: string
+): Promise<void> => {
+	const subject =
+		status === 'active'
+			? 'Your Pairflix account has been reactivated'
+			: `Your Pairflix account has been ${status}`;
+	const reasonHtml = reason ? `<p>Reason: ${reason}</p>` : '';
+	await sendEmail(env, {
+		to: email,
+		subject,
+		html: `<p>${subject}.</p>${reasonHtml}<p>Contact support if you have questions.</p>`,
+	});
+};

--- a/services/api/src/hono/lib/email.ts
+++ b/services/api/src/hono/lib/email.ts
@@ -46,6 +46,16 @@ export const sendEmail = async (
 const clientUrl = (env: Bindings): string =>
 	env.APP_CLIENT_URL ?? 'http://localhost:5173';
 
+/** Escapes free-text values before interpolating them into an HTML email body -- the only such
+ * value in this file is `sendAccountStatusEmail`'s admin-supplied `reason`. */
+const escapeHtml = (value: string): string =>
+	value
+		.replace(/&/g, '&amp;')
+		.replace(/</g, '&lt;')
+		.replace(/>/g, '&gt;')
+		.replace(/"/g, '&quot;')
+		.replace(/'/g, '&#39;');
+
 export const sendVerificationEmail = async (
 	env: Bindings,
 	email: string,
@@ -85,7 +95,7 @@ export const sendAccountStatusEmail = async (
 		status === 'active'
 			? 'Your Pairflix account has been reactivated'
 			: `Your Pairflix account has been ${status}`;
-	const reasonHtml = reason ? `<p>Reason: ${reason}</p>` : '';
+	const reasonHtml = reason ? `<p>Reason: ${escapeHtml(reason)}</p>` : '';
 	await sendEmail(env, {
 		to: email,
 		subject,

--- a/services/api/src/hono/lib/email.ts
+++ b/services/api/src/hono/lib/email.ts
@@ -82,6 +82,21 @@ export const sendPasswordResetEmail = async (
 	});
 };
 
+/** Delivers a plaintext password an admin just generated for a user (`lib/adminUsers.ts`'s
+ * `resetPassword`) -- a deliberate, existing product behavior (not a bug to design around): the
+ * admin chooses whether to email it or have it returned in the API response instead. */
+export const sendAdminPasswordResetEmail = async (
+	env: Bindings,
+	email: string,
+	newPassword: string
+): Promise<void> => {
+	await sendEmail(env, {
+		to: email,
+		subject: 'Your Pairflix password was reset',
+		html: `<p>An administrator reset your password.</p><p>Your new password: <strong>${newPassword}</strong></p><p>Sign in and change it as soon as possible.</p>`,
+	});
+};
+
 /** Notifies a user their account status changed at an admin's hand -- suspend/ban/reactivate are
  * the statuses worth a user-facing explanation; other transitions (e.g. 'pending') don't come
  * through this admin-initiated path. */

--- a/services/api/src/hono/lib/session.ts
+++ b/services/api/src/hono/lib/session.ts
@@ -7,6 +7,14 @@ import type { AppEnv } from '../types';
 
 const SESSION_TTL_MS = 30 * 24 * 60 * 60 * 1000;
 
+/** After this many bad login attempts in a row, an account is locked out for `LOCKOUT_MS`. Lives
+ * here (not `routes/auth.ts`, the only place that enforces it) so `lib/adminUsers.ts`'s
+ * locked-accounts view can use the exact same threshold instead of drifting out of sync with it --
+ * the current Express admin panel's locked-accounts list uses a hardcoded `3`, inconsistent with
+ * the real lockout threshold of `5` enforced at login. */
+export const FAILED_ATTEMPT_LIMIT = 5;
+export const LOCKOUT_MS = 15 * 60 * 1000;
+
 export const startSession = async (
 	c: Context<AppEnv>,
 	db: Database,
@@ -51,6 +59,22 @@ export const revokeOtherSessions = async (
 	const result = await db
 		.delete(sessions)
 		.where(and(eq(sessions.userId, userId), ne(sessions.id, keepSessionId)))
+		.returning({ id: sessions.id });
+	return result.length;
+};
+
+/** Deletes every session for a user, including whichever one the caller (an admin) is acting
+ * through -- there's no "keep this one" exception, unlike `revokeOtherSessions`. Used when an
+ * admin suspends/bans an account or explicitly terminates all of a user's sessions; unlike
+ * Express's decorative `UserSession` rows, deleting here takes effect immediately since a Hono
+ * session row is the live credential `sessionMiddleware` looks up on every request. */
+export const revokeAllSessions = async (
+	db: Database,
+	userId: string
+): Promise<number> => {
+	const result = await db
+		.delete(sessions)
+		.where(eq(sessions.userId, userId))
 		.returning({ id: sessions.id });
 	return result.length;
 };

--- a/services/api/src/hono/routes/admin.e2e.test.ts
+++ b/services/api/src/hono/routes/admin.e2e.test.ts
@@ -1,0 +1,424 @@
+import { env } from 'cloudflare:workers';
+import { content, contentReports, createDb } from '@pairflix/db';
+import { describe, expect, it } from 'vitest';
+import {
+	callApp,
+	createLoggedInAdmin,
+	createLoggedInUser,
+	loginUser,
+	postJson,
+	registerAndVerify,
+} from '../test/test-helpers';
+
+let counter = 0;
+const uniqueEmail = () => `admin-e2e-${Date.now()}-${counter++}@example.com`;
+const uniqueTmdbId = () => 800_000 + counter++;
+
+const seedContent = async (overrides: {
+	status?: 'active' | 'pending' | 'flagged' | 'removed';
+	reportedCount?: number;
+}): Promise<string> => {
+	const db = createDb(env.DB);
+	const id = `content_e2e_${Date.now()}_${counter++}`;
+	const now = new Date();
+	await db.insert(content).values({
+		id,
+		title: 'Some Movie',
+		type: 'movie',
+		tmdbId: uniqueTmdbId(),
+		status: overrides.status ?? 'pending',
+		reportedCount: overrides.reportedCount ?? 0,
+		providers: {},
+		createdAt: now,
+		updatedAt: now,
+	});
+	return id;
+};
+
+const seedReport = async (
+	contentId: string,
+	userId: string,
+	status: 'pending' | 'dismissed' | 'resolved' = 'pending'
+): Promise<string> => {
+	const db = createDb(env.DB);
+	const id = `report_e2e_${Date.now()}_${counter++}`;
+	const now = new Date();
+	await db.insert(contentReports).values({
+		id,
+		contentId,
+		userId,
+		reason: 'Inappropriate',
+		status,
+		createdAt: now,
+		updatedAt: now,
+	});
+	return id;
+};
+
+describe('admin routes -- authorization', () => {
+	it('rejects an unauthenticated caller', async () => {
+		const result = await callApp('/api/admin/users', {});
+		expect(result.status).toBe(401);
+	});
+
+	it('rejects a non-admin caller', async () => {
+		const { cookies } = await createLoggedInUser(uniqueEmail());
+		const result = await callApp('/api/admin/users', { cookies });
+		expect(result.status).toBe(403);
+	});
+});
+
+describe('admin routes -- user management', () => {
+	it('creates a user, then rejects a duplicate email', async () => {
+		const { cookies } = await createLoggedInAdmin(uniqueEmail());
+		const email = uniqueEmail();
+		const created = await postJson<{ id: string; email: string }>(
+			'/api/admin/users',
+			{ username: `au${Date.now()}`, email, password: 'Str0ngPass123' },
+			cookies
+		);
+		expect(created.status).toBe(201);
+		expect(created.body.email).toBe(email);
+
+		const duplicate = await postJson(
+			'/api/admin/users',
+			{ username: `au2${Date.now()}`, email, password: 'Str0ngPass123' },
+			cookies
+		);
+		expect(duplicate.status).toBe(409);
+	});
+
+	it('lists, fetches, updates, and deletes a user', async () => {
+		const { cookies } = await createLoggedInAdmin(uniqueEmail());
+		const { userId } = await createLoggedInUser(uniqueEmail());
+
+		const list = await callApp<{ data: Array<{ id: string }> }>(
+			'/api/admin/users?limit=100',
+			{ cookies }
+		);
+		expect(list.status).toBe(200);
+		expect(list.body.data.some(u => u.id === userId)).toBe(true);
+
+		const get = await callApp(`/api/admin/users/${userId}`, { cookies });
+		expect(get.status).toBe(200);
+
+		const updated = await postJson<{ username: string }>(
+			`/api/admin/users/${userId}`,
+			{ username: `renamed${Date.now()}` },
+			cookies,
+			{ method: 'PATCH' }
+		);
+		expect(updated.status).toBe(200);
+
+		const deleted = await postJson(`/api/admin/users/${userId}`, {}, cookies, {
+			method: 'DELETE',
+		});
+		expect(deleted.status).toBe(204);
+
+		const getAfterDelete = await callApp(`/api/admin/users/${userId}`, {
+			cookies,
+		});
+		expect(getAfterDelete.status).toBe(404);
+	});
+
+	it('404s updating an unknown user', async () => {
+		const { cookies } = await createLoggedInAdmin(uniqueEmail());
+		const result = await postJson(
+			'/api/admin/users/user_does_not_exist',
+			{ username: 'whoever' },
+			cookies,
+			{ method: 'PATCH' }
+		);
+		expect(result.status).toBe(404);
+	});
+
+	it('suspending a user terminates their sessions immediately', async () => {
+		const { cookies: adminCookies } = await createLoggedInAdmin(uniqueEmail());
+		const targetEmail = uniqueEmail();
+		const { userId, cookies: targetCookies } =
+			await createLoggedInUser(targetEmail);
+
+		const statusChange = await postJson(
+			`/api/admin/users/${userId}/status`,
+			{ status: 'suspended', reason: 'testing' },
+			adminCookies,
+			{ method: 'PATCH' }
+		);
+		expect(statusChange.status).toBe(200);
+
+		const meAfter = await callApp('/api/me', { cookies: targetCookies });
+		expect(meAfter.status).toBe(401);
+	});
+
+	it('returns the plaintext password when sendEmail is false', async () => {
+		const { cookies } = await createLoggedInAdmin(uniqueEmail());
+		const { userId } = await createLoggedInUser(uniqueEmail());
+
+		const result = await postJson<{ newPassword: string }>(
+			`/api/admin/users/${userId}/reset-password`,
+			{ sendEmail: false },
+			cookies
+		);
+		expect(result.status).toBe(200);
+		expect(result.body.newPassword.length).toBeGreaterThanOrEqual(8);
+	});
+
+	it('force-password-reset blocks login with the old password until reset', async () => {
+		const { cookies: adminCookies } = await createLoggedInAdmin(uniqueEmail());
+		const targetEmail = uniqueEmail();
+		const password = 'Str0ngPass123';
+		const { userId } = await createLoggedInUser(targetEmail, password);
+
+		const forced = await postJson(
+			`/api/admin/users/${userId}/force-password-reset`,
+			{},
+			adminCookies
+		);
+		expect(forced.status).toBe(200);
+
+		const relogin = await loginUser(targetEmail, password);
+		expect(relogin.status).toBe(403);
+	});
+
+	it('locked-accounts reflects the real login lockout threshold', async () => {
+		const { cookies } = await createLoggedInAdmin(uniqueEmail());
+		const targetEmail = uniqueEmail();
+		const { userId } = await registerAndVerify(targetEmail, 'Str0ngPass123');
+
+		for (let i = 0; i < 5; i++) {
+			await loginUser(targetEmail, 'WrongPassword1');
+		}
+
+		const locked = await callApp<{ data: Array<{ id: string }> }>(
+			'/api/admin/locked-accounts?limit=100',
+			{ cookies }
+		);
+		expect(locked.status).toBe(200);
+		expect(locked.body.data.some(u => u.id === userId)).toBe(true);
+
+		const unlocked = await postJson(
+			`/api/admin/users/${userId}/unlock`,
+			{},
+			cookies
+		);
+		expect(unlocked.status).toBe(200);
+
+		const lockedAfter = await callApp<{ data: Array<{ id: string }> }>(
+			'/api/admin/locked-accounts?limit=100',
+			{ cookies }
+		);
+		expect(lockedAfter.body.data.some(u => u.id === userId)).toBe(false);
+	});
+
+	it('lists and terminates a user session, which actually invalidates it', async () => {
+		const { cookies: adminCookies } = await createLoggedInAdmin(uniqueEmail());
+		const { userId, cookies: targetCookies } =
+			await createLoggedInUser(uniqueEmail());
+
+		const sessions = await callApp<{ sessions: Array<{ id: string }> }>(
+			`/api/admin/users/${userId}/sessions`,
+			{ cookies: adminCookies }
+		);
+		expect(sessions.status).toBe(200);
+		expect(sessions.body.sessions.length).toBeGreaterThan(0);
+		const sessionId = sessions.body.sessions[0]?.id;
+
+		const terminated = await postJson(
+			`/api/admin/users/${userId}/sessions/${sessionId}`,
+			{},
+			adminCookies,
+			{ method: 'DELETE' }
+		);
+		expect(terminated.status).toBe(204);
+
+		const meAfter = await callApp('/api/me', { cookies: targetCookies });
+		expect(meAfter.status).toBe(401);
+	});
+
+	it('exports users as CSV', async () => {
+		const { cookies } = await createLoggedInAdmin(uniqueEmail());
+		const result = await callApp('/api/admin/users/export', { cookies });
+		expect(result.status).toBe(200);
+		expect(result.response.headers.get('content-type')).toContain('text/csv');
+	});
+});
+
+describe('admin routes -- audit logs', () => {
+	it('lists audit logs and rejects an invalid level', async () => {
+		const { cookies } = await createLoggedInAdmin(uniqueEmail());
+
+		const list = await callApp<{ data: unknown[] }>('/api/admin/audit-logs', {
+			cookies,
+		});
+		expect(list.status).toBe(200);
+		expect(Array.isArray(list.body.data)).toBe(true);
+
+		const invalid = await callApp('/api/admin/audit-logs/not-a-level', {
+			cookies,
+		});
+		expect(invalid.status).toBe(400);
+
+		const byLevel = await callApp<{ data: unknown[] }>(
+			'/api/admin/audit-logs/info',
+			{ cookies }
+		);
+		expect(byLevel.status).toBe(200);
+	});
+
+	it('returns log sources and stats', async () => {
+		const { cookies } = await createLoggedInAdmin(uniqueEmail());
+
+		const sources = await callApp<{ sources: string[] }>(
+			'/api/admin/audit-logs/sources',
+			{ cookies }
+		);
+		expect(sources.status).toBe(200);
+		expect(Array.isArray(sources.body.sources)).toBe(true);
+
+		const stats = await callApp<{ total: number; byLevel: object }>(
+			'/api/admin/audit-logs/stats',
+			{ cookies }
+		);
+		expect(stats.status).toBe(200);
+		expect(typeof stats.body.total).toBe('number');
+		expect(stats.body.byLevel).toHaveProperty('info');
+	});
+});
+
+describe('admin routes -- settings', () => {
+	it('patches and reads back nested settings without clobbering unrelated keys', async () => {
+		const { cookies } = await createLoggedInAdmin(uniqueEmail());
+
+		const first = await postJson(
+			'/api/admin/settings',
+			{ general: { siteName: 'Pairflix Test' } },
+			cookies,
+			{ method: 'PATCH' }
+		);
+		expect(first.status).toBe(200);
+
+		const second = await postJson<{
+			general: { siteName: string };
+			recommendation: { llm_rerank: boolean };
+		}>(
+			'/api/admin/settings',
+			{ recommendation: { llm_rerank: true } },
+			cookies,
+			{ method: 'PATCH' }
+		);
+		expect(second.status).toBe(200);
+		expect(second.body.general.siteName).toBe('Pairflix Test');
+		expect(second.body.recommendation.llm_rerank).toBe(true);
+	});
+});
+
+describe('admin routes -- content moderation', () => {
+	it('flags, approves, and removes content', async () => {
+		const { cookies } = await createLoggedInAdmin(uniqueEmail());
+		const contentId = await seedContent({});
+
+		const flagged = await postJson<{ status: string }>(
+			`/api/admin/content/${contentId}/flag`,
+			{},
+			cookies,
+			{ method: 'PATCH' }
+		);
+		expect(flagged.status).toBe(200);
+		expect(flagged.body.status).toBe('flagged');
+
+		const approved = await postJson<{ status: string }>(
+			`/api/admin/content/${contentId}/approve`,
+			{},
+			cookies,
+			{ method: 'PATCH' }
+		);
+		expect(approved.body.status).toBe('active');
+
+		const removed = await postJson<{
+			status: string;
+			removalReason: string | null;
+		}>(
+			`/api/admin/content/${contentId}/remove`,
+			{ reason: 'not appropriate' },
+			cookies,
+			{ method: 'PATCH' }
+		);
+		expect(removed.body.status).toBe('removed');
+		expect(removed.body.removalReason).toBe('not appropriate');
+
+		const list = await callApp<{ data: Array<{ id: string }> }>(
+			'/api/admin/content?status=removed',
+			{ cookies }
+		);
+		expect(list.body.data.some(row => row.id === contentId)).toBe(true);
+	});
+
+	it('dismissing a report decrements reportedCount once, not on repeat dismissal', async () => {
+		const { cookies } = await createLoggedInAdmin(uniqueEmail());
+		const { userId: reporterId } = await createLoggedInUser(uniqueEmail());
+		const contentId = await seedContent({ reportedCount: 2 });
+		const reportId = await seedReport(contentId, reporterId, 'pending');
+
+		const reports = await callApp<{
+			reports: Array<{ id: string; reporterUsername: string }>;
+		}>(`/api/admin/content/${contentId}/reports`, { cookies });
+		expect(reports.status).toBe(200);
+		expect(reports.body.reports.some(r => r.id === reportId)).toBe(true);
+
+		const firstDismiss = await postJson(
+			`/api/admin/reports/${reportId}/dismiss`,
+			{},
+			cookies,
+			{ method: 'PATCH' }
+		);
+		expect(firstDismiss.status).toBe(200);
+
+		const afterFirst = await callApp<{
+			data: Array<{ id: string; reportedCount: number }>;
+		}>('/api/admin/content?search=Some Movie', { cookies });
+		expect(
+			afterFirst.body.data.find(row => row.id === contentId)?.reportedCount
+		).toBe(1);
+
+		const secondDismiss = await postJson(
+			`/api/admin/reports/${reportId}/dismiss`,
+			{},
+			cookies,
+			{ method: 'PATCH' }
+		);
+		expect(secondDismiss.status).toBe(200);
+
+		const afterSecond = await callApp<{
+			data: Array<{ id: string; reportedCount: number }>;
+		}>('/api/admin/content?search=Some Movie', { cookies });
+		expect(
+			afterSecond.body.data.find(row => row.id === contentId)?.reportedCount
+		).toBe(1);
+	});
+
+	it('404s dismissing an unknown report', async () => {
+		const { cookies } = await createLoggedInAdmin(uniqueEmail());
+		const result = await postJson(
+			'/api/admin/reports/report_does_not_exist/dismiss',
+			{},
+			cookies,
+			{ method: 'PATCH' }
+		);
+		expect(result.status).toBe(404);
+	});
+});
+
+describe('admin routes -- dashboard', () => {
+	it('returns dashboard stats', async () => {
+		const { cookies } = await createLoggedInAdmin(uniqueEmail());
+		const result = await callApp<{
+			totalUsers: number;
+			totalHouseholds: number;
+			premiumHouseholds: number;
+		}>('/api/admin/dashboard-stats', { cookies });
+		expect(result.status).toBe(200);
+		expect(typeof result.body.totalUsers).toBe('number');
+		expect(typeof result.body.totalHouseholds).toBe('number');
+		expect(typeof result.body.premiumHouseholds).toBe('number');
+	});
+});

--- a/services/api/src/hono/routes/admin.ts
+++ b/services/api/src/hono/routes/admin.ts
@@ -1,0 +1,539 @@
+import { createDb } from '@pairflix/db';
+import {
+	AdminAuditLogQuerySchema,
+	AdminAuditLogRotationRequestSchema,
+	AdminChangeStatusRequestSchema,
+	AdminContentListQuerySchema,
+	AdminCreateUserRequestSchema,
+	AdminPaginationQuerySchema,
+	AdminRemoveContentRequestSchema,
+	AdminResetPasswordRequestSchema,
+	AdminSettingsPatchRequestSchema,
+	AdminUpdateContentRequestSchema,
+	AdminUpdateUserRequestSchema,
+	AdminUserListQuerySchema,
+	AdminUsersExportQuerySchema,
+} from '@pairflix/lib.validation';
+import { Hono } from 'hono';
+import { auditInfo, auditWarn } from '../lib/audit';
+import {
+	cleanupOldLogs,
+	getAuditLogStats,
+	getLogSources,
+	listAuditLogs,
+	type AuditLogEntry,
+} from '../lib/adminAuditLogs';
+import {
+	approveContent,
+	dismissReport,
+	flagContent,
+	getContentReports,
+	listContent,
+	removeContent,
+	updateContent,
+} from '../lib/adminContent';
+import { getDashboardStats } from '../lib/adminDashboard';
+import { getSettings, updateSettings } from '../lib/adminSettings';
+import {
+	EmailTakenError,
+	UsernameTakenError,
+	createUser,
+	deleteUser,
+	exportUsersCsv,
+	forcePasswordReset,
+	getLockedAccounts,
+	getUserById,
+	listUserSessions,
+	listUsers,
+	resendVerification,
+	resetPassword,
+	terminateAllUserSessions,
+	terminateUserSession,
+	unlockUser,
+	updateUser,
+} from '../lib/adminUsers';
+import {
+	sendAccountStatusEmail,
+	sendAdminPasswordResetEmail,
+	sendPasswordResetEmail,
+	sendVerificationEmail,
+} from '../lib/email';
+import { requireAdmin, requireAuth } from '../middleware/auth';
+import type { AppEnv } from '../types';
+
+const AUDIT_LOG_LEVELS: AuditLogEntry['level'][] = [
+	'info',
+	'warn',
+	'error',
+	'debug',
+];
+
+const isAuditLogLevel = (value: string): value is AuditLogEntry['level'] =>
+	AUDIT_LOG_LEVELS.some(level => level === value);
+
+export const adminRoutes = new Hono<AppEnv>();
+
+adminRoutes.use('*', requireAuth, requireAdmin);
+
+adminRoutes.get('/dashboard-stats', async c => {
+	const db = createDb(c.env.DB);
+	return c.json(await getDashboardStats(db));
+});
+
+adminRoutes.get('/users/export', async c => {
+	const parsed = AdminUsersExportQuerySchema.safeParse(c.req.query());
+	if (!parsed.success) {
+		return c.json(
+			{
+				error: 'Invalid input',
+				details: parsed.error.issues.map(i => i.message),
+			},
+			400
+		);
+	}
+	const db = createDb(c.env.DB);
+	const csv = await exportUsersCsv(db, parsed.data);
+	await auditInfo(db, 'Exported users CSV', 'admin', parsed.data);
+	return c.text(csv, 200, {
+		'Content-Type': 'text/csv',
+		'Content-Disposition': 'attachment; filename="users.csv"',
+	});
+});
+
+adminRoutes.get('/users', async c => {
+	const parsed = AdminUserListQuerySchema.safeParse(c.req.query());
+	if (!parsed.success) {
+		return c.json(
+			{
+				error: 'Invalid input',
+				details: parsed.error.issues.map(i => i.message),
+			},
+			400
+		);
+	}
+	const db = createDb(c.env.DB);
+	return c.json(await listUsers(db, parsed.data));
+});
+
+adminRoutes.post('/users', async c => {
+	const parsed = AdminCreateUserRequestSchema.safeParse(
+		await c.req.json().catch(() => null)
+	);
+	if (!parsed.success) {
+		return c.json(
+			{
+				error: 'Invalid input',
+				details: parsed.error.issues.map(i => i.message),
+			},
+			400
+		);
+	}
+	const db = createDb(c.env.DB);
+	try {
+		const user = await createUser(db, parsed.data);
+		await auditInfo(db, 'Admin created user', 'admin', {
+			userId: user.id,
+			email: user.email,
+		});
+		return c.json(user, 201);
+	} catch (error) {
+		if (error instanceof EmailTakenError) {
+			return c.json({ error: 'email_taken' }, 409);
+		}
+		if (error instanceof UsernameTakenError) {
+			return c.json({ error: 'username_taken' }, 409);
+		}
+		throw error;
+	}
+});
+
+adminRoutes.get('/locked-accounts', async c => {
+	const parsed = AdminPaginationQuerySchema.safeParse(c.req.query());
+	if (!parsed.success) {
+		return c.json(
+			{
+				error: 'Invalid input',
+				details: parsed.error.issues.map(i => i.message),
+			},
+			400
+		);
+	}
+	const db = createDb(c.env.DB);
+	return c.json(await getLockedAccounts(db, parsed.data));
+});
+
+adminRoutes.get('/users/:userId', async c => {
+	const db = createDb(c.env.DB);
+	const user = await getUserById(db, c.req.param('userId'));
+	if (!user) return c.json({ error: 'user_not_found' }, 404);
+	return c.json(user);
+});
+
+adminRoutes.patch('/users/:userId', async c => {
+	const parsed = AdminUpdateUserRequestSchema.safeParse(
+		await c.req.json().catch(() => null)
+	);
+	if (!parsed.success) {
+		return c.json(
+			{
+				error: 'Invalid input',
+				details: parsed.error.issues.map(i => i.message),
+			},
+			400
+		);
+	}
+	const db = createDb(c.env.DB);
+	const userId = c.req.param('userId');
+	const user = await updateUser(db, userId, parsed.data);
+	if (!user) return c.json({ error: 'user_not_found' }, 404);
+	await auditInfo(db, 'Admin updated user', 'admin', {
+		userId,
+		changes: parsed.data,
+	});
+	return c.json(user);
+});
+
+adminRoutes.delete('/users/:userId', async c => {
+	const db = createDb(c.env.DB);
+	const userId = c.req.param('userId');
+	const deleted = await deleteUser(db, userId);
+	if (!deleted) return c.json({ error: 'user_not_found' }, 404);
+	await auditWarn(db, 'Admin deleted user', 'admin', { userId });
+	return c.body(null, 204);
+});
+
+/**
+ * Consolidates Express's two competing status-change endpoints (`status` and `status-enhanced`,
+ * which had materially different side effects) into one that always does the fuller behavior:
+ * revoke sessions on suspend/ban, and notify the user by email for the three statuses worth an
+ * explanation (active/suspended/banned -- see `lib/email.ts`'s `sendAccountStatusEmail`).
+ */
+adminRoutes.patch('/users/:userId/status', async c => {
+	const parsed = AdminChangeStatusRequestSchema.safeParse(
+		await c.req.json().catch(() => null)
+	);
+	if (!parsed.success) {
+		return c.json(
+			{
+				error: 'Invalid input',
+				details: parsed.error.issues.map(i => i.message),
+			},
+			400
+		);
+	}
+	const db = createDb(c.env.DB);
+	const userId = c.req.param('userId');
+	const { status, reason } = parsed.data;
+	const user = await updateUser(db, userId, { status });
+	if (!user) return c.json({ error: 'user_not_found' }, 404);
+
+	if (status === 'suspended' || status === 'banned') {
+		await terminateAllUserSessions(db, userId);
+	}
+	if (status === 'active' || status === 'suspended' || status === 'banned') {
+		await sendAccountStatusEmail(c.env, user.email, status, reason);
+	}
+	await auditWarn(db, 'Admin changed user status', 'admin', {
+		userId,
+		status,
+		reason,
+	});
+	return c.json(user);
+});
+
+adminRoutes.post('/users/:userId/reset-password', async c => {
+	const parsed = AdminResetPasswordRequestSchema.safeParse(
+		await c.req.json().catch(() => ({}))
+	);
+	if (!parsed.success) {
+		return c.json(
+			{
+				error: 'Invalid input',
+				details: parsed.error.issues.map(i => i.message),
+			},
+			400
+		);
+	}
+	const db = createDb(c.env.DB);
+	const userId = c.req.param('userId');
+	const result = await resetPassword(db, userId);
+	if (!result) return c.json({ error: 'user_not_found' }, 404);
+
+	await auditWarn(db, 'Admin reset user password', 'admin', {
+		userId,
+		emailed: parsed.data.sendEmail,
+	});
+	if (!parsed.data.sendEmail) {
+		return c.json({ newPassword: result.newPassword });
+	}
+	const user = await getUserById(db, userId);
+	if (user) {
+		await sendAdminPasswordResetEmail(c.env, user.email, result.newPassword);
+	}
+	return c.json({ ok: true });
+});
+
+adminRoutes.post('/users/:userId/force-password-reset', async c => {
+	const db = createDb(c.env.DB);
+	const userId = c.req.param('userId');
+	const result = await forcePasswordReset(db, userId);
+	if (!result) return c.json({ error: 'user_not_found' }, 404);
+
+	const user = await getUserById(db, userId);
+	if (user) await sendPasswordResetEmail(c.env, user.email, result.token);
+	await auditWarn(db, 'Admin forced password reset', 'admin', { userId });
+	return c.json({ ok: true });
+});
+
+adminRoutes.post('/users/:userId/resend-verification', async c => {
+	const db = createDb(c.env.DB);
+	const userId = c.req.param('userId');
+	const result = await resendVerification(db, userId);
+	if (result === 'not_found') return c.json({ error: 'user_not_found' }, 404);
+	if (result === 'already_verified') {
+		return c.json({ error: 'already_verified' }, 400);
+	}
+
+	const user = await getUserById(db, userId);
+	if (user) await sendVerificationEmail(c.env, user.email, result.token);
+	await auditInfo(db, 'Admin resent verification email', 'admin', { userId });
+	return c.json({ ok: true });
+});
+
+adminRoutes.post('/users/:userId/unlock', async c => {
+	const db = createDb(c.env.DB);
+	const userId = c.req.param('userId');
+	const user = await unlockUser(db, userId);
+	if (!user) return c.json({ error: 'user_not_found' }, 404);
+	await auditInfo(db, 'Admin unlocked account', 'admin', { userId });
+	return c.json(user);
+});
+
+adminRoutes.get('/users/:userId/sessions', async c => {
+	const db = createDb(c.env.DB);
+	const userId = c.req.param('userId');
+	const user = await getUserById(db, userId);
+	if (!user) return c.json({ error: 'user_not_found' }, 404);
+	return c.json({ sessions: await listUserSessions(db, userId) });
+});
+
+adminRoutes.delete('/users/:userId/sessions/:sessionId', async c => {
+	const db = createDb(c.env.DB);
+	const userId = c.req.param('userId');
+	const deleted = await terminateUserSession(
+		db,
+		userId,
+		c.req.param('sessionId')
+	);
+	if (!deleted) return c.json({ error: 'session_not_found' }, 404);
+	await auditWarn(db, 'Admin terminated session', 'admin', {
+		userId,
+		sessionId: c.req.param('sessionId'),
+	});
+	return c.body(null, 204);
+});
+
+adminRoutes.delete('/users/:userId/sessions', async c => {
+	const db = createDb(c.env.DB);
+	const userId = c.req.param('userId');
+	const count = await terminateAllUserSessions(db, userId);
+	await auditWarn(db, 'Admin terminated all sessions', 'admin', {
+		userId,
+		count,
+	});
+	return c.json({ terminated: count });
+});
+
+adminRoutes.get('/audit-logs/sources', async c => {
+	const db = createDb(c.env.DB);
+	return c.json({ sources: await getLogSources(db) });
+});
+
+adminRoutes.get('/audit-logs/stats', async c => {
+	const db = createDb(c.env.DB);
+	return c.json(await getAuditLogStats(db));
+});
+
+adminRoutes.post('/audit-logs/rotation', async c => {
+	const parsed = AdminAuditLogRotationRequestSchema.safeParse(
+		await c.req.json().catch(() => ({}))
+	);
+	if (!parsed.success) {
+		return c.json(
+			{
+				error: 'Invalid input',
+				details: parsed.error.issues.map(i => i.message),
+			},
+			400
+		);
+	}
+	const db = createDb(c.env.DB);
+	const deleted = await cleanupOldLogs(db, parsed.data.retentionDays);
+	await auditInfo(db, 'Admin ran audit log rotation', 'admin', deleted);
+	return c.json({ deleted });
+});
+
+adminRoutes.get('/audit-logs/:level', async c => {
+	const level = c.req.param('level');
+	if (!isAuditLogLevel(level)) {
+		return c.json(
+			{
+				error: 'Invalid input',
+				details: [`level must be one of: ${AUDIT_LOG_LEVELS.join(', ')}`],
+			},
+			400
+		);
+	}
+	const parsed = AdminAuditLogQuerySchema.safeParse(c.req.query());
+	if (!parsed.success) {
+		return c.json(
+			{
+				error: 'Invalid input',
+				details: parsed.error.issues.map(i => i.message),
+			},
+			400
+		);
+	}
+	const db = createDb(c.env.DB);
+	return c.json(await listAuditLogs(db, { ...parsed.data, level }));
+});
+
+adminRoutes.get('/audit-logs', async c => {
+	const parsed = AdminAuditLogQuerySchema.safeParse(c.req.query());
+	if (!parsed.success) {
+		return c.json(
+			{
+				error: 'Invalid input',
+				details: parsed.error.issues.map(i => i.message),
+			},
+			400
+		);
+	}
+	const db = createDb(c.env.DB);
+	return c.json(await listAuditLogs(db, parsed.data));
+});
+
+adminRoutes.get('/settings', async c => {
+	const db = createDb(c.env.DB);
+	return c.json(await getSettings(db));
+});
+
+adminRoutes.patch('/settings', async c => {
+	const parsed = AdminSettingsPatchRequestSchema.safeParse(
+		await c.req.json().catch(() => null)
+	);
+	if (!parsed.success) {
+		return c.json(
+			{
+				error: 'Invalid input',
+				details: parsed.error.issues.map(i => i.message),
+			},
+			400
+		);
+	}
+	const db = createDb(c.env.DB);
+	const settings = await updateSettings(db, parsed.data);
+	await auditInfo(db, 'Admin updated settings', 'admin', {
+		keys: Object.keys(parsed.data),
+	});
+	return c.json(settings);
+});
+
+adminRoutes.get('/content', async c => {
+	const parsed = AdminContentListQuerySchema.safeParse(c.req.query());
+	if (!parsed.success) {
+		return c.json(
+			{
+				error: 'Invalid input',
+				details: parsed.error.issues.map(i => i.message),
+			},
+			400
+		);
+	}
+	const db = createDb(c.env.DB);
+	return c.json(await listContent(db, parsed.data));
+});
+
+adminRoutes.get('/content/:contentId/reports', async c => {
+	const db = createDb(c.env.DB);
+	return c.json({
+		reports: await getContentReports(db, c.req.param('contentId')),
+	});
+});
+
+adminRoutes.patch('/content/:contentId', async c => {
+	const parsed = AdminUpdateContentRequestSchema.safeParse(
+		await c.req.json().catch(() => null)
+	);
+	if (!parsed.success) {
+		return c.json(
+			{
+				error: 'Invalid input',
+				details: parsed.error.issues.map(i => i.message),
+			},
+			400
+		);
+	}
+	const db = createDb(c.env.DB);
+	const contentId = c.req.param('contentId');
+	const updated = await updateContent(db, contentId, parsed.data);
+	if (!updated) return c.json({ error: 'content_not_found' }, 404);
+	await auditInfo(db, 'Admin updated content', 'admin', {
+		contentId,
+		changes: parsed.data,
+	});
+	return c.json(updated);
+});
+
+adminRoutes.patch('/content/:contentId/flag', async c => {
+	const db = createDb(c.env.DB);
+	const contentId = c.req.param('contentId');
+	const updated = await flagContent(db, contentId);
+	if (!updated) return c.json({ error: 'content_not_found' }, 404);
+	await auditWarn(db, 'Admin flagged content', 'admin', { contentId });
+	return c.json(updated);
+});
+
+adminRoutes.patch('/content/:contentId/approve', async c => {
+	const db = createDb(c.env.DB);
+	const contentId = c.req.param('contentId');
+	const updated = await approveContent(db, contentId);
+	if (!updated) return c.json({ error: 'content_not_found' }, 404);
+	await auditInfo(db, 'Admin approved content', 'admin', { contentId });
+	return c.json(updated);
+});
+
+adminRoutes.patch('/content/:contentId/remove', async c => {
+	const parsed = AdminRemoveContentRequestSchema.safeParse(
+		await c.req.json().catch(() => ({}))
+	);
+	if (!parsed.success) {
+		return c.json(
+			{
+				error: 'Invalid input',
+				details: parsed.error.issues.map(i => i.message),
+			},
+			400
+		);
+	}
+	const db = createDb(c.env.DB);
+	const contentId = c.req.param('contentId');
+	const updated = await removeContent(db, contentId, parsed.data.reason);
+	if (!updated) return c.json({ error: 'content_not_found' }, 404);
+	await auditWarn(db, 'Admin removed content', 'admin', {
+		contentId,
+		reason: parsed.data.reason,
+	});
+	return c.json(updated);
+});
+
+adminRoutes.patch('/reports/:reportId/dismiss', async c => {
+	const db = createDb(c.env.DB);
+	const reportId = c.req.param('reportId');
+	const dismissed = await dismissReport(db, reportId);
+	if (!dismissed) return c.json({ error: 'report_not_found' }, 404);
+	await auditInfo(db, 'Admin dismissed content report', 'admin', {
+		reportId,
+	});
+	return c.json(dismissed);
+});

--- a/services/api/src/hono/routes/auth.ts
+++ b/services/api/src/hono/routes/auth.ts
@@ -14,7 +14,12 @@ import { auditInfo } from '../lib/audit';
 import { hashPassword, timingSafeEqual, verifyPassword } from '../lib/crypto';
 import { sendPasswordResetEmail, sendVerificationEmail } from '../lib/email';
 import { newId, randomToken } from '../lib/id';
-import { endSession, startSession } from '../lib/session';
+import {
+	FAILED_ATTEMPT_LIMIT,
+	LOCKOUT_MS,
+	endSession,
+	startSession,
+} from '../lib/session';
 import { verifySecondFactor } from '../lib/two-factor';
 import { requireAuth } from '../middleware/auth';
 import { ipRateLimit } from '../middleware/ip-rate-limit';
@@ -24,9 +29,6 @@ export const authRoutes = new Hono<AppEnv>();
 
 const VERIFY_EMAIL_TTL_MS = 24 * 60 * 60 * 1000;
 const PASSWORD_RESET_TTL_MS = 60 * 60 * 1000;
-/** After this many bad attempts in a row, the account is locked out for `LOCKOUT_MS`. */
-const FAILED_ATTEMPT_LIMIT = 5;
-const LOCKOUT_MS = 15 * 60 * 1000;
 /** Per-IP budget for the unauthenticated routes below ('/register', '/forgot-password',
  * '/resend-verification') -- '/login' already has its own account-level lockout above and isn't
  * throttled here. */

--- a/services/api/src/hono/routes/households.e2e.test.ts
+++ b/services/api/src/hono/routes/households.e2e.test.ts
@@ -811,3 +811,100 @@ describe('GET /api/households/:id/pick-events/stats', () => {
 		expect(stats.body.providerClicksBySlug.netflix).toBe(1);
 	});
 });
+
+describe('GET /api/households/:id/entitlements', () => {
+	it('rejects a non-member', async () => {
+		const { cookies: ownerCookies } = await createLoggedInUser(uniqueEmail());
+		const { cookies: outsiderCookies } =
+			await createLoggedInUser(uniqueEmail());
+		const householdId = await createHousehold(ownerCookies);
+
+		const result = await callApp(
+			`/api/households/${householdId}/entitlements`,
+			{
+				cookies: outsiderCookies,
+			}
+		);
+		expect(result.status).toBe(403);
+	});
+
+	it('returns free-tier defaults for a new household', async () => {
+		const { cookies } = await createLoggedInUser(uniqueEmail());
+		const householdId = await createHousehold(cookies);
+
+		const result = await callApp<{
+			tier: string;
+			dailyPickLimit: number;
+			canUseMultiRegion: boolean;
+		}>(`/api/households/${householdId}/entitlements`, { cookies });
+		expect(result.status).toBe(200);
+		expect(result.body.tier).toBe('free');
+		expect(result.body.dailyPickLimit).toBe(3);
+		expect(result.body.canUseMultiRegion).toBe(false);
+	});
+});
+
+describe('billing routes', () => {
+	it('POST /:id/billing/checkout is owner-only and returns a checkout URL', async () => {
+		const { cookies: ownerCookies } = await createLoggedInUser(uniqueEmail());
+		const { cookies: memberCookies } = await createLoggedInUser(uniqueEmail());
+		const householdId = await createHousehold(ownerCookies);
+		const invite = await postJson<{ invite: { token: string } }>(
+			`/api/households/${householdId}/invites`,
+			{},
+			ownerCookies
+		);
+		await postJson(
+			`/api/households/invites/${invite.body.invite.token}/accept`,
+			{},
+			memberCookies
+		);
+
+		const asMember = await postJson(
+			`/api/households/${householdId}/billing/checkout`,
+			{},
+			memberCookies
+		);
+		expect(asMember.status).toBe(403);
+
+		const asOwner = await postJson<{ checkoutUrl: string }>(
+			`/api/households/${householdId}/billing/checkout`,
+			{},
+			ownerCookies
+		);
+		expect(asOwner.status).toBe(200);
+		expect(asOwner.body.checkoutUrl).toContain(householdId);
+	});
+
+	it('mock-activate flips the household to premium, cancel reverts it', async () => {
+		const { cookies } = await createLoggedInUser(uniqueEmail());
+		const householdId = await createHousehold(cookies);
+
+		const activated = await postJson(
+			`/api/households/${householdId}/billing/mock-activate`,
+			{},
+			cookies
+		);
+		expect(activated.status).toBe(200);
+
+		const afterActivate = await callApp<{
+			tier: string;
+			canUseMultiRegion: boolean;
+		}>(`/api/households/${householdId}/entitlements`, { cookies });
+		expect(afterActivate.body.tier).toBe('premium');
+		expect(afterActivate.body.canUseMultiRegion).toBe(true);
+
+		const canceled = await postJson(
+			`/api/households/${householdId}/billing/cancel`,
+			{},
+			cookies
+		);
+		expect(canceled.status).toBe(204);
+
+		const afterCancel = await callApp<{ tier: string }>(
+			`/api/households/${householdId}/entitlements`,
+			{ cookies }
+		);
+		expect(afterCancel.body.tier).toBe('free');
+	});
+});

--- a/services/api/src/hono/routes/households.ts
+++ b/services/api/src/hono/routes/households.ts
@@ -12,6 +12,13 @@ import {
 	type PickRequest,
 } from '@pairflix/lib.validation';
 import { Hono } from 'hono';
+import {
+	cancelSubscription,
+	isBillingMockEnabled,
+	mockActivatePremium,
+	startCheckout,
+} from '../lib/billing';
+import { getEntitlements } from '../lib/entitlements';
 import { listHistory, setEnjoyed } from '../lib/history';
 import {
 	InviteInvalidError,
@@ -45,10 +52,13 @@ import type { AppEnv } from '../types';
 
 /**
  * Covers what the current Express `household.routes.ts` mounts under `/api/households` (CRUD,
- * invites, pick, commit, provider-launch, pick-events) plus `history.routes.ts`'s two routes --
- * minus `GET /:id/entitlements`, which stays deferred to billing/admin. Also mounts accept-invite,
- * which exists in Express (`householdInvites.routes.ts`) but is never actually registered on the
- * app router there -- without it, an invite can be created but never accepted.
+ * invites, pick, commit, provider-launch, pick-events) plus `history.routes.ts`'s two routes and
+ * `billing.routes.ts`'s household-scoped entitlements/checkout/cancel/mock-activate (the flat
+ * `/api/billing/*` + body `household_id` shape in Express becomes `/:id/billing/*`, matching every
+ * other household-scoped route here and reusing `requireHouseholdOwner` instead of Express's own
+ * per-handler owner check). Also mounts accept-invite, which exists in Express
+ * (`householdInvites.routes.ts`) but is never actually registered on the app router there --
+ * without it, an invite can be created but never accepted.
  *
  * `/:id/history` and `/:id/picks/:tmdbId/launch` both run `enforceRegionLock` even though neither
  * is the pick endpoint -- they're the other two places a caller picks which region's provider data
@@ -407,5 +417,42 @@ householdsRoutes.get(
 			parsed.data.windowDays
 		);
 		return c.json(stats);
+	}
+);
+
+householdsRoutes.get('/:id/entitlements', requireHouseholdMember, async c => {
+	const householdId = c.req.param('id');
+	const db = createDb(c.env.DB);
+	const entitlements = await getEntitlements(db, householdId);
+	return c.json(entitlements);
+});
+
+householdsRoutes.post('/:id/billing/checkout', requireHouseholdOwner, c => {
+	const householdId = c.req.param('id');
+	return c.json(startCheckout(householdId));
+});
+
+householdsRoutes.post('/:id/billing/cancel', requireHouseholdOwner, async c => {
+	const householdId = c.req.param('id');
+	const db = createDb(c.env.DB);
+	await cancelSubscription(db, householdId);
+	return c.body(null, 204);
+});
+
+/**
+ * Pretends not to exist (404) when the mock is disabled, matching Express's
+ * `isBillingMockEnabled()` gate -- there's no real Stripe integration behind this route, so it
+ * shouldn't be discoverable outside dev/demo use.
+ */
+householdsRoutes.post(
+	'/:id/billing/mock-activate',
+	requireHouseholdOwner,
+	async c => {
+		if (!isBillingMockEnabled(c.env))
+			return c.json({ error: 'not_found' }, 404);
+		const householdId = c.req.param('id');
+		const db = createDb(c.env.DB);
+		await mockActivatePremium(db, householdId);
+		return c.json({ ok: true });
 	}
 );

--- a/services/api/src/hono/types.ts
+++ b/services/api/src/hono/types.ts
@@ -22,6 +22,10 @@ export type Bindings = {
 	 * `LLMUnavailable`, which `lib/recommendation.ts` catches to fall back to the pure-ML pick,
 	 * same "unconfigured is a valid state" degrade as the current Express `llm.service.ts`. */
 	ANTHROPIC_API_KEY?: string;
+	/** Gates `POST /:id/billing/mock-activate` (lib/billing.ts) -- unset means enabled whenever
+	 * `ENVIRONMENT !== 'production'`, same "unconfigured is a valid state" default as the current
+	 * Express `isBillingMockEnabled()`. Set to the literal string `'false'` to hard-disable. */
+	BILLING_MOCK_ENABLED?: string;
 };
 
 /** Request-scoped values set by middleware. */

--- a/services/api/vitest.config.mts
+++ b/services/api/vitest.config.mts
@@ -28,6 +28,12 @@ export default defineConfig(async () => {
         miniflare: {
           bindings: {
             TEST_MIGRATIONS: migrations,
+            // wrangler.jsonc's own `vars.ENVIRONMENT` is 'production' (a placeholder -- there's no
+            // per-environment wrangler config split yet, see that file's own comment). Overridden
+            // here so the four `ENVIRONMENT !== 'production'` / `=== 'development'` checks in
+            // routes/auth.ts, lib/session.ts, lib/email.ts, and lib/billing.ts behave like the
+            // non-production deployment a test run actually is.
+            ENVIRONMENT: 'development',
             // .dev.vars.example ships with every secret blank (fine for manual `wrangler dev` --
             // routes that need one just degrade gracefully, e.g. bootstrap-admin 501s, 2FA
             // enroll/verify 501s). Tests that exercise those routes need a real value; this only


### PR DESCRIPTION
### What's New

- Feature: Ports the billing/admin domain (Express to Hono Worker) -- the last P3 domain, completing the re-platform's route-porting phase after auth (#66, #67), households/pick (#68), and providers/history (#69).
- Feature: New `GET /api/admin/dashboard-stats`, built from tables that still exist post-pivot (users, households, subscriptions, audit-log errors), replacing most of Express's stats/activity surface.
- Fix: Consolidates Express's two competing user-status-change endpoints into one that always revokes sessions and notifies the user on suspend/ban.
- Fix: Several smaller bugs found while porting -- see Description.
- Test: 22 new `vitest-pool-workers` integration tests.

---

### Description

New `services/api/src/hono` files:
- `lib/adminUsers.ts` -- user management (list/get/create/update/delete), locked-accounts (the real login lockout threshold, not Express's drifted hardcoded copy), forced password reset (guarded against un-suspending/un-banning an account as a side effect), sessions, CSV export (properly quoted, unlike Express).
- `lib/adminContent.ts` -- content moderation (list/reports/flag/approve/remove), dismiss-report with a guarded `reportedCount` decrement (fixes a double-decrement idempotency bug).
- `lib/adminAuditLogs.ts` -- list/by-level/sources/stats/manual retention-cleanup over `audit_logs`.
- `lib/adminSettings.ts` -- get/update over the existing `settings` table, compatible with `lib/featureFlags.ts`'s established flat dot-path-key, no-cache read pattern.
- `lib/adminDashboard.ts` -- the new dashboard-stats aggregation.
- `lib/billing.ts` -- mock checkout/cancel/mock-activate. No webhook (Express's is a no-op stub with no signature verification and no DB effect; it lands for real, HMAC-verified, alongside actual Stripe).
- `routes/admin.ts` (new) -- mounted at `/api/admin` behind `requireAuth` + `requireAdmin` (role + TOTP, same session as everyone else).
- `routes/households.ts` extended with `GET /:id/entitlements` (already earmarked for this domain in that file's own header comment) and `/:id/billing/{checkout,cancel,mock-activate}` -- household-scoped and owner-gated via the existing `requireHouseholdOwner` middleware, replacing Express's flat `/api/billing/*` + body `household_id` shape.

**No new migration.** Every table this domain touches (`content`, `content_reports`, `audit_logs`, `settings`, `subscriptions`, `sessions`) already had the columns it needed -- several already carried doc comments in `packages/db/src/schema.ts` anticipating this exact port.

**Scope decisions, backed by the research:**
- The separate admin JWT login/validate-token/refresh/logout endpoints are dropped entirely -- confirmed structurally identical to regular auth (same `JWT_SECRET`, same `authenticateToken`), fully subsumed by the session-cookie + `requireAdmin` gate every other admin route already uses.
- `watchlist-entries` and `matches` admin routes are dropped -- backed by tables removed in the re-platform, with zero live callers even in the current admin SPA (one even has a live field-name bug that's never fired because nothing calls it).
- 8 of Express's 12 stats/activity endpoints are dropped -- backed by the removed `activity_log` table, or Postgres/Node-process introspection (`pg_stat_activity`, `os.*`, `process.memoryUsage()`) with no D1/Workers-isolate equivalent; several of those numbers are already hardcoded random fallbacks in Express, not real telemetry.

**Bugs fixed while porting** (beyond the status-change consolidation and lockout-threshold/idempotency fixes above): `listUsers`/`listContent`'s `sortBy` is whitelisted through a column lookup instead of splicing the raw query string into the ORM's order clause; an admin-supplied status-change `reason` is HTML-escaped before reaching an email body (a real Copilot review finding on this PR, fixed in the second push); terminating a user's session is now genuinely enforced -- a Hono `sessions` row is the live credential `sessionMiddleware` checks on every request, unlike Express's `user_sessions` rows, which its own auth middleware never consulted.

**Known gap, not fixed here:** the automatic daily audit-log retention sweep (Express: a `node-cron` job) isn't ported -- a stateless Worker has no equivalent always-running process. `POST /api/admin/audit-logs/rotation` covers the manual/on-demand half; the automatic half needs a Cloudflare Cron Trigger (same "not implemented yet" status as the provider-cache refresh cron from #69).

**Test infrastructure fix:** `vitest.config.mts` now overrides `ENVIRONMENT` to `'development'` in the test Miniflare bindings. `wrangler.jsonc`'s own `vars.ENVIRONMENT` is `'production'` (a placeholder -- no per-environment config split exists yet), which was silently disabling every `ENVIRONMENT !== 'production'` / `=== 'development'` default in the codebase (`lib/billing.ts`'s mock-enabled gate, cookie `secure` flags, the email dev-fallback log) for the entire test suite, not just this PR's tests -- caught because it's the first PR whose happy-path tests actually depend on the non-production default firing.

---

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented parts that are complex or non-obvious
- [x] I have updated relevant documentation
- [x] I have added or updated tests
- [x] No new warnings or errors are introduced
- [x] All tests pass locally

---

### Screenshots

N/A -- backend only, no UI changes.

---

### Related Issues / PRs

- Continues #66 / #67 (P3 auth domain), #68 (P3 households/pick domain), #69 (P3 providers/history domain).
- Tracked in `docs/roadmap.md` under P3 -- this was the last P3 domain. Only collapsing the two server entry points and the P5 cutover remain.

---

### Notes for Reviewers

- Full monorepo verification green: `turbo run type-check lint build test` across all 8 workspaces (22/22 tasks); `wrangler deploy --dry-run` bundles successfully. `services/api`'s Jest suite (Express, untouched) still passes at 292/292; the Hono Vitest suite is now 92/92 (70 pre-existing + 22 new).
- Like #69, this PR was built up incrementally across several pushes (research/foundational pieces, lib layer, routes+tests, docs) rather than opened only once finished, so CI/CodeQL ran against each increment.
- One real Copilot review finding was addressed in an earlier push: an admin-supplied `reason` string was interpolated unescaped into an HTML email body -- fixed with a small `escapeHtml` helper in `lib/email.ts`.