### PR TITLE
feat(api): automate audit-log retention via a Cloudflare Cron Trigger

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -23,7 +23,7 @@ many households** — not per-tenant infrastructure, and not a fleet of services
                  ┌──────────────────────────────┐ ┌───────────────────────────┐
    admins   ───► │ apps/admin (Pages SPA)        │►│ services/api (Worker, Hono)│
                  │  users · content moderation    │ │  ├─ fetch:     REST API     │
-                 └──────────────────────────────┘ │  └─ scheduled: cron refresh │
+                 └──────────────────────────────┘ │  └─ scheduled: log rotation │
                                                    └────────┬──────────┬─────────┘
                                                             ▼          ▼
                                                         D1 (SQLite)  R2 (optional)
@@ -152,11 +152,20 @@ still exist.
 
 ## Background work (cron)
 
-Target: a Workers **cron trigger** running provider-cache refresh and taste-profile recompute, so a
-cache miss never blocks a request. Not implemented yet -- today provider caching is entirely
-lazy/on-demand (see Providers & regions, above), matching what the Express version it replaces did.
-Processing would be inline to start (no Cloudflare Queues, which need the Workers Paid plan); move
-to a queue only when volume justifies the plan, exactly as creatorgrid defers it.
+`services/api`'s `scheduled` handler (`src/index.ts`) runs a daily Workers **Cron Trigger**
+(`wrangler.jsonc`'s `triggers.crons`, `"0 3 * * *"`) that calls `lib/adminAuditLogs.ts`'s
+`rotateAuditLogsOnSchedule` -- the same per-level retention sweep as the manual
+`POST /api/admin/audit-logs/rotation` route, logged under the `cron` source so it's distinguishable
+from an admin-triggered run.
+
+A provider-cache refresh cron remains unbuilt -- today provider caching is entirely lazy/on-demand
+(see Providers & regions, above), matching what the Express version it replaces did. Unlike
+audit-log retention, its scope isn't decided yet (what to refresh, on what interval, at what TMDb
+API quota cost). Taste-profile recompute doesn't need a cron at all -- `lib/tasteRecompute.ts`
+already recomputes it synchronously on every watched-together rating, not on a schedule.
+
+Any future cron processing would be inline to start (no Cloudflare Queues, which need the Workers
+Paid plan); move to a queue only when volume justifies the plan, exactly as creatorgrid defers it.
 
 ## Deploying
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -185,11 +185,14 @@ Copilot review finding on this PR). Terminating a user's session is also now gen
 a Hono `sessions` row is the live credential `sessionMiddleware` checks on every request, unlike
 Express's `user_sessions` rows, which were never consulted by its own auth middleware.
 
-**Known gap, not fixed here:** the automatic daily audit-log retention sweep (Express: a
-`node-cron` job) isn't ported -- a stateless Worker has no equivalent always-running process for it.
-`POST /api/admin/audit-logs/rotation` covers the manual/on-demand half; the automatic half needs a
-Cloudflare Cron Trigger, same "not implemented yet" status as the provider-cache refresh cron noted
-below.
+~~**Known gap, not fixed here:** the automatic daily audit-log retention sweep isn't ported~~ --
+fixed in a later pass: `lib/adminAuditLogs.ts`'s `rotateAuditLogsOnSchedule` runs the same
+`cleanupOldLogs` sweep as the manual `POST /api/admin/audit-logs/rotation` route, wired into
+`src/index.ts`'s `scheduled` handler and triggered daily via `wrangler.jsonc`'s `triggers.crons`
+(`"0 3 * * *"`, off-peak UTC) -- a stateless Worker has no always-running process, but a Cron
+Trigger doesn't need one. The provider-cache refresh cron noted below remains unbuilt; its scope
+(what to refresh, on what interval, at what TMDb-quota cost) isn't decided yet, unlike audit-log
+retention's already-settled per-level policy.
 
 22 new `vitest-pool-workers` tests (`admin.e2e.test.ts`, new, plus `households.e2e.test.ts`
 extended) covering the auth gate, each of the behavior fixes above, and the billing/entitlements

--- a/services/api/docs/SECURITY.md
+++ b/services/api/docs/SECURITY.md
@@ -41,13 +41,15 @@ this Worker only ever returns JSON) and `hono/cors`, restricted to the origins l
 
 `lib/audit.ts` writes structured rows (`level`, `message`, `source`, JSON `context`) to the
 `audit_logs` D1 table for auth and admin actions. `GET /api/admin/audit-logs` (paginated) and
-`POST /api/admin/audit-logs/rotation` (manual retention sweep) expose it to admins — see
-`docs/roadmap.md`'s P3 billing/admin notes for what's intentionally not automated yet (no
-cron-driven retention; a stateless Worker has no long-running process for one).
+`POST /api/admin/audit-logs/rotation` (manual retention sweep, source `admin`) expose it to admins;
+`rotateAuditLogsOnSchedule` (`lib/adminAuditLogs.ts`, source `cron`) runs the same sweep
+automatically via a daily Cloudflare Cron Trigger (`wrangler.jsonc`'s `triggers.crons`) — see
+`docs/roadmap.md`'s P3 billing/admin notes for the history.
 
 ## Known gaps
 
 Documented rather than silently left out — see `docs/roadmap.md` for the phase each was deferred in:
 
-- No cron-driven audit-log retention sweep (manual only, via the rotation endpoint above).
+- No cron-driven provider-cache refresh (lazy/on-demand only) -- unlike audit-log retention, its
+  scope (what to refresh, on what interval, at what TMDb-quota cost) isn't decided yet.
 - Real Stripe billing is deferred; the current billing routes are an explicit mock.

--- a/services/api/src/index.ts
+++ b/services/api/src/index.ts
@@ -1,6 +1,8 @@
+import { createDb } from '@pairflix/db';
 import { Hono } from 'hono';
 import { cors } from 'hono/cors';
 import { secureHeaders } from 'hono/secure-headers';
+import { rotateAuditLogsOnSchedule } from './lib/adminAuditLogs';
 import { sessionMiddleware } from './middleware/auth';
 import { csrfMiddleware } from './middleware/csrf';
 import { adminRoutes } from './routes/admin';
@@ -56,4 +58,7 @@ app.onError((error, c) => {
 
 export default {
 	fetch: app.fetch,
+	async scheduled(_controller, env, ctx) {
+		ctx.waitUntil(rotateAuditLogsOnSchedule(createDb(env.DB)));
+	},
 } satisfies ExportedHandler<Bindings>;

--- a/services/api/src/index.ts
+++ b/services/api/src/index.ts
@@ -59,6 +59,10 @@ app.onError((error, c) => {
 export default {
 	fetch: app.fetch,
 	async scheduled(_controller, env, ctx) {
-		ctx.waitUntil(rotateAuditLogsOnSchedule(createDb(env.DB)));
+		ctx.waitUntil(
+			rotateAuditLogsOnSchedule(createDb(env.DB)).catch(err => {
+				console.error('[cron] failed to rotate audit logs', err);
+			})
+		);
 	},
 } satisfies ExportedHandler<Bindings>;

--- a/services/api/src/lib/adminAuditLogs.test.ts
+++ b/services/api/src/lib/adminAuditLogs.test.ts
@@ -1,0 +1,77 @@
+import { env } from 'cloudflare:workers';
+import { auditLogs, createDb } from '@pairflix/db';
+import { and, desc, eq } from 'drizzle-orm';
+import { describe, expect, it } from 'vitest';
+import { newId } from './id';
+import { rotateAuditLogsOnSchedule } from './adminAuditLogs';
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+const seedLog = async (
+	level: 'info' | 'warn' | 'error' | 'debug',
+	ageDays: number
+): Promise<string> => {
+	const db = createDb(env.DB);
+	const id = newId('audit');
+	await db.insert(auditLogs).values({
+		id,
+		level,
+		message: 'test log',
+		source: 'test',
+		context: {},
+		createdAt: new Date(Date.now() - ageDays * MS_PER_DAY),
+	});
+	return id;
+};
+
+describe('rotateAuditLogsOnSchedule', () => {
+	it('deletes rows past the default retention window and leaves recent rows', async () => {
+		const db = createDb(env.DB);
+		const oldInfo = await seedLog('info', 40); // default: 30 days
+		const recentInfo = await seedLog('info', 1);
+		const oldWarn = await seedLog('warn', 100); // default: 90 days
+		const recentWarn = await seedLog('warn', 1);
+
+		await rotateAuditLogsOnSchedule(db);
+
+		const remaining = await db
+			.select({ id: auditLogs.id })
+			.from(auditLogs)
+			.where(eq(auditLogs.source, 'test'));
+		const remainingIds = remaining.map(row => row.id);
+
+		expect(remainingIds).not.toContain(oldInfo);
+		expect(remainingIds).not.toContain(oldWarn);
+		expect(remainingIds).toContain(recentInfo);
+		expect(remainingIds).toContain(recentWarn);
+	});
+
+	it("records the run under the 'cron' source with the deleted counts", async () => {
+		const db = createDb(env.DB);
+		await seedLog('info', 40);
+
+		await rotateAuditLogsOnSchedule(db);
+
+		// Storage isn't reset between `it()` blocks in this file (see the first test, which also
+		// triggers a rotation), so this test's own run is whichever cron-sourced row is newest,
+		// not necessarily the only one.
+		const [latestCronLog] = await db
+			.select()
+			.from(auditLogs)
+			.where(
+				and(
+					eq(auditLogs.source, 'cron'),
+					eq(auditLogs.message, 'Cron ran audit log rotation')
+				)
+			)
+			.orderBy(desc(auditLogs.createdAt))
+			.limit(1);
+
+		expect(latestCronLog?.context).toEqual({
+			info: 1,
+			warn: 0,
+			error: 0,
+			debug: 0,
+		});
+	});
+});

--- a/services/api/src/lib/adminAuditLogs.test.ts
+++ b/services/api/src/lib/adminAuditLogs.test.ts
@@ -1,6 +1,6 @@
 import { env } from 'cloudflare:workers';
 import { auditLogs, createDb } from '@pairflix/db';
-import { and, desc, eq } from 'drizzle-orm';
+import { and, eq } from 'drizzle-orm';
 import { describe, expect, it } from 'vitest';
 import { newId } from './id';
 import { rotateAuditLogsOnSchedule } from './adminAuditLogs';
@@ -48,14 +48,15 @@ describe('rotateAuditLogsOnSchedule', () => {
 
 	it("records the run under the 'cron' source with the deleted counts", async () => {
 		const db = createDb(env.DB);
+		// Storage isn't reset between `it()` blocks in this file (see the first test, which also
+		// triggers a rotation), so this test's own run isn't necessarily the only cron-sourced row
+		// -- clear any that exist first, scoping the assertion below to this test's own call.
+		await db.delete(auditLogs).where(eq(auditLogs.source, 'cron'));
 		await seedLog('info', 40);
 
 		await rotateAuditLogsOnSchedule(db);
 
-		// Storage isn't reset between `it()` blocks in this file (see the first test, which also
-		// triggers a rotation), so this test's own run is whichever cron-sourced row is newest,
-		// not necessarily the only one.
-		const [latestCronLog] = await db
+		const cronLogs = await db
 			.select()
 			.from(auditLogs)
 			.where(
@@ -63,11 +64,10 @@ describe('rotateAuditLogsOnSchedule', () => {
 					eq(auditLogs.source, 'cron'),
 					eq(auditLogs.message, 'Cron ran audit log rotation')
 				)
-			)
-			.orderBy(desc(auditLogs.createdAt))
-			.limit(1);
+			);
 
-		expect(latestCronLog?.context).toEqual({
+		expect(cronLogs).toHaveLength(1);
+		expect(cronLogs[0]?.context).toEqual({
 			info: 1,
 			warn: 0,
 			error: 0,

--- a/services/api/src/lib/adminAuditLogs.ts
+++ b/services/api/src/lib/adminAuditLogs.ts
@@ -1,5 +1,6 @@
 import { auditLogs, type Database } from '@pairflix/db';
 import { and, asc, count, desc, eq, lt, max, min } from 'drizzle-orm';
+import { auditInfo } from './audit';
 
 export type AuditLogEntry = {
 	id: string;
@@ -129,4 +130,15 @@ export const cleanupOldLogs = async (
 	}
 
 	return deleted;
+};
+
+/** Cloudflare Cron Trigger entry point (wired from `scheduled` in index.ts) -- runs the same
+ * cleanup as the manual `POST /audit-logs/rotation` route, at the default per-level retention
+ * policy, and records the result under its own `'cron'` source so the audit log distinguishes a
+ * scheduled run from an admin-triggered one. */
+export const rotateAuditLogsOnSchedule = async (
+	db: Database
+): Promise<void> => {
+	const deleted = await cleanupOldLogs(db);
+	await auditInfo(db, 'Cron ran audit log rotation', 'cron', deleted);
 };

--- a/services/api/src/lib/adminAuditLogs.ts
+++ b/services/api/src/lib/adminAuditLogs.ts
@@ -133,9 +133,9 @@ export const cleanupOldLogs = async (
 };
 
 /** Cloudflare Cron Trigger entry point (wired from `scheduled` in index.ts) -- runs the same
- * cleanup as the manual `POST /audit-logs/rotation` route, at the default per-level retention
- * policy, and records the result under its own `'cron'` source so the audit log distinguishes a
- * scheduled run from an admin-triggered one. */
+ * cleanup as the manual `POST /api/admin/audit-logs/rotation` route, at the default per-level
+ * retention policy, and records the result under its own `'cron'` source so the audit log
+ * distinguishes a scheduled run from an admin-triggered one. */
 export const rotateAuditLogsOnSchedule = async (
 	db: Database
 ): Promise<void> => {

--- a/services/api/wrangler.jsonc
+++ b/services/api/wrangler.jsonc
@@ -30,5 +30,10 @@
 			"migrations_dir": "../../packages/db/migrations",
 			"remote": false
 		}
-	]
+	],
+	// Daily, off-peak UTC -- runs the same audit-log retention sweep as the manual
+	// `POST /api/admin/audit-logs/rotation` route (src/index.ts's `scheduled` handler).
+	"triggers": {
+		"crons": ["0 3 * * *"]
+	}
 }


### PR DESCRIPTION
### 🚀 What's New

- ✨ Feature: audit-log retention now runs automatically on a daily Cloudflare Cron Trigger, not just on-demand via the admin route.
- 🧪 Test: new `lib/adminAuditLogs.test.ts` covering the scheduled sweep.

---

### 📝 Description

Closes a known gap called out in `docs/roadmap.md`'s P3 billing/admin notes and `services/api/docs/SECURITY.md`: `POST /api/admin/audit-logs/rotation` (the retention sweep) only ever ran when an admin manually triggered it — there was no automatic schedule, since a stateless Worker has no long-running process to host one.

- `lib/adminAuditLogs.ts`: new `rotateAuditLogsOnSchedule` runs the existing `cleanupOldLogs` sweep (same default per-level retention policy as the manual route: info 30d, debug 7d, warn 90d, error 365d) and records the result under a `'cron'` audit-log source, so the log distinguishes a scheduled run from an admin-triggered one (`'admin'`).
- `index.ts`: wires it into a new `scheduled` Worker export via `ctx.waitUntil(...)`, matching Cloudflare's documented pattern for scheduled handlers.
- `wrangler.jsonc`: adds a daily, off-peak `triggers.crons` entry (`"0 3 * * *"` UTC).

Docs updated to match: `docs/roadmap.md`, `services/api/docs/SECURITY.md`, and `docs/architecture.md`'s "Background work (cron)" section and topology diagram (also corrected a stale claim there that taste-profile recompute needs a cron — it already runs synchronously on every watched-together rating, from the earlier taste-signals work).

**Scope note:** the "Background work (cron)" target this gap sat alongside also mentioned a provider-cache refresh cron. That one remains intentionally unbuilt — unlike audit-log retention (an already-decided, already-implemented policy just needing a schedule), its shape isn't decided yet: what to refresh, on what interval, at what TMDb API quota cost. Building it now would mean inventing a design nobody's signed off on, so I left it as a documented gap rather than guessing.

---

### ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented parts that are complex or non-obvious
- [x] I have updated relevant documentation
- [x] I have added or updated tests
- [x] No new warnings or errors are introduced
- [x] All tests pass locally

---

### ⚠️ Notes for Reviewers

- The Cron Trigger config (`wrangler.jsonc`) is verified via `wrangler deploy --dry-run` (accepts the config, no schema error) — it can't be exercised as a live firing yet, since no D1 database or Worker has been provisioned in a real Cloudflare account (the same pre-existing, documented gap as the rest of the re-platform — see `docs/dev-setup.md`).
- Correspondingly, the new test exercises `rotateAuditLogsOnSchedule` directly against local D1 (`vitest-pool-workers`), not the `scheduled` export itself — `index.ts` has never had direct test coverage in this codebase (it's excluded from the coverage config), matching the existing convention that routing/wiring stays thin and untested while the `lib` layer underneath it is what's actually verified.
- Full verification run clean: monorepo `type-check`, `lint`, `build` (including the api `wrangler deploy --dry-run`), and the full `services/api` vitest suite (148 tests).

---

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XaZAU6ca9bxsD6vhj8j392

---
_Generated by [Claude Code](https://claude.ai/code/session_01XaZAU6ca9bxsD6vhj8j392)_