### PR TITLE
Onboarding taste-starter flow (taste-personalization PR 2 of 2)

### DIFF
--- a/apps/client/src/components/layout/Routes.tsx
+++ b/apps/client/src/components/layout/Routes.tsx
@@ -17,6 +17,7 @@ import HistoryPage from '../../features/history/HistoryPage';
 import AcceptInvitePage from '../../features/households/AcceptInvitePage';
 import CreateHouseholdPage from '../../features/households/CreateHouseholdPage';
 import InviteToHouseholdPage from '../../features/households/InviteToHouseholdPage';
+import TasteOnboardingPage from '../../features/onboarding/TasteOnboardingPage';
 import TonightPicker from '../../features/tonight/TonightPicker';
 import { useAuth } from '../../hooks/useAuth';
 
@@ -107,6 +108,10 @@ const AppRoutes: React.FC = () => {
               <Route
                 path="/household-invites/:token"
                 element={<ProtectedRoute element={<AcceptInvitePage />} />}
+              />
+              <Route
+                path="/onboarding/taste"
+                element={<ProtectedRoute element={<TasteOnboardingPage />} />}
               />
               <Route
                 path="/profile"

--- a/apps/client/src/features/households/AcceptInvitePage.tsx
+++ b/apps/client/src/features/households/AcceptInvitePage.tsx
@@ -19,7 +19,7 @@ const AcceptInvitePage: React.FC = () => {
     mutationFn: () => householdsApi.acceptInvite(token ?? ''),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ['households'] });
-      navigate('/tonight');
+      navigate(`/onboarding/taste?next=${encodeURIComponent('/tonight')}`);
     },
   });
 

--- a/apps/client/src/features/households/CreateHouseholdPage.tsx
+++ b/apps/client/src/features/households/CreateHouseholdPage.tsx
@@ -22,7 +22,10 @@ const CreateHouseholdPage: React.FC = () => {
     mutationFn: (body: { name?: string }) => householdsApi.create(body),
     onSuccess: data => {
       void queryClient.invalidateQueries({ queryKey: ['households'] });
-      navigate(`/households/${data.household.id}/invites`);
+      const next = encodeURIComponent(
+        `/households/${data.household.id}/invites`
+      );
+      navigate(`/onboarding/taste?next=${next}`);
     },
     onError: (err: Error) => setError(err.message),
   });

--- a/apps/client/src/features/onboarding/TasteOnboardingPage.css.ts
+++ b/apps/client/src/features/onboarding/TasteOnboardingPage.css.ts
@@ -1,0 +1,60 @@
+import { style } from '@vanilla-extract/css';
+import { recipe } from '@vanilla-extract/recipes';
+import { vars } from '@pairflix/components';
+
+export const header = style({
+  marginBottom: vars.spacing.md,
+});
+
+export const chip = recipe({
+  base: {
+    padding: `${vars.spacing.sm} ${vars.spacing.md}`,
+    borderRadius: '999px',
+    cursor: 'pointer',
+    fontSize: vars.typography.fontSize.sm,
+    transition: 'background 0.15s ease',
+  },
+  variants: {
+    selected: {
+      true: {
+        border: `1px solid ${vars.colors.primary}`,
+        background: vars.colors.primary,
+        color: '#ffffff',
+        selectors: {
+          '&:hover': { background: vars.colors.primary },
+        },
+      },
+      false: {
+        border: `1px solid ${vars.colors.border}`,
+        background: 'transparent',
+        color: vars.colors.text.primary,
+        selectors: {
+          '&:hover': { background: vars.colors.background.secondary },
+        },
+      },
+    },
+  },
+  defaultVariants: {
+    selected: false,
+  },
+});
+
+export const formSection = style({
+  marginBottom: vars.spacing.lg,
+});
+
+export const poster = style({
+  width: '160px',
+  aspectRatio: '2/3',
+  objectFit: 'cover',
+  borderRadius: vars.borderRadius.sm,
+  marginBottom: vars.spacing.md,
+});
+
+export const nextButton = style({
+  marginTop: vars.spacing.lg,
+});
+
+export const errorMessage = style({
+  marginTop: vars.spacing.md,
+});

--- a/apps/client/src/features/onboarding/TasteOnboardingPage.tsx
+++ b/apps/client/src/features/onboarding/TasteOnboardingPage.tsx
@@ -1,0 +1,232 @@
+import {
+  Button,
+  Card,
+  CardContent,
+  Container,
+  Flex,
+  H1,
+  H2,
+  PageContainer,
+  Typography,
+} from '@pairflix/components';
+import { useMutation, useQuery } from '@tanstack/react-query';
+import React, { useState } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+import {
+  tasteOnboarding,
+  type OnboardingCard,
+  type OnboardingSwipe,
+} from '../../services/api';
+import { ONBOARDING_GENRES } from './genres';
+import * as styles from './TasteOnboardingPage.css';
+
+const PROVIDER_OPTIONS: { id: string; label: string }[] = [
+  { id: 'netflix', label: 'Netflix' },
+  { id: 'prime', label: 'Prime Video' },
+  { id: 'disney_plus', label: 'Disney+' },
+];
+
+type Step = 'genres' | 'swipe' | 'providers';
+
+const DEFAULT_NEXT_PATH = '/tonight';
+
+/**
+ * Skippable taste-starter flow shown once per household member at their own join moment --
+ * CreateHouseholdPage and AcceptInvitePage both navigate here (with `?next=` set to wherever they
+ * would otherwise have gone) instead of straight to their normal next page. Every step's Skip goes
+ * straight to `next` without submitting; completing all three steps submits once on finish, then
+ * also navigates to `next`.
+ */
+const TasteOnboardingPage: React.FC = () => {
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const nextPath = searchParams.get('next') || DEFAULT_NEXT_PATH;
+
+  const [step, setStep] = useState<Step>('genres');
+  const [likedGenreIds, setLikedGenreIds] = useState<number[]>([]);
+  const [swipes, setSwipes] = useState<OnboardingSwipe[]>([]);
+  const [cardIndex, setCardIndex] = useState(0);
+  const [providers, setProviders] = useState<string[]>([]);
+
+  const deckQuery = useQuery({
+    queryKey: ['taste-onboarding-deck'],
+    queryFn: () => tasteOnboarding.getDeck(),
+  });
+  const deck = deckQuery.data?.cards ?? [];
+  const currentCard: OnboardingCard | undefined = deck[cardIndex];
+
+  const submitMutation = useMutation({
+    mutationFn: () =>
+      tasteOnboarding.submit({ likedGenreIds, swipes, providers }),
+    onSuccess: () => navigate(nextPath),
+  });
+
+  const skip = () => navigate(nextPath);
+
+  const toggleGenre = (id: number) => {
+    setLikedGenreIds(prev =>
+      prev.includes(id) ? prev.filter(g => g !== id) : [...prev, id]
+    );
+  };
+
+  const toggleProvider = (id: string) => {
+    setProviders(prev =>
+      prev.includes(id) ? prev.filter(p => p !== id) : [...prev, id]
+    );
+  };
+
+  const swipeCard = (card: OnboardingCard, verdict: 'love' | 'not_for_me') => {
+    setSwipes(prev => [
+      ...prev,
+      {
+        tmdbId: card.tmdbId,
+        mediaType: card.mediaType,
+        genreIds: card.genreIds,
+        verdict,
+      },
+    ]);
+    setCardIndex(prev => prev + 1);
+  };
+
+  return (
+    <PageContainer maxWidth="md" padding="lg" centered>
+      <Container fluid>
+        <Flex
+          justifyContent="space-between"
+          alignItems="center"
+          className={styles.header}
+        >
+          <H1>Tell us what you like</H1>
+          <Button variant="text" onClick={skip}>
+            Skip
+          </Button>
+        </Flex>
+
+        {step === 'genres' && (
+          <Card variant="secondary">
+            <CardContent>
+              <H2 gutterBottom>Pick a few genres you love</H2>
+              <Typography variant="body2" gutterBottom>
+                Select as many as you like -- this just gives your first picks a
+                head start.
+              </Typography>
+              <Flex wrap="wrap" gap="sm" className={styles.formSection}>
+                {ONBOARDING_GENRES.map(genre => (
+                  <button
+                    key={genre.id}
+                    type="button"
+                    className={styles.chip({
+                      selected: likedGenreIds.includes(genre.id),
+                    })}
+                    onClick={() => toggleGenre(genre.id)}
+                  >
+                    {genre.label}
+                  </button>
+                ))}
+              </Flex>
+              <Button
+                variant="primary"
+                className={styles.nextButton}
+                onClick={() => setStep('swipe')}
+              >
+                Continue
+              </Button>
+            </CardContent>
+          </Card>
+        )}
+
+        {step === 'swipe' && (
+          <Card variant="secondary">
+            <CardContent>
+              <H2 gutterBottom>Love it, or not for you?</H2>
+              {deckQuery.isLoading && (
+                <Typography variant="body2">Loading titles…</Typography>
+              )}
+              {deckQuery.error && (
+                <Typography variant="body2">
+                  Couldn&apos;t load titles to swipe on right now.
+                </Typography>
+              )}
+              {currentCard && (
+                <div className={styles.formSection}>
+                  {currentCard.posterPath && (
+                    <img
+                      className={styles.poster}
+                      src={`https://image.tmdb.org/t/p/w342${currentCard.posterPath}`}
+                      alt={currentCard.title}
+                    />
+                  )}
+                  <Typography variant="body1" gutterBottom>
+                    {currentCard.title}
+                  </Typography>
+                  <Flex gap="md">
+                    <Button
+                      variant="danger"
+                      onClick={() => swipeCard(currentCard, 'not_for_me')}
+                    >
+                      Not for me
+                    </Button>
+                    <Button
+                      variant="success"
+                      onClick={() => swipeCard(currentCard, 'love')}
+                    >
+                      Love it
+                    </Button>
+                  </Flex>
+                </div>
+              )}
+              {!currentCard && !deckQuery.isLoading && (
+                <Typography variant="body2" className={styles.formSection}>
+                  That&apos;s everything for now.
+                </Typography>
+              )}
+              <Button
+                variant="primary"
+                className={styles.nextButton}
+                onClick={() => setStep('providers')}
+              >
+                Continue
+              </Button>
+            </CardContent>
+          </Card>
+        )}
+
+        {step === 'providers' && (
+          <Card variant="secondary">
+            <CardContent>
+              <H2 gutterBottom>Where do you stream?</H2>
+              <Flex wrap="wrap" className={styles.formSection}>
+                {PROVIDER_OPTIONS.map(p => (
+                  <label key={p.id}>
+                    <input
+                      type="checkbox"
+                      checked={providers.includes(p.id)}
+                      onChange={() => toggleProvider(p.id)}
+                    />{' '}
+                    {p.label}
+                  </label>
+                ))}
+              </Flex>
+              {submitMutation.error && (
+                <Typography variant="body2" className={styles.errorMessage}>
+                  {submitMutation.error.message}
+                </Typography>
+              )}
+              <Button
+                variant="primary"
+                className={styles.nextButton}
+                onClick={() => submitMutation.mutate()}
+                disabled={submitMutation.isPending}
+                isLoading={submitMutation.isPending}
+              >
+                Finish
+              </Button>
+            </CardContent>
+          </Card>
+        )}
+      </Container>
+    </PageContainer>
+  );
+};
+
+export default TasteOnboardingPage;

--- a/apps/client/src/features/onboarding/TasteOnboardingPage.tsx
+++ b/apps/client/src/features/onboarding/TasteOnboardingPage.tsx
@@ -30,6 +30,11 @@ type Step = 'genres' | 'swipe' | 'providers';
 
 const DEFAULT_NEXT_PATH = '/tonight';
 
+// `next` comes from a URL query param -- reject anything that isn't a same-origin path (an
+// absolute or protocol-relative URL would throw a SecurityError out of history.pushState).
+const isInternalPath = (path: string): boolean =>
+  path.startsWith('/') && !path.startsWith('//');
+
 /**
  * Skippable taste-starter flow shown once per household member at their own join moment --
  * CreateHouseholdPage and AcceptInvitePage both navigate here (with `?next=` set to wherever they
@@ -40,7 +45,9 @@ const DEFAULT_NEXT_PATH = '/tonight';
 const TasteOnboardingPage: React.FC = () => {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
-  const nextPath = searchParams.get('next') || DEFAULT_NEXT_PATH;
+  const rawNext = searchParams.get('next');
+  const nextPath =
+    rawNext && isInternalPath(rawNext) ? rawNext : DEFAULT_NEXT_PATH;
 
   const [step, setStep] = useState<Step>('genres');
   const [likedGenreIds, setLikedGenreIds] = useState<number[]>([]);
@@ -115,6 +122,7 @@ const TasteOnboardingPage: React.FC = () => {
                   <button
                     key={genre.id}
                     type="button"
+                    aria-pressed={likedGenreIds.includes(genre.id)}
                     className={styles.chip({
                       selected: likedGenreIds.includes(genre.id),
                     })}

--- a/apps/client/src/features/onboarding/__tests__/TasteOnboardingPage.test.tsx
+++ b/apps/client/src/features/onboarding/__tests__/TasteOnboardingPage.test.tsx
@@ -1,0 +1,87 @@
+import userEvent from '@testing-library/user-event';
+import { tasteOnboarding } from '../../../services/api';
+import { render, screen, waitFor } from '../../../tests/setup';
+import TasteOnboardingPage from '../TasteOnboardingPage';
+
+// Mock the API module
+jest.mock('../../../services/api', () => {
+  const originalModule = jest.requireActual('../../../services/api');
+  return {
+    ...originalModule,
+    tasteOnboarding: {
+      getDeck: jest.fn(),
+      submit: jest.fn(),
+    },
+  };
+});
+
+// Mock the useNavigate hook
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockNavigate,
+}));
+
+const DECK = [
+  {
+    tmdbId: 101,
+    mediaType: 'movie' as const,
+    title: 'Test Movie One',
+    posterPath: null,
+    genreIds: [35],
+  },
+];
+
+describe('TasteOnboardingPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (tasteOnboarding.getDeck as jest.Mock).mockResolvedValue({ cards: DECK });
+    (tasteOnboarding.submit as jest.Mock).mockResolvedValue(undefined);
+  });
+
+  it('skip navigates to the default next path without submitting anything', async () => {
+    const user = userEvent.setup();
+    render(<TasteOnboardingPage />);
+
+    await user.click(screen.getByRole('button', { name: 'Skip' }));
+
+    expect(tasteOnboarding.submit).not.toHaveBeenCalled();
+    expect(mockNavigate).toHaveBeenCalledWith('/tonight');
+  });
+
+  it('walks through genre selection, a swipe, and provider selection, then submits and navigates', async () => {
+    const user = userEvent.setup();
+    render(<TasteOnboardingPage />);
+
+    // Step 1: genre multi-select.
+    await user.click(screen.getByRole('button', { name: 'Comedy' }));
+    await user.click(screen.getByRole('button', { name: 'Continue' }));
+
+    // Step 2: swipe deck -- love the one card in the mocked deck.
+    await waitFor(() => {
+      expect(screen.getByText('Test Movie One')).toBeInTheDocument();
+    });
+    await user.click(screen.getByRole('button', { name: 'Love it' }));
+    await user.click(screen.getByRole('button', { name: 'Continue' }));
+
+    // Step 3: streaming providers, then finish.
+    await user.click(screen.getByLabelText('Netflix'));
+    await user.click(screen.getByRole('button', { name: 'Finish' }));
+
+    await waitFor(() => {
+      expect(tasteOnboarding.submit).toHaveBeenCalledWith({
+        likedGenreIds: [35],
+        swipes: [
+          {
+            tmdbId: 101,
+            mediaType: 'movie',
+            genreIds: [35],
+            verdict: 'love',
+          },
+        ],
+        providers: ['netflix'],
+      });
+    });
+    expect(mockNavigate).toHaveBeenCalledWith('/tonight');
+  });
+});

--- a/apps/client/src/features/onboarding/genres.ts
+++ b/apps/client/src/features/onboarding/genres.ts
@@ -1,0 +1,23 @@
+// Mirrors services/api/src/lib/genres.ts's GENRE_NAMES (TMDb genre id -> label) -- apps/client has
+// no path to import from the Worker, same reason services/api/households.ts's Mood type is a local
+// copy rather than an import from @pairflix/lib.validation.
+export const ONBOARDING_GENRES: { id: number; label: string }[] = [
+  { id: 28, label: 'Action' },
+  { id: 12, label: 'Adventure' },
+  { id: 16, label: 'Animation' },
+  { id: 35, label: 'Comedy' },
+  { id: 80, label: 'Crime' },
+  { id: 99, label: 'Documentary' },
+  { id: 18, label: 'Drama' },
+  { id: 10751, label: 'Family' },
+  { id: 14, label: 'Fantasy' },
+  { id: 36, label: 'History' },
+  { id: 27, label: 'Horror' },
+  { id: 10402, label: 'Music' },
+  { id: 9648, label: 'Mystery' },
+  { id: 10749, label: 'Romance' },
+  { id: 878, label: 'Sci-Fi' },
+  { id: 53, label: 'Thriller' },
+  { id: 10752, label: 'War' },
+  { id: 37, label: 'Western' },
+];

--- a/apps/client/src/features/tonight/useTonightHomepage.ts
+++ b/apps/client/src/features/tonight/useTonightHomepage.ts
@@ -1,16 +1,12 @@
 import { useAuth } from '../../hooks/useAuth';
 
-interface PreferencesWithTonight {
-  selectedProviders?: string[];
-}
-
 export function useTonightHomepagePreference(): {
   selectedProviders: string[];
 } {
   const { user } = useAuth();
-  const prefs = (user?.preferences as PreferencesWithTonight | undefined) ?? {};
+  const prefs = user?.preferences;
   return {
-    selectedProviders: prefs.selectedProviders ?? [
+    selectedProviders: prefs?.selectedProviders ?? [
       'netflix',
       'prime',
       'disney_plus',

--- a/apps/client/src/services/api/index.ts
+++ b/apps/client/src/services/api/index.ts
@@ -3,6 +3,7 @@ import { billing } from './billing';
 import { emailService } from './email';
 import { history } from './history';
 import { households } from './households';
+import { tasteOnboarding } from './tasteOnboarding';
 import { user } from './user';
 import { fetchWithAuth } from './utils';
 
@@ -22,6 +23,13 @@ export type {
   SubscriptionTier,
 } from './billing';
 
+// Re-export types from tasteOnboarding
+export type {
+  OnboardingCard,
+  OnboardingSubmission,
+  OnboardingSwipe,
+} from './tasteOnboarding';
+
 // Export individual services
 export {
   auth,
@@ -30,6 +38,7 @@ export {
   fetchWithAuth,
   history,
   households,
+  tasteOnboarding,
   user,
 };
 
@@ -44,6 +53,7 @@ const api = {
   email: emailService,
   history,
   households,
+  tasteOnboarding,
 };
 
 export default api;

--- a/apps/client/src/services/api/tasteOnboarding.ts
+++ b/apps/client/src/services/api/tasteOnboarding.ts
@@ -1,0 +1,36 @@
+import { fetchWithAuth } from './utils';
+
+export interface OnboardingCard {
+  tmdbId: number;
+  mediaType: 'movie' | 'tv';
+  title: string;
+  posterPath: string | null;
+  genreIds: number[];
+}
+
+export interface OnboardingSwipe {
+  tmdbId: number;
+  mediaType: 'movie' | 'tv';
+  genreIds: number[];
+  verdict: 'love' | 'not_for_me';
+}
+
+export interface OnboardingSubmission {
+  likedGenreIds: number[];
+  swipes: OnboardingSwipe[];
+  providers: string[];
+}
+
+export const tasteOnboarding = {
+  getDeck: async (): Promise<{ cards: OnboardingCard[] }> => {
+    const response = await fetchWithAuth('/api/me/taste-onboarding/deck');
+    return response.data;
+  },
+
+  submit: async (body: OnboardingSubmission): Promise<void> => {
+    await fetchWithAuth('/api/me/taste-onboarding', {
+      method: 'POST',
+      body: JSON.stringify(body),
+    });
+  },
+};

--- a/apps/client/src/services/api/utils.ts
+++ b/apps/client/src/services/api/utils.ts
@@ -72,6 +72,7 @@ export interface UserPreferences {
   emailNotifications: boolean;
   autoArchiveDays: number;
   favoriteGenres: string[];
+  selectedProviders?: string[];
 }
 
 export interface PaginatedResponse<T> {

--- a/apps/client/src/tests/__mocks__/api.ts
+++ b/apps/client/src/tests/__mocks__/api.ts
@@ -105,6 +105,11 @@ export const history = {
   }),
 };
 
+export const tasteOnboarding = {
+  getDeck: jest.fn().mockResolvedValue({ cards: [] }),
+  submit: jest.fn().mockResolvedValue(undefined),
+};
+
 export const households = {
   list: jest.fn().mockResolvedValue({ households: [] }),
   create: jest.fn().mockResolvedValue({

--- a/docs/db-schema.md
+++ b/docs/db-schema.md
@@ -74,7 +74,9 @@ export const users = sqliteTable('users', {
 ```
 
 `UserPreferences`: `{ theme: 'light' | 'dark', viewStyle: 'list' | 'grid', emailNotifications:
-boolean, autoArchiveDays: number, favoriteGenres: string[] }`.
+boolean, autoArchiveDays: number, favoriteGenres: string[], selectedProviders?: string[] }`.
+`selectedProviders` is the streaming-service picklist from the taste-onboarding flow (routes/me.ts's
+`POST /api/me/taste-onboarding`) and the tonight homepage's provider filter default.
 
 Session auth (ADR 0002) adds `sessions` and `authTokens`, both ported from creatorgrid's mechanism —
 these replace the old `user_sessions`, `email_verifications`, and `password_resets` tables, which are

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -280,9 +280,6 @@ Independent of the platform, needed before opening to an invited cohort:
 - Extend the recommender to TV, and make runtime actually influence scoring.
 - Feed `ProviderBadges` real provider data on the Tonight card and history.
 - Integration tests for the pick / providers / entitlements paths.
-- Build the **onboarding taste-starter** (genre/mood picks + a few love-it/not-for-me swipes + service
-  selection) to seed `taste_profiles` and solve cold-start — the decided taste model is onboarding +
-  watched-together thumbs, no watchlist.
 - Real Stripe (gated on go-live sign-off) — until then premium is comp/mock only.
 
 **Alpha exit criteria:** a real household can create an account, get a genuinely good first pick in

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -63,6 +63,7 @@ export type UserPreferences = {
   emailNotifications: boolean;
   autoArchiveDays: number;
   favoriteGenres: string[];
+  selectedProviders?: string[];
 };
 
 /**

--- a/packages/lib.validation/src/index.ts
+++ b/packages/lib.validation/src/index.ts
@@ -2,3 +2,4 @@ export * from './schemas/admin';
 export * from './schemas/auth';
 export * from './schemas/household';
 export * from './schemas/providers';
+export * from './schemas/taste';

--- a/packages/lib.validation/src/schemas/auth.ts
+++ b/packages/lib.validation/src/schemas/auth.ts
@@ -92,6 +92,7 @@ const PreferencesPatchSchema = z.object({
   emailNotifications: z.boolean().optional(),
   autoArchiveDays: z.number().int().min(0).optional(),
   favoriteGenres: z.array(z.string()).optional(),
+  selectedProviders: z.array(z.string()).optional(),
 });
 
 export const UpdatePreferencesRequestSchema = z.object({

--- a/packages/lib.validation/src/schemas/taste.ts
+++ b/packages/lib.validation/src/schemas/taste.ts
@@ -1,0 +1,18 @@
+import { z } from 'zod';
+
+export const TasteOnboardingSwipeSchema = z.object({
+  tmdbId: z.number().int().positive(),
+  mediaType: z.enum(['movie', 'tv']),
+  genreIds: z.array(z.number().int().positive()),
+  verdict: z.enum(['love', 'not_for_me']),
+});
+export type TasteOnboardingSwipe = z.infer<typeof TasteOnboardingSwipeSchema>;
+
+export const TasteOnboardingRequestSchema = z.object({
+  likedGenreIds: z.array(z.number().int().positive()),
+  swipes: z.array(TasteOnboardingSwipeSchema),
+  providers: z.array(z.string().trim().min(1)),
+});
+export type TasteOnboardingRequest = z.infer<
+  typeof TasteOnboardingRequestSchema
+>;

--- a/services/api/src/lib/tasteOnboarding.test.ts
+++ b/services/api/src/lib/tasteOnboarding.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+import { GENRE_NAMES } from './genres';
+import { buildOnboardingGenreWeights } from './tasteOnboarding';
+import { NEUTRAL_GENRE_WEIGHT } from './tasteWeights';
+
+describe('buildOnboardingGenreWeights', () => {
+	it('is dense across every GENRE_NAMES id at the neutral weight given no input', () => {
+		const weights = buildOnboardingGenreWeights([], []);
+		const genreIds = Object.keys(GENRE_NAMES);
+		expect(Object.keys(weights)).toHaveLength(genreIds.length);
+		for (const id of genreIds) {
+			expect(weights[id]).toBe(NEUTRAL_GENRE_WEIGHT);
+		}
+	});
+
+	it('weights a picked genre at 0.75 and leaves the rest neutral', () => {
+		const weights = buildOnboardingGenreWeights([35], []);
+		expect(weights['35']).toBe(0.75);
+		expect(weights['18']).toBe(NEUTRAL_GENRE_WEIGHT);
+	});
+
+	it('nudges a loved swipe up by 0.15 from the neutral baseline', () => {
+		const weights = buildOnboardingGenreWeights(
+			[],
+			[{ tmdbId: 1, mediaType: 'movie', genreIds: [35], verdict: 'love' }]
+		);
+		expect(weights['35']).toBeCloseTo(0.5, 10);
+	});
+
+	it('nudges a not-for-me swipe down by 0.2 from the neutral baseline', () => {
+		const weights = buildOnboardingGenreWeights(
+			[],
+			[
+				{
+					tmdbId: 1,
+					mediaType: 'movie',
+					genreIds: [35],
+					verdict: 'not_for_me',
+				},
+			]
+		);
+		expect(weights['35']).toBeCloseTo(0.15, 10);
+	});
+
+	it('applies swipe deltas on top of a picked genre, not instead of it', () => {
+		const weights = buildOnboardingGenreWeights(
+			[35],
+			[{ tmdbId: 1, mediaType: 'movie', genreIds: [35], verdict: 'love' }]
+		);
+		expect(weights['35']).toBeCloseTo(0.9, 10);
+	});
+
+	it('caps a repeatedly loved genre at 1.0', () => {
+		const swipes = Array.from({ length: 10 }, (_, i) => ({
+			tmdbId: i,
+			mediaType: 'movie' as const,
+			genreIds: [35],
+			verdict: 'love' as const,
+		}));
+		const weights = buildOnboardingGenreWeights([35], swipes);
+		expect(weights['35']).toBe(1);
+	});
+
+	it('floors a repeatedly not-for-me genre at 0.05, not 0', () => {
+		const swipes = Array.from({ length: 10 }, (_, i) => ({
+			tmdbId: i,
+			mediaType: 'movie' as const,
+			genreIds: [35],
+			verdict: 'not_for_me' as const,
+		}));
+		const weights = buildOnboardingGenreWeights([], swipes);
+		expect(weights['35']).toBe(0.05);
+	});
+
+	it('ignores a genre id outside the canonical GENRE_NAMES set', () => {
+		const weights = buildOnboardingGenreWeights(
+			[999999],
+			[{ tmdbId: 1, mediaType: 'movie', genreIds: [999999], verdict: 'love' }]
+		);
+		expect(weights['999999']).toBeUndefined();
+	});
+});

--- a/services/api/src/lib/tasteOnboarding.ts
+++ b/services/api/src/lib/tasteOnboarding.ts
@@ -1,0 +1,176 @@
+import { tasteProfiles, users, type Database } from '@pairflix/db';
+import { eq } from 'drizzle-orm';
+import type { Bindings } from '../types';
+import { GENRE_NAMES } from './genres';
+import { denseGenreWeights, NEUTRAL_GENRE_WEIGHT } from './tasteWeights';
+import { discoverMedia, type TMDbDiscoverMovie } from './tmdb';
+
+/**
+ * The onboarding taste-starter flow (PR 2 of the taste-personalization fix -- lib/tasteRecompute.ts
+ * is PR 1, the watched-together thumbs recompute). Shown once per household member at their own
+ * join moment (routes/me.ts), this is `taste_profiles`'s second writer: it seeds a dense
+ * genre-weights row directly from onboarding answers instead of waiting for ratings to accumulate,
+ * so `mergeProfiles` (lib/recommendation.ts) has something better than a mood-only fallback from
+ * the very first pick.
+ */
+
+// comedy, drama, action, horror, romance, sci-fi, documentary, animation -- a spread across
+// distinct moods, not a top-N by any other criterion.
+const ANCHOR_GENRE_IDS = [35, 18, 28, 27, 10749, 878, 99, 16];
+const CARDS_PER_GENRE = 2;
+const DECK_SIZE = 16;
+// Higher than the pick path's own default (200, see lib/recommendation.ts) -- these need to be
+// titles a new user actually recognizes, not just whatever clears the bar for a filtered pick.
+const VOTE_COUNT_FLOOR = 500;
+
+export type OnboardingCard = {
+	tmdbId: number;
+	mediaType: 'movie' | 'tv';
+	title: string;
+	posterPath: string | null;
+	genreIds: number[];
+};
+
+/** One `/discover` call per anchor genre (parallel), top `CARDS_PER_GENRE` each, deduped by
+ * tmdbId -- a movie tagged with two anchor genres (e.g. an action-comedy) only appears once, kept
+ * with the full `genre_ids` from whichever call it was first seen on. Movie-only, matching the pick
+ * path's own `discoverMedia` calls (lib/recommendation.ts). */
+export const buildOnboardingDeck = async (
+	env: Bindings
+): Promise<OnboardingCard[]> => {
+	const responses = await Promise.all(
+		ANCHOR_GENRE_IDS.map(genreId =>
+			discoverMedia(env, {
+				mediaType: 'movie',
+				genres: [genreId],
+				voteCountGte: VOTE_COUNT_FLOOR,
+				sortBy: 'popularity.desc',
+			})
+		)
+	);
+
+	const seen = new Set<number>();
+	const deck: OnboardingCard[] = [];
+	for (const response of responses) {
+		const top = (response.results ?? []).slice(0, CARDS_PER_GENRE);
+		for (const item of top) {
+			if (seen.has(item.id)) continue;
+			seen.add(item.id);
+			deck.push({
+				tmdbId: item.id,
+				mediaType: 'movie',
+				// Every discoverMedia call above fixes mediaType to 'movie', so item is always
+				// shaped like TMDbDiscoverMovie, not the TMDbDiscoverTV half of the union.
+				title: (item as TMDbDiscoverMovie).title,
+				posterPath: item.poster_path,
+				genreIds: item.genre_ids,
+			});
+		}
+	}
+	return deck.slice(0, DECK_SIZE);
+};
+
+const LIKED_GENRE_WEIGHT = 0.75;
+const LOVE_SWIPE_DELTA = 0.15;
+const NOT_FOR_ME_SWIPE_DELTA = -0.2;
+const SWIPE_WEIGHT_CEILING = 1;
+const SWIPE_WEIGHT_FLOOR = 0.05;
+
+export type OnboardingSwipe = {
+	tmdbId: number;
+	mediaType: 'movie' | 'tv';
+	genreIds: number[];
+	verdict: 'love' | 'not_for_me';
+};
+
+/** Pure weight-building over a dense genre baseline -- no DB access, so this is unit-testable
+ * without D1, same split as `tasteRecompute.ts`'s `nudgeGenreWeights`. Liked genres are set to
+ * `LIKED_GENRE_WEIGHT` first; swipes are then applied on top (so a genre that's both picked and
+ * swiped reflects both), each swipe nudging every genre on that card by a fixed delta -- not an
+ * EMA, since there's no prior rating history here to decay -- clamped to
+ * `[SWIPE_WEIGHT_FLOOR, SWIPE_WEIGHT_CEILING]`. A genre id outside `GENRE_NAMES` is silently
+ * skipped, matching `nudgeGenreWeights`'s own convention. */
+export const buildOnboardingGenreWeights = (
+	likedGenreIds: number[],
+	swipes: OnboardingSwipe[]
+): Record<string, number> => {
+	const weights = denseGenreWeights();
+
+	for (const genreId of likedGenreIds) {
+		if (!(genreId in GENRE_NAMES)) continue;
+		weights[String(genreId)] = LIKED_GENRE_WEIGHT;
+	}
+
+	for (const swipe of swipes) {
+		const delta =
+			swipe.verdict === 'love' ? LOVE_SWIPE_DELTA : NOT_FOR_ME_SWIPE_DELTA;
+		for (const genreId of swipe.genreIds) {
+			if (!(genreId in GENRE_NAMES)) continue;
+			const key = String(genreId);
+			const current = weights[key] ?? NEUTRAL_GENRE_WEIGHT;
+			weights[key] = Math.min(
+				SWIPE_WEIGHT_CEILING,
+				Math.max(SWIPE_WEIGHT_FLOOR, current + delta)
+			);
+		}
+	}
+
+	return weights;
+};
+
+export type OnboardingSubmission = {
+	likedGenreIds: number[];
+	swipes: OnboardingSwipe[];
+	providers: string[];
+};
+
+/** Writes both `taste_profiles` (genre weights, seeded fresh from onboarding answers -- unlike
+ * `recomputeTasteFromRating`'s EMA nudge, there's no prior rating history here to nudge) and
+ * `users.preferences.selectedProviders`, upserting the taste profile the same
+ * read-existing-then-`onConflictDoUpdate` way `tasteRecompute.ts` does, so a second onboarding
+ * submission (or a profile already seeded by a rating) only ever overwrites `weights.genres`. */
+export const submitOnboarding = async (
+	db: Database,
+	userId: string,
+	input: OnboardingSubmission
+): Promise<void> => {
+	const genres = buildOnboardingGenreWeights(input.likedGenreIds, input.swipes);
+
+	const [existingProfile, user] = await Promise.all([
+		db
+			.select({ weights: tasteProfiles.weights })
+			.from(tasteProfiles)
+			.where(eq(tasteProfiles.userId, userId))
+			.get(),
+		db
+			.select({ preferences: users.preferences })
+			.from(users)
+			.where(eq(users.id, userId))
+			.get(),
+	]);
+	// requireAuth only resolves userId from a live, unexpired session row, and sessions.userId
+	// cascades on delete -- a session pointing at a userId with no users row is not a reachable
+	// state, so this is an invariant check, not a real-world 404.
+	if (!user) throw new Error(`submitOnboarding: user ${userId} not found`);
+
+	const now = new Date();
+	const weights = { ...existingProfile?.weights, genres };
+	const preferences = {
+		...user.preferences,
+		selectedProviders: input.providers,
+	};
+
+	await Promise.all([
+		db
+			.insert(tasteProfiles)
+			.values({ userId, weights, updatedAt: now })
+			.onConflictDoUpdate({
+				target: tasteProfiles.userId,
+				set: { weights, updatedAt: now },
+			}),
+		db
+			.update(users)
+			.set({ preferences, updatedAt: now })
+			.where(eq(users.id, userId)),
+	]);
+};

--- a/services/api/src/lib/tasteOnboarding.ts
+++ b/services/api/src/lib/tasteOnboarding.ts
@@ -160,7 +160,7 @@ export const submitOnboarding = async (
 		selectedProviders: input.providers,
 	};
 
-	await Promise.all([
+	await db.batch([
 		db
 			.insert(tasteProfiles)
 			.values({ userId, weights, updatedAt: now })

--- a/services/api/src/routes/me.e2e.test.ts
+++ b/services/api/src/routes/me.e2e.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from 'vitest';
+import { env } from 'cloudflare:workers';
+import { afterEach, describe, expect, it } from 'vitest';
 import { currentTotpCode } from '../lib/totp';
 import {
 	callApp,
@@ -13,6 +14,124 @@ import {
 let counter = 0;
 const uniqueEmail = () => `me-e2e-${Date.now()}-${counter++}@example.com`;
 const PASSWORD = 'Str0ngPass123';
+
+const jsonResponse = (data: unknown, status = 200): Response =>
+	new Response(JSON.stringify(data), {
+		status,
+		headers: { 'content-type': 'application/json' },
+	});
+
+type MockDiscoverMovie = {
+	id: number;
+	title: string;
+	poster_path: string | null;
+	genre_ids: number[];
+};
+
+const REAL_FETCH = globalThis.fetch;
+afterEach(() => {
+	globalThis.fetch = REAL_FETCH;
+});
+
+/** One entry per anchor genre id in lib/tasteOnboarding.ts's `ANCHOR_GENRE_IDS`, keyed by
+ * `with_genres`, so every discover call the deck endpoint makes is deterministically mocked. Genre
+ * 3501 is deliberately returned from both the comedy (35) and drama (18) genres -- comedy is
+ * processed first, so it exercises the dedup-by-tmdbId path (3501 keeps comedy's [35, 18]
+ * genre_ids, drama's copy is dropped). */
+const MOVIES_BY_GENRE: Record<number, MockDiscoverMovie[]> = {
+	35: [
+		{
+			id: 3501,
+			title: 'Cross-genre Pick',
+			poster_path: '/c1.jpg',
+			genre_ids: [35, 18],
+		},
+		{ id: 3502, title: 'Comedy Two', poster_path: '/c2.jpg', genre_ids: [35] },
+	],
+	18: [
+		{
+			id: 3501,
+			title: 'Cross-genre Pick',
+			poster_path: '/c1.jpg',
+			genre_ids: [35, 18],
+		},
+		{ id: 1802, title: 'Drama Two', poster_path: '/d2.jpg', genre_ids: [18] },
+	],
+	28: [
+		{ id: 2801, title: 'Action One', poster_path: '/a1.jpg', genre_ids: [28] },
+		{ id: 2802, title: 'Action Two', poster_path: '/a2.jpg', genre_ids: [28] },
+	],
+	27: [
+		{ id: 2701, title: 'Horror One', poster_path: '/h1.jpg', genre_ids: [27] },
+		{ id: 2702, title: 'Horror Two', poster_path: '/h2.jpg', genre_ids: [27] },
+	],
+	10749: [
+		{
+			id: 10001,
+			title: 'Romance One',
+			poster_path: '/r1.jpg',
+			genre_ids: [10749],
+		},
+		{
+			id: 10002,
+			title: 'Romance Two',
+			poster_path: '/r2.jpg',
+			genre_ids: [10749],
+		},
+	],
+	878: [
+		{ id: 8701, title: 'Sci-Fi One', poster_path: '/s1.jpg', genre_ids: [878] },
+		{ id: 8702, title: 'Sci-Fi Two', poster_path: '/s2.jpg', genre_ids: [878] },
+	],
+	99: [
+		{
+			id: 9901,
+			title: 'Documentary One',
+			poster_path: '/doc1.jpg',
+			genre_ids: [99],
+		},
+		{
+			id: 9902,
+			title: 'Documentary Two',
+			poster_path: '/doc2.jpg',
+			genre_ids: [99],
+		},
+	],
+	16: [
+		{
+			id: 1601,
+			title: 'Animation One',
+			poster_path: '/an1.jpg',
+			genre_ids: [16],
+		},
+		{
+			id: 1602,
+			title: 'Animation Two',
+			poster_path: '/an2.jpg',
+			genre_ids: [16],
+		},
+	],
+};
+
+/** Replaces the global fetch for the rest of the current test, same intent as
+ * households.e2e.test.ts's `mockExternalApis` -- unreachable/non-deterministic real TMDb calls
+ * are never exercised here. */
+const mockOnboardingDeckApi = (): void => {
+	globalThis.fetch = (async (input: RequestInfo | URL) => {
+		const url =
+			typeof input === 'string'
+				? input
+				: input instanceof URL
+					? input.toString()
+					: input.url;
+		const { hostname, pathname, searchParams } = new URL(url);
+		if (hostname === 'api.themoviedb.org' && pathname === '/3/discover/movie') {
+			const genreId = Number(searchParams.get('with_genres'));
+			return jsonResponse({ results: MOVIES_BY_GENRE[genreId] ?? [] });
+		}
+		throw new Error(`Unmocked fetch in test: ${url}`);
+	}) as typeof fetch;
+};
 
 describe('2FA enroll / verify / login / disable', () => {
 	it('enrolling requires a valid code, then login requires one too', async () => {
@@ -246,5 +365,106 @@ describe('profile updates', () => {
 		expect(second.status).toBe(200);
 		expect(second.body.data.preferences.theme).toBe('light');
 		expect(second.body.data.preferences.autoArchiveDays).toBe(7);
+	});
+});
+
+describe('GET /api/me/taste-onboarding/deck', () => {
+	it('rejects an unauthenticated caller', async () => {
+		const result = await callApp('/api/me/taste-onboarding/deck', {});
+		expect(result.status).toBe(401);
+	});
+
+	it('returns a deck of cards spanning the anchor genres, deduped by tmdbId', async () => {
+		const { cookies } = await createLoggedInUser(uniqueEmail());
+		mockOnboardingDeckApi();
+
+		const result = await callApp<{
+			data: {
+				cards: Array<{
+					tmdbId: number;
+					mediaType: string;
+					title: string;
+					posterPath: string | null;
+					genreIds: number[];
+				}>;
+			};
+		}>('/api/me/taste-onboarding/deck', { cookies });
+		expect(result.status).toBe(200);
+
+		const cards = result.body.data.cards;
+		// 8 anchor genres x top 2 each, minus the one deliberate cross-genre duplicate.
+		expect(cards).toHaveLength(15);
+		expect(cards.every(c => c.mediaType === 'movie')).toBe(true);
+		expect(cards.filter(c => c.tmdbId === 3501)).toHaveLength(1);
+		expect(cards.find(c => c.tmdbId === 3501)?.genreIds).toEqual([35, 18]);
+	});
+});
+
+describe('POST /api/me/taste-onboarding', () => {
+	it('rejects an invalid verdict', async () => {
+		const { cookies } = await createLoggedInUser(uniqueEmail());
+
+		const result = await postJson(
+			'/api/me/taste-onboarding',
+			{
+				likedGenreIds: [],
+				swipes: [
+					{ tmdbId: 1, mediaType: 'movie', genreIds: [18], verdict: 'like' },
+				],
+				providers: [],
+			},
+			cookies
+		);
+		expect(result.status).toBe(400);
+	});
+
+	it('writes a dense taste_profiles row with the expected weights and updates selectedProviders', async () => {
+		const { userId, cookies } = await createLoggedInUser(uniqueEmail());
+
+		const result = await postJson(
+			'/api/me/taste-onboarding',
+			{
+				likedGenreIds: [35],
+				swipes: [
+					{ tmdbId: 1, mediaType: 'movie', genreIds: [18], verdict: 'love' },
+					{
+						tmdbId: 2,
+						mediaType: 'movie',
+						genreIds: [27],
+						verdict: 'not_for_me',
+					},
+				],
+				providers: ['netflix', 'prime'],
+			},
+			cookies
+		);
+		expect(result.status).toBe(200);
+
+		const profileRow = await env.DB.prepare(
+			'SELECT weights FROM taste_profiles WHERE user_id = ?1'
+		)
+			.bind(userId)
+			.first<{ weights: string }>();
+		expect(profileRow).not.toBeNull();
+		const weights = JSON.parse(profileRow!.weights) as {
+			genres: Record<string, number>;
+		};
+		expect(Object.keys(weights.genres)).toHaveLength(18);
+		// Picked genre.
+		expect(weights.genres['35']).toBe(0.75);
+		// Loved-swipe genre: 0.35 + 0.15.
+		expect(weights.genres['18']).toBeCloseTo(0.5, 10);
+		// Not-for-me-swipe genre: 0.35 - 0.2.
+		expect(weights.genres['27']).toBeCloseTo(0.15, 10);
+		// Untouched genre stays at the neutral baseline.
+		expect(weights.genres['28']).toBe(0.35);
+
+		const me = await callApp<{
+			data: { preferences: { selectedProviders?: string[] } };
+		}>('/api/auth/me', { cookies });
+		expect(me.body.data.preferences.selectedProviders).toEqual([
+			'netflix',
+			'prime',
+		]);
 	});
 });

--- a/services/api/src/routes/me.ts
+++ b/services/api/src/routes/me.ts
@@ -1,5 +1,6 @@
 import { authTokens, createDb, users } from '@pairflix/db';
 import {
+	TasteOnboardingRequestSchema,
 	TotpDisableRequestSchema,
 	TotpVerifyRequestSchema,
 	UpdateEmailRequestSchema,
@@ -27,6 +28,7 @@ import { isUniqueConstraintViolation } from '../lib/dbErrors';
 import { sendVerificationEmail } from '../lib/email';
 import { randomToken } from '../lib/id';
 import { revokeOtherSessions } from '../lib/session';
+import { buildOnboardingDeck, submitOnboarding } from '../lib/tasteOnboarding';
 import { verifySecondFactor } from '../lib/two-factor';
 import { requireAuth } from '../middleware/auth';
 import type { AppEnv } from '../types';
@@ -348,4 +350,41 @@ meRoutes.patch('/preferences', async c => {
 		.where(eq(users.id, userId));
 
 	return c.json({ data: { preferences } });
+});
+
+/**
+ * Skippable, shown once per household member at their own join moment (routes/households.ts's
+ * create and accept-invite flows navigate the client here first -- see apps/client's
+ * CreateHouseholdPage/AcceptInvitePage). Both routes below run synchronously, not via
+ * `c.executionCtx.waitUntil` -- unlike the ongoing thumbs-recompute in lib/tasteRecompute.ts, this
+ * is a one-time, user-initiated action with no reason to defer.
+ */
+meRoutes.get('/taste-onboarding/deck', async c => {
+	const cards = await buildOnboardingDeck(c.env);
+	return c.json({ data: { cards } });
+});
+
+meRoutes.post('/taste-onboarding', async c => {
+	const userId = c.get('userId') as string;
+	const parsed = TasteOnboardingRequestSchema.safeParse(
+		await c.req.json().catch(() => null)
+	);
+	if (!parsed.success) {
+		return c.json(
+			{
+				error: 'Invalid input',
+				details: parsed.error.issues.map(i => i.message),
+			},
+			400
+		);
+	}
+
+	const db = createDb(c.env.DB);
+	await submitOnboarding(db, userId, {
+		likedGenreIds: parsed.data.likedGenreIds,
+		swipes: parsed.data.swipes,
+		providers: parsed.data.providers,
+	});
+
+	return c.json({ data: { ok: true } });
 });


### PR DESCRIPTION
### 🚀 What&#39;s New

- ✨ Feature: a 3-step onboarding flow (genre picks → swipe deck → streaming services) that seeds a new household member&#39;s `taste_profiles` row immediately, instead of waiting for watched-together ratings to accumulate.
- ✨ Feature: `GET /api/me/taste-onboarding/deck` and `POST /api/me/taste-onboarding` endpoints.
- 🐛 Fix: `useTonightHomepage.ts`&#39;s read of `preferences.selectedProviders` now type-checks against the real `UserPreferences` type instead of an ad-hoc local workaround — the field existed nowhere in the real type until this PR.
- 📝 Docs: removes the now-completed &#34;Build the onboarding taste-starter&#34; line from `docs/roadmap.md`&#39;s product-work checklist; documents the `selectedProviders` field in `docs/db-schema.md`.

---

### 📝 Description

PR 2 of 2 for the taste-personalization fix (PR 1 — the watched-together thumbs recompute — merged in #74). `taste_profiles` had zero writers since the product pivot; PR 1 fixed that going forward, but a brand-new household still starts from a mood-only, zero-signal pick. This PR closes that cold-start gap.

**Product decisions this implements** (confirmed in review discussion before work started):
- **Skippable**, not blocking — matches the product&#39;s &#34;one title in under 30s&#34; promise; no new friction before first use.
- Shown to **every household member individually, at their own join moment** — both the creator (right after creating the household) and anyone accepting an invite later — not just the creator, since `taste_profiles` is keyed per user.
- Shows **all 18 genres** from `GENRE_NAMES`, not a curated subset.

**Weight-building math** (`services/api/src/lib/tasteOnboarding.ts`, pure function, unit-tested without D1) starts from the same dense-across-all-18-genres baseline PR 1 established in `lib/tasteWeights.ts` — picked genres set to `0.75`, each swiped card&#39;s genres nudged by a fixed `+0.15`/`-0.2` clamped to `[0.05, 1.0]`. No EMA here (unlike PR 1&#39;s ongoing recompute) — there&#39;s no prior rating history yet to decay against; a real thumbs rating later will naturally converge the seed via PR 1&#39;s EMA over subsequent ratings.

**Insertion points**: both `CreateHouseholdPage` and `AcceptInvitePage` now navigate to `/onboarding/taste?next=` instead of navigating directly. Skip or Finish both land on whatever `next` points at, so each flow&#39;s original destination is unchanged — the onboarding step is a detour, not a new terminal page.

Fixes: none (planned follow-up to #74&#39;s review discussion, not an issue)

---

### ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented parts that are complex or non-obvious
- [x] I have updated relevant documentation
- [x] I have added or updated tests
- [x] No new warnings or errors are introduced
- [x] All tests pass locally

**Verification run:**

- [x] `pnpm -r type-check` — clean across all 8 workspaces
- [x] `pnpm -r lint` — 0 errors (pre-existing warnings only, none new)
- [x] `pnpm -r test` — all suites pass: services/api 129, lib.components 505, apps/admin 10, apps/client 20
- [x] `pnpm build` — all 4 buildable workspaces succeed
- [x] Manual real-browser verification (Playwright against local `wrangler dev` + Vite): create-household correctly detours through `/onboarding/taste?next=...`; Skip honors `next` and lands on the original destination; the full genres → swipe → providers → Finish path submits `POST /api/me/taste-onboarding` (200) and then navigates to `next`; a swipe-deck load failure (TMDb unconfigured locally) degrades gracefully to a fallback message instead of breaking the flow, per the TMDb best-effort convention

---

### 📸 Screenshots (if applicable)

Verified live in a real browser rather than screenshots here — see the verification run above. Genre-selection, swipe-deck-error, and provider-selection states were all visually confirmed to render correctly, including that the new `aria-pressed` state on genre chips doesn&#39;t affect their styling.

---

### 🔗 Related Issues / PRs

Follows #74 (taste-model PR 1 — recompute from thumbs ratings — landed there after review found related bugs; see that PR&#39;s history). Completes the taste-personalization fix scoped from the earlier codebase-wide triage.

---

### ⚠️ Notes for Reviewers

- `services/api/src/lib/tasteOnboarding.ts`&#39;s `buildOnboardingGenreWeights` is the one piece worth reading closely if you review one thing — it&#39;s the only place onboarding and the ongoing recompute (PR 1&#39;s `nudgeGenreWeights`) could diverge in the weight shape they produce, and they need to stay compatible since `mergeProfiles` consumes both.
- Second commit addresses Copilot&#39;s review: `submitOnboarding` now writes via `db.batch` instead of `Promise.all` (atomicity, matching `household.ts`), `next=` is validated as an internal path before navigating (guards against a crafted absolute/protocol-relative URL throwing out of `history.pushState`), and the genre chips now expose `aria-pressed`. The union-narrowing suggestion on `buildOnboardingDeck`&#39;s title read wasn&#39;t applied — it already follows the same caller-discriminated-cast pattern `lib/recommendation.ts`&#39;s own `getTitle` uses (see thread for detail).

Co-Authored-By: Claude Sonnet 5
Claude-Session: https://claude.ai/code/session_01XaZAU6ca9bxsD6vhj8j392

---
_Generated by [Claude Code](https://claude.ai/code/session_01XaZAU6ca9bxsD6vhj8j392)_