### PR TITLE
Extend the recommender to TV for genre-compatible moods

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -24,8 +24,10 @@
 - **Two server entry points** (`index.ts` runtime vs orphaned `app.ts`) mount different routes; at
   runtime the **email flows are unreachable** and the user prefix differs. The Hono port collapses
   this to one app and fixes it.
-- **Recommender is movie-only** and runtime-blind (neutral runtime score) despite `movie | tv`
-  plumbing.
+- **Recommender is runtime-blind** (neutral runtime score at ranking time; real runtime is fetched
+  only for display, after the pick is already decided). TV candidates now appear for
+  genre-compatible moods (funny/feelgood/thoughtful); dark/tense/romantic/action stay movie-only --
+  TV's genre taxonomy has no Horror/Romance/Thriller/Action+Adventure equivalent to map onto.
 - **Billing is mock-only** (no Stripe).
 - **Thin tests on the pivot** — no integration tests for any pivot endpoint; several pivot services
   untested.
@@ -119,13 +121,10 @@ generic `POST /:id/pick-events` endpoint's `kind` is narrowed to `swapped`/`dism
 
 **Known gaps, not fixed here:**
 
-- `content` rows created by the provider-cache write path get a placeholder title
-  (`"Untitled movie"`/`"Untitled show"`) — the caching path never fetches real title/poster data,
-  matching Express exactly (a pre-existing gap, not a regression). History entries' `providers`
-  field is real; `title`/`year`/`posterPath` read as the placeholder until something enriches
-  `content` with real metadata -- the natural place is `lib/recommendation.ts`'s hydration step,
-  which already fetches real title/runtime per candidate but doesn't write it back to `content`.
-  Deliberately not bundled into this change; a small, low-risk follow-up.
+- ~~`content` rows created by the provider-cache write path get a placeholder title~~ — fixed in the
+  codebase-triage follow-up: `lib/providers.ts`'s `cacheContentDetails` fetches and writes real
+  title/year/poster/genre ids, called from `lib/recommendation.ts`'s `commitPick` alongside the
+  provider-cache write.
 - The standalone `GET /api/providers/:tmdbId` has no household context, so it can't apply the
   free-tier GB region-lock the way `/:id/pick`, `/:id/history`, and `/:id/picks/:tmdbId/launch` now
   all do -- a free-tier caller can request any region directly through this one endpoint. Closing it
@@ -276,8 +275,13 @@ what's left to actually run a deploy with -- provisioning the target account is 
 
 Independent of the platform, needed before opening to an invited cohort:
 
-- Wire the LLM re-rank and validate it improves first-pick acceptance (premium only).
-- Extend the recommender to TV, and make runtime actually influence scoring.
+- Validate the LLM re-rank actually improves first-pick acceptance (premium only) -- it's wired in
+  and feature-flagged, needs real usage data to judge.
+- ~~Extend the recommender to TV~~ — done for genre-compatible moods (funny/feelgood/thoughtful);
+  dark/tense/romantic/action need a product decision on mapping Horror/Romance/Thriller/
+  Action+Adventure onto TV's different genre taxonomy before they can include TV candidates too.
+- Make runtime actually influence scoring, not just gate the initial `/discover` query -- separate
+  from the TV work above.
 - Feed `ProviderBadges` real provider data on the Tonight card and history.
 - Integration tests for the pick / providers / entitlements paths.
 - Real Stripe (gated on go-live sign-off) — until then premium is comp/mock only.

--- a/services/api/src/lib/genres.ts
+++ b/services/api/src/lib/genres.ts
@@ -23,6 +23,15 @@ export const GENRE_NAMES: Record<number, string> = {
 	37: 'western',
 };
 
+/** TMDb's TV genre list only shares these ids with the movie list above -- TV has no standalone
+ * Horror (27), Romance (10749), or Thriller (53), and merges Action+Adventure into a single id
+ * (10759, not 28+12). `lib/recommendation.ts` only fetches TV candidates when every genre id it
+ * would filter on is in this set, so a `/discover/tv` call never filters on an id that doesn't
+ * exist in TV's taxonomy. */
+export const TV_COMPATIBLE_GENRE_IDS = new Set<number>([
+	16, 35, 80, 99, 18, 10751, 9648, 37,
+]);
+
 export const MOOD_FILTERS: Record<Mood, { genres: number[]; label: string }> = {
 	funny: { genres: [35], label: 'comedy' },
 	dark: { genres: [80, 53], label: 'dark crime/thriller' },

--- a/services/api/src/lib/recommendation.ts
+++ b/services/api/src/lib/recommendation.ts
@@ -9,7 +9,7 @@ import { eq, inArray } from 'drizzle-orm';
 import type { CommitPickRequest, PickRequest } from '@pairflix/lib.validation';
 import type { Bindings } from '../types';
 import { isLlmRerankEnabledForHousehold } from './featureFlags';
-import { GENRE_NAMES, MOOD_FILTERS } from './genres';
+import { GENRE_NAMES, MOOD_FILTERS, TV_COMPATIBLE_GENRE_IDS } from './genres';
 import { newId } from './id';
 import {
 	rerankCandidates,
@@ -338,23 +338,57 @@ export const pickForHousehold = async (
 	const genres = topMergedGenres(merged, moodCfg.genres, 3);
 
 	const watchedRows = await db
-		.select({ tmdbId: watchedTogether.tmdbId })
+		.select({
+			tmdbId: watchedTogether.tmdbId,
+			mediaType: watchedTogether.mediaType,
+		})
 		.from(watchedTogether)
 		.where(eq(watchedTogether.householdId, householdId));
-	const excluded = new Set<number>([
-		...watchedRows.map(w => w.tmdbId),
-		...(request.excludeTmdbIds ?? []),
-	]);
+	// Keyed by tmdbId+mediaType, not tmdbId alone -- movie and TV ids are assigned from separate
+	// TMDb id spaces, so a watched movie must not exclude an unrelated TV show (or vice versa)
+	// that happens to share the same numeric id, now that both are candidate sources below.
+	const excludedWatched = new Set<string>(
+		watchedRows.map(w => `${w.tmdbId}:${w.mediaType}`)
+	);
+	const excludedRequested = new Set<number>(request.excludeTmdbIds ?? []);
 
-	const discoverResp = await discoverMedia(env, {
-		mediaType: 'movie',
+	const discoverParams = {
 		genres,
 		withRuntimeLte: request.minutes,
 		voteCountGte: 200,
 		region,
-	});
-	const filtered = (discoverResp.results ?? []).filter(
-		c => !excluded.has(c.id)
+	};
+	// Only fetch TV candidates when every genre this pick filters on (mood genres, plus up to 3
+	// more pulled in from the household's taste weights) is valid in TV's genre taxonomy -- see
+	// TV_COMPATIBLE_GENRE_IDS's doc comment. Household taste can inject an incompatible id even
+	// under an eligible mood, so the TV call itself filters on the compatible subset of `genres`,
+	// not the full list the movie call uses.
+	const tvEligible = moodCfg.genres.every(g => TV_COMPATIBLE_GENRE_IDS.has(g));
+	const [movieResp, tvResp] = await Promise.all([
+		discoverMedia(env, { ...discoverParams, mediaType: 'movie' }),
+		tvEligible
+			? discoverMedia(env, {
+					...discoverParams,
+					genres: genres.filter(g => TV_COMPATIBLE_GENRE_IDS.has(g)),
+					mediaType: 'tv',
+				})
+			: Promise.resolve({ results: [] }),
+	]);
+
+	const candidates = [
+		...(movieResp.results ?? []).map(item => ({
+			item,
+			mediaType: 'movie' as const,
+		})),
+		...(tvResp.results ?? []).map(item => ({
+			item,
+			mediaType: 'tv' as const,
+		})),
+	];
+	const filtered = candidates.filter(
+		c =>
+			!excludedWatched.has(`${c.item.id}:${c.mediaType}`) &&
+			!excludedRequested.has(c.item.id)
 	);
 	if (filtered.length === 0) {
 		throw new NoCandidatesError('No candidates found for these inputs');
@@ -362,13 +396,13 @@ export const pickForHousehold = async (
 
 	const currentYear = new Date().getFullYear();
 	const scored = filtered
-		.map(item => ({
-			item,
+		.map(c => ({
+			...c,
 			// /discover responses don't carry runtime; use null so the runtime component contributes
 			// a neutral 0.5 instead of the gaussian peak -- real runtime is fetched during hydration
 			// below, for display only, and never re-scored.
 			score: scoreCandidate(
-				item,
+				c.item,
 				null,
 				merged,
 				moodCfg.genres,
@@ -388,7 +422,13 @@ export const pickForHousehold = async (
 	const hydrated = await Promise.all(
 		top.map(async entry => ({
 			entry,
-			card: await hydrate(env, entry.item, 'movie', region, request.providers),
+			card: await hydrate(
+				env,
+				entry.item,
+				entry.mediaType,
+				region,
+				request.providers
+			),
 		}))
 	);
 	const paired = hydrated.filter(

--- a/services/api/src/lib/tasteOnboarding.ts
+++ b/services/api/src/lib/tasteOnboarding.ts
@@ -33,8 +33,9 @@ export type OnboardingCard = {
 
 /** One `/discover` call per anchor genre (parallel), top `CARDS_PER_GENRE` each, deduped by
  * tmdbId -- a movie tagged with two anchor genres (e.g. an action-comedy) only appears once, kept
- * with the full `genre_ids` from whichever call it was first seen on. Movie-only, matching the pick
- * path's own `discoverMedia` calls (lib/recommendation.ts). */
+ * with the full `genre_ids` from whichever call it was first seen on. Movie-only -- onboarding has
+ * no mood to gate a TV genre-compatibility check against (see `lib/recommendation.ts`'s
+ * TV_COMPATIBLE_GENRE_IDS use), so it keeps the pick path's original all-movie behavior. */
 export const buildOnboardingDeck = async (
 	env: Bindings
 ): Promise<OnboardingCard[]> => {

--- a/services/api/src/routes/households.e2e.test.ts
+++ b/services/api/src/routes/households.e2e.test.ts
@@ -81,6 +81,35 @@ const MOVIE_C: MockMovie = {
 };
 const DEFAULT_MOVIES = [MOVIE_A, MOVIE_B, MOVIE_C];
 
+type MockShow = {
+	id: number;
+	name: string;
+	overview: string;
+	poster_path: string | null;
+	first_air_date: string;
+	vote_average: number;
+	vote_count: number;
+	genre_ids: number[];
+	popularity: number;
+	episode_run_time: number[];
+	providers?: MockMovie['providers'];
+};
+
+const SHOW_A: MockShow = {
+	id: 201,
+	name: 'The Improv Hour',
+	overview: 'A very funny show.',
+	poster_path: null,
+	// Much more recent than DEFAULT_MOVIES (2019-2021) -- guarantees a strictly higher
+	// recencyBonus, so tests can assert this show wins the pick deterministically.
+	first_air_date: '2026-01-01',
+	vote_average: 8.0,
+	vote_count: 600,
+	genre_ids: [35],
+	popularity: 60,
+	episode_run_time: [30],
+};
+
 const jsonResponse = (data: unknown, status = 200): Response =>
 	new Response(JSON.stringify(data), {
 		status,
@@ -102,7 +131,8 @@ afterEach(() => {
  * shape (e.g. proving the region-lock override reached TMDb). */
 const mockExternalApis = (
 	movies: MockMovie[],
-	anthropic?: MockAnthropic
+	anthropic?: MockAnthropic,
+	shows: MockShow[] = []
 ): string[] => {
 	const capturedUrls: string[] = [];
 	globalThis.fetch = (async (input: RequestInfo | URL) => {
@@ -118,6 +148,8 @@ const mockExternalApis = (
 		if (hostname === 'api.themoviedb.org') {
 			if (pathname === '/3/discover/movie')
 				return jsonResponse({ results: movies });
+			if (pathname === '/3/discover/tv')
+				return jsonResponse({ results: shows });
 			const detail = /^\/3\/movie\/(\d+)$/.exec(pathname);
 			if (detail) {
 				const movie = movies.find(m => m.id === Number(detail[1]));
@@ -135,11 +167,35 @@ const mockExternalApis = (
 					})),
 				});
 			}
+			const tvDetail = /^\/3\/tv\/(\d+)$/.exec(pathname);
+			if (tvDetail) {
+				const show = shows.find(s => s.id === Number(tvDetail[1]));
+				if (!show) return jsonResponse({}, 404);
+				return jsonResponse({
+					id: show.id,
+					name: show.name,
+					overview: show.overview,
+					poster_path: show.poster_path,
+					episode_run_time: show.episode_run_time,
+					first_air_date: show.first_air_date,
+					genres: show.genre_ids.map(id => ({
+						id,
+						name: GENRE_NAMES[id] ?? 'Unknown',
+					})),
+				});
+			}
 			const providers = /^\/3\/movie\/(\d+)\/watch\/providers$/.exec(pathname);
 			if (providers) {
 				const movie = movies.find(m => m.id === Number(providers[1]));
 				return jsonResponse({
 					results: movie?.providers ? { GB: movie.providers } : {},
+				});
+			}
+			const tvProviders = /^\/3\/tv\/(\d+)\/watch\/providers$/.exec(pathname);
+			if (tvProviders) {
+				const show = shows.find(s => s.id === Number(tvProviders[1]));
+				return jsonResponse({
+					results: show?.providers ? { GB: show.providers } : {},
 				});
 			}
 		}
@@ -492,6 +548,69 @@ describe('POST /api/households/:id/pick', () => {
 			cookies
 		);
 		expect(result.status).toBe(404);
+	});
+});
+
+describe('POST /api/households/:id/pick -- TV candidates', () => {
+	it('can win the pick under a TV-compatible mood', async () => {
+		const { cookies } = await createLoggedInUser(uniqueEmail());
+		const householdId = await createHousehold(cookies);
+
+		mockExternalApis(DEFAULT_MOVIES, undefined, [SHOW_A]);
+		const result = await postJson<{
+			pick: { tmdbId: number; mediaType: string };
+		}>(
+			`/api/households/${householdId}/pick`,
+			{ mood: 'funny', minutes: 120 },
+			cookies
+		);
+		expect(result.status).toBe(200);
+		expect(result.body.pick.mediaType).toBe('tv');
+		expect(result.body.pick.tmdbId).toBe(SHOW_A.id);
+	});
+
+	it('never queries TV for a mood outside the TV-compatible genre set', async () => {
+		const { cookies } = await createLoggedInUser(uniqueEmail());
+		const householdId = await createHousehold(cookies);
+
+		// action mood's genres (28 action, 12 adventure) have no TV equivalent -- see
+		// TV_COMPATIBLE_GENRE_IDS.
+		const capturedUrls = mockExternalApis(DEFAULT_MOVIES, undefined, [SHOW_A]);
+		const result = await postJson(
+			`/api/households/${householdId}/pick`,
+			{ mood: 'action', minutes: 120 },
+			cookies
+		);
+		expect(result.status).toBe(200);
+		expect(capturedUrls.some(u => u.includes('/3/discover/tv'))).toBe(false);
+	});
+
+	it('does not exclude a TV candidate whose id matches a watched movie', async () => {
+		const { cookies } = await createLoggedInUser(uniqueEmail());
+		const householdId = await createHousehold(cookies);
+
+		mockExternalApis(DEFAULT_MOVIES);
+		await postJson(
+			`/api/households/${householdId}/picks/${MOVIE_A.id}/commit`,
+			{ mediaType: 'movie', mood: 'funny', minutes: 120 },
+			cookies
+		);
+
+		// Movie and TV tmdb ids come from separate TMDb id spaces, so a TV show legitimately
+		// sharing MOVIE_A's numeric id is a real (if coincidental) scenario, not a malformed
+		// fixture -- the watched-together exclusion must key on tmdbId+mediaType, not tmdbId alone.
+		const showSharingId: MockShow = { ...SHOW_A, id: MOVIE_A.id };
+		mockExternalApis(DEFAULT_MOVIES, undefined, [showSharingId]);
+		const result = await postJson<{
+			pick: { tmdbId: number; mediaType: string };
+		}>(
+			`/api/households/${householdId}/pick`,
+			{ mood: 'funny', minutes: 120 },
+			cookies
+		);
+		expect(result.status).toBe(200);
+		expect(result.body.pick.mediaType).toBe('tv');
+		expect(result.body.pick.tmdbId).toBe(MOVIE_A.id);
 	});
 });
 


### PR DESCRIPTION
### 🚀 What's New

- ✨ Feature: `POST /households/:id/pick` now fetches TV candidates alongside movies for moods whose genres exist in TMDb's TV taxonomy (funny, feelgood, thoughtful), so those moods can return a TV show instead of always a movie.
- 🐛 Fix: the watched-together exclusion set was keyed on bare `tmdbId`, so a watched movie could wrongly exclude an unrelated TV show sharing the same numeric id (movie and TV ids come from separate TMDb id spaces) — now keyed on `tmdbId` + `mediaType`. Latent since the recommender launched; only became reachable once TV candidates existed.
- 📝 Docs: two stale `roadmap.md` notes caught along the way — see below.

---

### 📝 Description

Picks up the "extend the recommender to TV" item from the roadmap's closed-alpha checklist. TMDb uses a **different genre taxonomy for TV than movies**: no standalone Horror (27), Romance (10749), or Thriller (53), and Action+Adventure merge into a single id (10759, not 28+12) — while `GENRE_NAMES`/`MOOD_FILTERS`/`taste_profiles` are entirely movie-genre-id-keyed. Passing a movie-only genre id to `/discover/tv`'s `with_genres` would filter on an id that doesn't exist in TV's space.

**Scoping decision** (confirmed in review discussion before work started): only fetch TV for moods whose genres are valid TV ids — funny (comedy=35), feelgood (family=10751, comedy=35), thoughtful (drama=18) — since those happen to be identical ids in both taxonomies. `dark`/`tense`/`romantic`/`action` stay movie-only; mapping Horror/Romance/Thriller/Action+Adventure onto TV's genre space is a separate product decision (documented in `roadmap.md`), not made here.

**Implementation** (`services/api/src/lib/recommendation.ts`'s `pickForHousehold`): most of the scoring/hydration pipeline (`scoreCandidate`, `hydrate`, `getTitle`, `getYear`) was already `mediaType`-generic — only the actual `discoverMedia` call and the hydrate-mediaType argument were hardcoded to `'movie'`. Now fetches movie and TV candidates in parallel (TV only when `moodCfg.genres` are all TV-compatible), tags each candidate with its origin `mediaType`, and filters the TV discover call's own genre list down to the TV-compatible subset of `genres` (which can include up to 3 more ids pulled in from the household's taste weights, potentially incompatible even under an eligible mood).

New `TV_COMPATIBLE_GENRE_IDS` constant in `lib/genres.ts` documents the taxonomy overlap (comedy/drama/family/crime/documentary/mystery/western/animation — 8 of 18 movie genre ids).

---

### ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented parts that are complex or non-obvious
- [x] I have updated relevant documentation
- [x] I have added or updated tests
- [x] No new warnings or errors are introduced
- [x] All tests pass locally

**Verification run:**

- [x] `pnpm -r type-check` — clean across all 8 workspaces
- [x] `pnpm -r lint` — 0 errors (pre-existing warnings only, none new, none in touched files)
- [x] `pnpm -r test` — services/api 132/132 (3 new: TV wins under an eligible mood, no `/discover/tv` call under an ineligible mood, a TV candidate isn't excluded by a watched movie sharing its numeric id)
- [x] `pnpm build` — all 4 buildable workspaces succeed, including the Worker's `wrangler deploy --dry-run` bundle check

---

### 📸 Screenshots (if applicable)

N/A — backend-only change. The client already threads `card.mediaType` generically through launch/record-pick-event/commit (no hardcoded `'movie'` assumption), so no client changes were needed for real TV picks to work end-to-end.

---

### 🔗 Related Issues / PRs

Follows the closed-alpha checklist in `docs/roadmap.md` ("Product work to reach closed alpha"), item scoped after the earlier codebase-wide triage (#74, #75).

---

### ⚠️ Notes for Reviewers

- The genre-taxonomy mismatch (and which moods to scope TV to) was a real product/design decision, not a pure engineering call — confirmed before implementation rather than picked silently.
- `roadmap.md` also picked up two unrelated stale-doc corrections noticed while updating the same sections: the "`content` gets a placeholder title" gap was already closed by an earlier commit's `cacheContentDetails` wiring (verified it's actually called from `commitPick`), and "wire the LLM re-rank" was already done — only "validate it improves acceptance" is still open.
- Runtime still doesn't influence scoring (real runtime is only fetched for display, after the pick is decided) — left as a separate, still-open roadmap item, not bundled into this change.

Co-Authored-By: Claude Sonnet 5
Claude-Session: https://claude.ai/code/session_01XaZAU6ca9bxsD6vhj8j392

---
_Generated by [Claude Code](https://claude.ai/code/session_01XaZAU6ca9bxsD6vhj8j392)_