### PR TITLE
Make runtime actually influence which pick wins

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -282,8 +282,14 @@ Independent of the platform, needed before opening to an invited cohort:
   Action+Adventure onto TV's different genre taxonomy before they can include TV candidates too.
 - Make runtime actually influence scoring, not just gate the initial `/discover` query -- separate
   from the TV work above.
-- Feed `ProviderBadges` real provider data on the Tonight card and history.
-- Integration tests for the pick / providers / entitlements paths.
+- ~~Feed `ProviderBadges` real provider data on the Tonight card and history~~ — done; History wires
+  real API provider data into the shared component (`HistoryPage.tsx`), and Tonight's own launch
+  buttons (a bespoke UI, not the shared component -- it needs launch `onClick`s the component's
+  static-link-only API doesn't support) have read real `pick.providers` since before this checklist
+  item was written.
+- ~~Integration tests for the pick / providers / entitlements paths~~ — done; `households.e2e.test.ts`
+  and `providers.e2e.test.ts` cover all three, including the quota-atomicity race and region-lock
+  enforcement.
 - Real Stripe (gated on go-live sign-off) — until then premium is comp/mock only.
 
 **Alpha exit criteria:** a real household can create an account, get a genuinely good first pick in

--- a/services/api/src/lib/recommendation.ts
+++ b/services/api/src/lib/recommendation.ts
@@ -399,8 +399,9 @@ export const pickForHousehold = async (
 		.map(c => ({
 			...c,
 			// /discover responses don't carry runtime; use null so the runtime component contributes
-			// a neutral 0.5 instead of the gaussian peak -- real runtime is fetched during hydration
-			// below, for display only, and never re-scored.
+			// a neutral 0.5 instead of the gaussian peak for every candidate alike here. This score
+			// only decides which candidates get hydrated (real runtime fetched below) -- the `ranked`
+			// re-score after hydration is what actually decides the final pick.
 			score: scoreCandidate(
 				c.item,
 				null,
@@ -439,8 +440,30 @@ export const pickForHousehold = async (
 		throw new NoCandidatesError('No candidates matched the provider filter');
 	}
 
-	const cards = paired.map(p => p.card);
-	const mlPick = paired[0]!;
+	// Re-score with each candidate's now-known real runtime (the scoring pass above used null,
+	// since /discover doesn't carry it) and re-sort -- the pre-hydration order only ever reflected
+	// a neutral runtime guess for every candidate alike, so this is the first point a candidate's
+	// actual fit for the household's time budget can affect which one wins, not just display copy.
+	const ranked = paired
+		.map(p => ({
+			...p,
+			score: scoreCandidate(
+				p.entry.item,
+				p.card.runtime,
+				merged,
+				moodCfg.genres,
+				request.minutes,
+				currentYear
+			),
+		}))
+		.sort((a, b) =>
+			b.score !== a.score
+				? b.score - a.score
+				: b.entry.item.vote_average - a.entry.item.vote_average
+		);
+
+	const cards = ranked.map(p => p.card);
+	const mlPick = ranked[0]!;
 	const mlResult: RecommendationResult = {
 		pick: mlPick.card,
 		alternates: cards.slice(1, 3),
@@ -452,10 +475,10 @@ export const pickForHousehold = async (
 			mlPick.card.runtime,
 			pickProviderName(mlPick.card.providers)
 		),
-		score: mlPick.entry.score,
+		score: mlPick.score,
 	};
 
-	if (!llmEligible || paired.length < 2) {
+	if (!llmEligible || ranked.length < 2) {
 		return mlResult;
 	}
 
@@ -468,7 +491,7 @@ export const pickForHousehold = async (
 		}),
 	}));
 
-	const llmCandidates: LlmCandidate[] = paired.map(p => ({
+	const llmCandidates: LlmCandidate[] = ranked.map(p => ({
 		tmdbId: p.card.tmdbId,
 		title: p.card.title,
 		year: p.card.year ?? currentYear,
@@ -498,7 +521,7 @@ export const pickForHousehold = async (
 	}
 	if (!llmResult) return mlResult;
 
-	const byTmdbId = new Map(paired.map(p => [p.card.tmdbId, p]));
+	const byTmdbId = new Map(ranked.map(p => [p.card.tmdbId, p]));
 	const llmPick = byTmdbId.get(llmResult.pickTmdbId);
 	if (!llmPick) return mlResult;
 
@@ -511,7 +534,7 @@ export const pickForHousehold = async (
 		pick: llmPick.card,
 		alternates: llmAlternates,
 		rationale: llmResult.rationale,
-		score: llmPick.entry.score,
+		score: llmPick.score,
 	};
 };
 

--- a/services/api/src/routes/households.e2e.test.ts
+++ b/services/api/src/routes/households.e2e.test.ts
@@ -95,6 +95,37 @@ type MockShow = {
 	providers?: MockMovie['providers'];
 };
 
+// A deliberately-mismatched pair for the runtime re-ranking test below: OLD_GOOD_RUNTIME scores
+// lower pre-hydration (older, so a smaller recencyBonus) but has a real runtime close to the
+// gaussian peak for a 120-minute request; NEW_BAD_RUNTIME scores higher pre-hydration (brand new,
+// full recencyBonus) but its real runtime is far too short. Pre-hydration scoring can't see either
+// runtime (uses a neutral 0.5 for both), so it ranks NEW_BAD_RUNTIME first; only a re-score after
+// hydration (once real runtime is known) can correct that.
+const OLD_GOOD_RUNTIME_MOVIE: MockMovie = {
+	id: 301,
+	title: 'The Right Length',
+	overview: 'An older movie with a great runtime fit.',
+	poster_path: null,
+	release_date: '2015-01-01',
+	vote_average: 6.0,
+	vote_count: 250,
+	genre_ids: [35],
+	popularity: 20,
+	runtime: 112,
+};
+const NEW_BAD_RUNTIME_MOVIE: MockMovie = {
+	id: 302,
+	title: 'Too Short',
+	overview: 'A brand-new movie that runs far too short.',
+	poster_path: null,
+	release_date: '2026-01-01',
+	vote_average: 6.0,
+	vote_count: 250,
+	genre_ids: [35],
+	popularity: 20,
+	runtime: 20,
+};
+
 const SHOW_A: MockShow = {
 	id: 201,
 	name: 'The Improv Hour',
@@ -107,7 +138,10 @@ const SHOW_A: MockShow = {
 	vote_count: 600,
 	genre_ids: [35],
 	popularity: 60,
-	episode_run_time: [30],
+	// Close to DEFAULT_MOVIES' runtimes (95-110), not a real half-hour-comedy episode length --
+	// keeps this fixture winning on recencyBonus specifically in tests that use a ~120-minute
+	// request, isolated from the real-runtime re-ranking covered by its own test below.
+	episode_run_time: [112],
 };
 
 const jsonResponse = (data: unknown, status = 200): Response =>
@@ -611,6 +645,22 @@ describe('POST /api/households/:id/pick -- TV candidates', () => {
 		expect(result.status).toBe(200);
 		expect(result.body.pick.mediaType).toBe('tv');
 		expect(result.body.pick.tmdbId).toBe(MOVIE_A.id);
+	});
+});
+
+describe('POST /api/households/:id/pick -- runtime-aware ranking', () => {
+	it('re-ranks by real runtime after hydration, not the pre-hydration neutral guess', async () => {
+		const { cookies } = await createLoggedInUser(uniqueEmail());
+		const householdId = await createHousehold(cookies);
+
+		mockExternalApis([OLD_GOOD_RUNTIME_MOVIE, NEW_BAD_RUNTIME_MOVIE]);
+		const result = await postJson<{ pick: { tmdbId: number } }>(
+			`/api/households/${householdId}/pick`,
+			{ mood: 'funny', minutes: 120 },
+			cookies
+		);
+		expect(result.status).toBe(200);
+		expect(result.body.pick.tmdbId).toBe(OLD_GOOD_RUNTIME_MOVIE.id);
 	});
 });
 


### PR DESCRIPTION
### 🚀 What's New

- 🐛 Fix: `POST /households/:id/pick` now re-scores candidates with their real runtime after hydration and uses that to decide the final pick, alternates, and (when eligible) the LLM re-rank candidate list — previously the only ranking pass used a neutral runtime guess for every candidate, so a much better runtime fit couldn't win over a candidate that merely scored better on genre/mood/recency.
- 📝 Docs: two more stale `roadmap.md` checklist items struck — see below.

---

### 📝 Description

Closes the other half of the "extend the recommender to TV, and make runtime actually influence scoring" roadmap item (the TV half shipped in #76). `pickForHousehold`'s initial `scoreCandidate` pass always passes `runtime: null` — `/discover` responses don't carry it — so the runtime term of the score (weighted 0.2) contributes the same neutral `0.5` to every candidate alike. That score only ever decided *which* candidates got hydrated. Real runtime, fetched during `hydrate()`, was previously used for display copy only (`buildRationale`'s "fits your X-minute slot at Y min") and never fed back into the ranking that actually chose the pick.

Added a re-score-and-resort pass (`ranked`) right after hydration, once each candidate's real runtime is known, and threaded it through everywhere the old pre-hydration-ordered `paired` was used downstream (`cards`/`mlPick` for the pure-ML result, `llmCandidates`/`byTmdbId` for the LLM re-rank path). No new TMDb calls — hydration already fetches real runtime for the top-N candidates; this just uses it.

---

### ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented parts that are complex or non-obvious
- [x] I have updated relevant documentation
- [x] I have added or updated tests
- [x] No new warnings or errors are introduced
- [x] All tests pass locally

**Verification run:**

- [x] `pnpm -r type-check` — clean across all 8 workspaces
- [x] `pnpm --filter @pairflix/api lint` — 0 errors
- [x] `pnpm --filter @pairflix/api test` — 133/133 (1 new: a deliberately-mismatched pair where the pre-hydration-favored candidate — newer, so a higher recency bonus — loses after re-scoring to an older candidate whose real runtime is a near-perfect fit; also caught and fixed a fixture bug in an earlier commit's TV-candidate tests, whose mock show's runtime hadn't been fitted to the request minutes and started losing once real runtime started mattering)
- [x] `pnpm --filter @pairflix/api build` — Worker's `wrangler deploy --dry-run` bundle check succeeds

---

### 📸 Screenshots (if applicable)

N/A — backend-only ranking change, no API contract or UI change.

---

### 🔗 Related Issues / PRs

Other half of the roadmap item split across #76 (TV candidates) and this PR (runtime scoring) — same underlying "Product work to reach closed alpha" checklist entry.

---

### ⚠️ Notes for Reviewers

- The new `ranked` step re-runs the same pure `scoreCandidate` function already used for the pre-hydration pass, just with `p.card.runtime` instead of `null` — worth comparing the two call sites side by side if you review one thing.
- `roadmap.md` also picked up two more stale-doc corrections while updating the same section (following the same pattern as #76's docs fixes): `ProviderBadges` already renders real provider data (History wires it in directly; Tonight's own launch buttons — a separate, bespoke UI — have read real `pick.providers` since before this checklist item existed), and the pick/providers/entitlements integration-test coverage is already comprehensive, including the quota-atomicity race and region-lock enforcement tests.

Co-Authored-By: Claude Sonnet 5
Claude-Session: https://claude.ai/code/session_01XaZAU6ca9bxsD6vhj8j392

---
_Generated by [Claude Code](https://claude.ai/code/session_01XaZAU6ca9bxsD6vhj8j392)_