### PR TITLE
feat(api): TV action-mood genre mapping + Stripe billing scaffold

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -345,10 +345,21 @@ Promote a component to `packages/lib.components` only when a second consumer nee
   scored candidates instead of 3 and pass them to `rerankCandidates`. Whether it actually improves
   first-pick acceptance is still unvalidated — see the roadmap.
 
-### Stripe (deferred)
+### Stripe
 
-- Not integrated. When enabled, port creatorgrid's test-mode pattern (`lib/stripe.ts` +
-  `routes/billing.ts`, "unconfigured is a valid state"). The mock checkout is for demos only.
+- Scaffolded, not live. `lib/stripe.ts` ports creatorgrid's hand-rolled-fetch pattern (no `stripe`
+  SDK — needs Node APIs this Worker doesn't otherwise require); `routes/billing.ts` mounts the
+  global `GET /api/billing/status` + `POST /api/billing/webhook`. Household-scoped
+  `POST /:id/billing/checkout` (`routes/households.ts`) is Stripe-aware when configured
+  (`STRIPE_SECRET_KEY` + `STRIPE_PRICE_PREMIUM`, single premium tier — not creatorgrid's four
+  paid plans), else falls back to the pre-existing mock (`lib/billing.ts`'s `startCheckout`, still
+  demo-only). `POST /:id/billing/portal` is new, matching creatorgrid's self-service Billing
+  Portal pattern for real cancellation.
+- "Unconfigured is a valid state" everywhere: absent secrets 501 the webhook/portal and leave
+  checkout on the mock, rather than throwing.
+- Not live because no real Stripe account is wired up yet (same "needs real Cloudflare/external
+  account access" gap as the rest of the deploy story) — go-live still needs a decision, not more
+  code.
 
 ---
 

--- a/docs/db-schema.md
+++ b/docs/db-schema.md
@@ -339,8 +339,11 @@ export const pickUsage = sqliteTable(
 );
 ```
 
-Premium is `tier = 'premium' AND status = 'active' AND current_period_end > now`. `stripe_*` stay
-null until real Stripe is wired.
+Premium is `tier = 'premium' AND status = 'active' AND current_period_end > now`. `stripe_*` are
+populated by `services/api`'s Stripe webhook (`routes/billing.ts`) once a household completes a
+real checkout, but stay null until Stripe is actually configured -- no real account is wired up yet
+(see `docs/roadmap.md`), so `startCheckout` (`lib/billing.ts`) falls back to a mock checkout that
+never touches these columns at all.
 
 ## Analytics
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -26,8 +26,9 @@
   this to one app and fixes it.
 - ~~**Recommender is runtime-blind**~~ — fixed; candidates are re-scored on real runtime after
   hydration and re-sorted before the final pick. TV candidates now appear for genre-compatible
-  moods (funny/feelgood/thoughtful); dark/tense/romantic/action stay movie-only -- TV's genre
-  taxonomy has no Horror/Romance/Thriller/Action+Adventure equivalent to map onto.
+  moods (funny/feelgood/thoughtful) and for action (TMDb's TV "Action & Adventure" id, 10759, maps
+  back onto movie Action/Adventure for scoring); dark/tense/romantic stay movie-only -- TV's genre
+  taxonomy has no Horror/Romance/Thriller equivalent to map onto at all.
 - **Billing is mock-only** (no Stripe).
 - ~~**Thin tests on the pivot**~~ — no longer true; `households.e2e.test.ts` alone is 1,300+ lines
   covering pick/commit/history/entitlements/TV/runtime-ranking, plus dedicated suites for auth,
@@ -292,9 +293,12 @@ Independent of the platform, needed before opening to an invited cohort:
 
 - Validate the LLM re-rank actually improves first-pick acceptance (premium only) -- it's wired in
   and feature-flagged, needs real usage data to judge.
-- ~~Extend the recommender to TV~~ — done for genre-compatible moods (funny/feelgood/thoughtful);
-  dark/tense/romantic/action need a product decision on mapping Horror/Romance/Thriller/
-  Action+Adventure onto TV's different genre taxonomy before they can include TV candidates too.
+- ~~Extend the recommender to TV~~ — done for genre-compatible moods (funny/feelgood/thoughtful)
+  and for action (TMDb's TV genre taxonomy has an actual equivalent, just under a different id --
+  see `TV_ACTION_ADVENTURE_GENRE_ID`). dark/tense/romantic stay movie-only by decision, not by
+  gap: TV has no Horror/Thriller/Romance genre at all, so there's nothing accurate to map onto --
+  approximating with an adjacent TV genre (Mystery, Crime, Drama) would serve picks that don't
+  actually match what the mood promised.
 - ~~Make runtime actually influence scoring~~ — done; candidates are re-scored with their real
   runtime after hydration and re-sorted before the final pick, instead of only ever scoring against
   a neutral runtime guess.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -311,7 +311,13 @@ Independent of the platform, needed before opening to an invited cohort:
   covers all three, including the quota-atomicity race and region-lock enforcement. (A dedicated
   `providers.e2e.test.ts` covered this too, until the standalone provider route it tested was
   deleted for having no callers -- see this file's providers/history section.)
-- Real Stripe (gated on go-live sign-off) — until then premium is comp/mock only.
+- ~~Real Stripe~~ — scaffolded: `lib/stripe.ts` (creatorgrid's hand-rolled-fetch pattern, collapsed
+  to pairflix's single premium tier), `routes/billing.ts` (status + webhook), and Stripe-aware
+  `POST /:id/billing/checkout` + new `POST /:id/billing/portal` in `routes/households.ts`. Not
+  live — no real Stripe account is wired up (`STRIPE_SECRET_KEY`/`STRIPE_PRICE_PREMIUM` unset), so
+  checkout still falls back to the existing mock. Going live from here is a config/account step
+  (set the three `STRIPE_*` secrets, point a Stripe webhook endpoint at `/api/billing/webhook`),
+  gated on go-live sign-off, not more code.
 
 **Alpha exit criteria:** a real household can create an account, get a genuinely good first pick in
 under 30s across their providers, launch it, and have it remembered — reliably, on the deployed

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -299,8 +299,11 @@ export const contentReports = sqliteTable(
   table => [index('idx_content_reports_content').on(table.contentId)]
 );
 
-/** Premium is `tier = 'premium' AND status = 'active' AND currentPeriodEnd > now`. `stripe*` stay
- * null until real Stripe is wired (see docs/roadmap.md). */
+/** Premium is `tier = 'premium' AND status = 'active' AND currentPeriodEnd > now`. `stripe*` are
+ * populated by `services/api`'s Stripe webhook (`routes/billing.ts`) once a household completes a
+ * real checkout, but stay null until Stripe is actually configured -- no real account is wired up
+ * yet (see docs/roadmap.md), so `startCheckout` (`lib/billing.ts`) falls back to a mock checkout
+ * that never touches these columns at all. */
 export const subscriptions = sqliteTable('subscriptions', {
   id: text('id').primaryKey(),
   householdId: text('household_id')

--- a/services/api/.dev.vars.example
+++ b/services/api/.dev.vars.example
@@ -36,3 +36,13 @@ TMDB_API_KEY=""
 # null (falls back to the pure-ML pick, same "unconfigured is a valid state" pattern as email).
 # Also gated behind the recommendation.llm_rerank setting and premium entitlements either way.
 ANTHROPIC_API_KEY=""
+
+# Stripe (src/lib/stripe.ts, src/routes/billing.ts) -- leave all three blank to keep
+# POST /:id/billing/checkout on the existing mock flow and /:id/billing/portal, /api/billing/webhook
+# 501ing, same "unconfigured is a valid state" pattern as the rest of this file. Get test-mode
+# values at https://dashboard.stripe.com/test/apikeys (secret key), .../test/webhooks (webhook
+# signing secret, after creating an endpoint pointed at /api/billing/webhook), and
+# .../test/products (a recurring Price id for the premium tier).
+STRIPE_SECRET_KEY=""
+STRIPE_WEBHOOK_SECRET=""
+STRIPE_PRICE_PREMIUM=""

--- a/services/api/src/index.ts
+++ b/services/api/src/index.ts
@@ -7,6 +7,7 @@ import { sessionMiddleware } from './middleware/auth';
 import { csrfMiddleware } from './middleware/csrf';
 import { adminRoutes } from './routes/admin';
 import { authRoutes } from './routes/auth';
+import { billingRoutes } from './routes/billing';
 import { healthRoutes } from './routes/health';
 import { householdsRoutes } from './routes/households';
 import { meRoutes } from './routes/me';
@@ -49,6 +50,7 @@ app.route('/api/auth', authRoutes);
 app.route('/api/me', meRoutes);
 app.route('/api/households', householdsRoutes);
 app.route('/api/admin', adminRoutes);
+app.route('/api/billing', billingRoutes);
 
 app.notFound(c => c.json({ error: 'Not found' }, 404));
 app.onError((error, c) => {

--- a/services/api/src/lib/billing.ts
+++ b/services/api/src/lib/billing.ts
@@ -1,7 +1,12 @@
-import { subscriptions, type Database } from '@pairflix/db';
+import { subscriptions, users, type Database } from '@pairflix/db';
 import { eq } from 'drizzle-orm';
 import type { Bindings } from '../types';
 import { newId } from './id';
+import {
+	createCheckoutSession,
+	createPortalSession,
+	isStripeConfigured,
+} from './stripe';
 
 const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
 
@@ -11,10 +16,79 @@ export const startCheckout = (
 	householdId: string,
 	tier: 'premium' = 'premium'
 ): CheckoutSession => {
-	// TODO: replace with stripe.checkout.sessions.create(...) when Stripe goes live.
 	return {
 		checkoutUrl: `/billing/mock-checkout?household=${householdId}&tier=${tier}`,
 	};
+};
+
+/** Real Stripe checkout when configured, falling back to the mock above otherwise -- callers
+ * (routes/households.ts) don't need to branch on configuration state themselves. Reuses an
+ * existing `stripeCustomerId` if this household has checked out before (even if that
+ * subscription later lapsed), rather than creating a duplicate Stripe customer every time. */
+export const startRealOrMockCheckout = async (
+	env: Bindings,
+	db: Database,
+	householdId: string,
+	ownerUserId: string
+): Promise<CheckoutSession> => {
+	if (!isStripeConfigured(env)) return startCheckout(householdId);
+
+	const [existing, owner] = await Promise.all([
+		db
+			.select({ stripeCustomerId: subscriptions.stripeCustomerId })
+			.from(subscriptions)
+			.where(eq(subscriptions.householdId, householdId))
+			.get(),
+		db
+			.select({ email: users.email })
+			.from(users)
+			.where(eq(users.id, ownerUserId))
+			.get(),
+	]);
+	if (!owner) throw new Error('Household owner not found');
+
+	const appClientUrl = env.APP_CLIENT_URL ?? 'http://localhost:5173';
+	const session = await createCheckoutSession({
+		secretKey: env.STRIPE_SECRET_KEY,
+		priceId: env.STRIPE_PRICE_PREMIUM,
+		customerId: existing?.stripeCustomerId ?? null,
+		customerEmail: owner.email,
+		successUrl: `${appClientUrl}/profile?billing=success`,
+		cancelUrl: `${appClientUrl}/profile?billing=cancel`,
+		householdId,
+	});
+	return { checkoutUrl: session.url };
+};
+
+export type PortalSessionResult =
+	| { ok: true; portalUrl: string }
+	| { ok: false; reason: 'not_configured' | 'no_customer' };
+
+/** Stripe's self-service Billing Portal -- where a real subscription actually gets changed or
+ * canceled once Stripe is live (unlike `cancelSubscription` below, which only ever moves this
+ * product's own DB state, mock or not). 400s via `reason: 'no_customer'` until the household has
+ * completed a real checkout at least once. */
+export const startPortalSession = async (
+	env: Bindings,
+	db: Database,
+	householdId: string
+): Promise<PortalSessionResult> => {
+	if (!isStripeConfigured(env)) return { ok: false, reason: 'not_configured' };
+
+	const existing = await db
+		.select({ stripeCustomerId: subscriptions.stripeCustomerId })
+		.from(subscriptions)
+		.where(eq(subscriptions.householdId, householdId))
+		.get();
+	if (!existing?.stripeCustomerId) return { ok: false, reason: 'no_customer' };
+
+	const appClientUrl = env.APP_CLIENT_URL ?? 'http://localhost:5173';
+	const session = await createPortalSession({
+		secretKey: env.STRIPE_SECRET_KEY,
+		customerId: existing.stripeCustomerId,
+		returnUrl: `${appClientUrl}/profile`,
+	});
+	return { ok: true, portalUrl: session.url };
 };
 
 export const isBillingMockEnabled = (env: Bindings): boolean => {

--- a/services/api/src/lib/genres.ts
+++ b/services/api/src/lib/genres.ts
@@ -37,6 +37,17 @@ export const TV_COMPATIBLE_GENRE_IDS = new Set<number>([
  * both merge into this single TV id rather than sharing either movie id directly. */
 export const TV_ACTION_ADVENTURE_GENRE_ID = 10759;
 
+/** Every genre id this codebase stores or scores against -- `GENRE_NAMES`, `taste_profiles.weights.
+ * genres`, and `MOOD_FILTERS` -- is keyed by the movie id space. Expands TV_ACTION_ADVENTURE_GENRE_ID
+ * back to the movie ids it represents so a TV item's raw `genre_ids` (from `/discover/tv`, or a full
+ * `/tv/:id` details fetch) can be treated the same as a movie's everywhere that keyspace matters:
+ * scoring, taste-weight nudging, rationale text, and the LLM candidate payload. Every other TV genre
+ * id already equals its movie counterpart (see TV_COMPATIBLE_GENRE_IDS) and passes through
+ * unchanged; calling this on a movie's own genre_ids is always a no-op, since 10759 never appears
+ * there. */
+export const toMovieGenreIds = (genreIds: number[]): number[] =>
+	genreIds.flatMap(g => (g === TV_ACTION_ADVENTURE_GENRE_ID ? [28, 12] : [g]));
+
 export const MOOD_FILTERS: Record<Mood, { genres: number[]; label: string }> = {
 	funny: { genres: [35], label: 'comedy' },
 	dark: { genres: [80, 53], label: 'dark crime/thriller' },

--- a/services/api/src/lib/genres.ts
+++ b/services/api/src/lib/genres.ts
@@ -24,13 +24,18 @@ export const GENRE_NAMES: Record<number, string> = {
 };
 
 /** TMDb's TV genre list only shares these ids with the movie list above -- TV has no standalone
- * Horror (27), Romance (10749), or Thriller (53), and merges Action+Adventure into a single id
- * (10759, not 28+12). `lib/recommendation.ts` only fetches TV candidates when every genre id it
- * would filter on is in this set, so a `/discover/tv` call never filters on an id that doesn't
- * exist in TV's taxonomy. */
+ * Horror (27), Romance (10749), or Thriller (53) at all, so there's no way to map `dark`/`tense`/
+ * `romantic` onto TV. `lib/recommendation.ts` only fetches TV candidates when every genre id a mood
+ * would filter on is either in this set or is the Action/Adventure exception below, so a
+ * `/discover/tv` call never filters on an id that doesn't exist in TV's taxonomy. */
 export const TV_COMPATIBLE_GENRE_IDS = new Set<number>([
 	16, 35, 80, 99, 18, 10751, 9648, 37,
 ]);
+
+/** TMDb's TV "Action & Adventure" id -- the one case where TV genuinely has an equivalent for a
+ * movie mood's genres, just under a different numeric id: movie Action (28) and Adventure (12)
+ * both merge into this single TV id rather than sharing either movie id directly. */
+export const TV_ACTION_ADVENTURE_GENRE_ID = 10759;
 
 export const MOOD_FILTERS: Record<Mood, { genres: number[]; label: string }> = {
 	funny: { genres: [35], label: 'comedy' },

--- a/services/api/src/lib/providers.ts
+++ b/services/api/src/lib/providers.ts
@@ -6,6 +6,7 @@ import {
 } from '@pairflix/db';
 import { and, eq } from 'drizzle-orm';
 import type { Bindings } from '../types';
+import { toMovieGenreIds } from './genres';
 import { newId } from './id';
 import {
 	getAllWatchProviders,
@@ -135,7 +136,13 @@ export const cacheContentDetails = async (
 			year = parseYear(full.first_air_date);
 			runtime = full.episode_run_time?.[0] ?? null;
 			posterPath = full.poster_path;
-			genreIds = full.genres ? full.genres.map(g => g.id) : null;
+			// Normalized to the movie genre-id space (see toMovieGenreIds) so a rating on this title
+			// nudges taste_profiles.weights.genres correctly -- recomputeTasteFromRating reads
+			// genreIds straight from this column and skips any id GENRE_NAMES doesn't recognize,
+			// which TV's raw Action & Adventure id (10759) never would.
+			genreIds = full.genres
+				? toMovieGenreIds(full.genres.map(g => g.id))
+				: null;
 		}
 	} catch (err) {
 		console.warn(

--- a/services/api/src/lib/recommendation.ts
+++ b/services/api/src/lib/recommendation.ts
@@ -19,6 +19,7 @@ import {
 	MOOD_FILTERS,
 	TV_ACTION_ADVENTURE_GENRE_ID,
 	TV_COMPATIBLE_GENRE_IDS,
+	toMovieGenreIds,
 } from './genres';
 import { newId } from './id';
 import {
@@ -240,14 +241,9 @@ const scoreCandidate = (
 	targetMinutes: number,
 	currentYear: number
 ): number => {
-	// A TV item carries TV_ACTION_ADVENTURE_GENRE_ID instead of the movie ids (28, 12) that
-	// `prefs.genres` and `moodGenres` are keyed by -- expand it back so a TV action/adventure
-	// candidate's genre-based scoring terms (genreMatch, genreMoodHit below) see the same ids a
-	// household's learned taste and the `action` mood filter use. Every other TV genre id already
-	// equals its movie counterpart (see TV_COMPATIBLE_GENRE_IDS) and passes through unchanged.
-	const genreIds = (item.genre_ids ?? []).flatMap(g =>
-		g === TV_ACTION_ADVENTURE_GENRE_ID ? [28, 12] : [g]
-	);
+	// Already normalized to the movie genre-id space by the time a TV item reaches here -- see
+	// where `candidates` is built in pickForHousehold.
+	const genreIds = item.genre_ids ?? [];
 
 	let genreSum = 0;
 	let genreCount = 0;
@@ -453,14 +449,15 @@ export const pickForHousehold = async (
 		voteCountGte: 200,
 		region,
 	};
-	// Only fetch TV candidates when every genre this pick filters on (mood genres, plus up to 3
-	// more pulled in from the household's taste weights) is valid in TV's genre taxonomy -- see
-	// TV_COMPATIBLE_GENRE_IDS's doc comment. Household taste can inject an incompatible id even
-	// under an eligible mood, so the TV call itself filters on the compatible subset of `genres`,
-	// not the full list the movie call uses. Action (28) and Adventure (12) aren't literally in
-	// TV_COMPATIBLE_GENRE_IDS -- TMDb merges them into the differently-numbered
-	// TV_ACTION_ADVENTURE_GENRE_ID -- so both the eligibility check and the filter treat that pair
-	// as compatible too, remapped to the TV id `/discover/tv` actually understands.
+	// Only fetch TV candidates when every genre the *mood itself* filters on is valid in TV's genre
+	// taxonomy -- see TV_COMPATIBLE_GENRE_IDS's doc comment. The up-to-3 extra ids pulled in from
+	// the household's taste weights don't gate eligibility -- an eligible mood can still pull in an
+	// incompatible one, so the TV call filters `genres` (mood + taste extras) down to the
+	// compatible subset itself, not the full list the movie call uses. Action (28) and Adventure
+	// (12) aren't literally in TV_COMPATIBLE_GENRE_IDS -- TMDb merges them into the
+	// differently-numbered TV_ACTION_ADVENTURE_GENRE_ID -- so both the eligibility check and the
+	// filter treat that pair as compatible too, remapped to the TV id `/discover/tv` actually
+	// understands.
 	const isTvCompatibleGenre = (g: number) =>
 		TV_COMPATIBLE_GENRE_IDS.has(g) || g === 28 || g === 12;
 	const toTvGenreId = (g: number) =>
@@ -484,8 +481,12 @@ export const pickForHousehold = async (
 			item,
 			mediaType: 'movie' as const,
 		})),
+		// Normalized to the movie genre-id space here, once, so every downstream reader of
+		// `item.genre_ids` (scoreCandidate, buildRationale, the LLM candidate payload) sees ids
+		// consistent with GENRE_NAMES/taste_profiles.weights.genres/MOOD_FILTERS without each of
+		// them needing to remember to expand TV_ACTION_ADVENTURE_GENRE_ID individually.
 		...(tvResp.results ?? []).map(item => ({
-			item,
+			item: { ...item, genre_ids: toMovieGenreIds(item.genre_ids ?? []) },
 			mediaType: 'tv' as const,
 		})),
 	];

--- a/services/api/src/lib/recommendation.ts
+++ b/services/api/src/lib/recommendation.ts
@@ -14,7 +14,12 @@ import type {
 import type { Bindings } from '../types';
 import { eraBucketForYear } from './eras';
 import { isLlmRerankEnabledForHousehold } from './featureFlags';
-import { GENRE_NAMES, MOOD_FILTERS, TV_COMPATIBLE_GENRE_IDS } from './genres';
+import {
+	GENRE_NAMES,
+	MOOD_FILTERS,
+	TV_ACTION_ADVENTURE_GENRE_ID,
+	TV_COMPATIBLE_GENRE_IDS,
+} from './genres';
 import { newId } from './id';
 import {
 	rerankCandidates,
@@ -235,7 +240,14 @@ const scoreCandidate = (
 	targetMinutes: number,
 	currentYear: number
 ): number => {
-	const genreIds = item.genre_ids ?? [];
+	// A TV item carries TV_ACTION_ADVENTURE_GENRE_ID instead of the movie ids (28, 12) that
+	// `prefs.genres` and `moodGenres` are keyed by -- expand it back so a TV action/adventure
+	// candidate's genre-based scoring terms (genreMatch, genreMoodHit below) see the same ids a
+	// household's learned taste and the `action` mood filter use. Every other TV genre id already
+	// equals its movie counterpart (see TV_COMPATIBLE_GENRE_IDS) and passes through unchanged.
+	const genreIds = (item.genre_ids ?? []).flatMap(g =>
+		g === TV_ACTION_ADVENTURE_GENRE_ID ? [28, 12] : [g]
+	);
 
 	let genreSum = 0;
 	let genreCount = 0;
@@ -445,14 +457,23 @@ export const pickForHousehold = async (
 	// more pulled in from the household's taste weights) is valid in TV's genre taxonomy -- see
 	// TV_COMPATIBLE_GENRE_IDS's doc comment. Household taste can inject an incompatible id even
 	// under an eligible mood, so the TV call itself filters on the compatible subset of `genres`,
-	// not the full list the movie call uses.
-	const tvEligible = moodCfg.genres.every(g => TV_COMPATIBLE_GENRE_IDS.has(g));
+	// not the full list the movie call uses. Action (28) and Adventure (12) aren't literally in
+	// TV_COMPATIBLE_GENRE_IDS -- TMDb merges them into the differently-numbered
+	// TV_ACTION_ADVENTURE_GENRE_ID -- so both the eligibility check and the filter treat that pair
+	// as compatible too, remapped to the TV id `/discover/tv` actually understands.
+	const isTvCompatibleGenre = (g: number) =>
+		TV_COMPATIBLE_GENRE_IDS.has(g) || g === 28 || g === 12;
+	const toTvGenreId = (g: number) =>
+		g === 28 || g === 12 ? TV_ACTION_ADVENTURE_GENRE_ID : g;
+	const tvEligible = moodCfg.genres.every(isTvCompatibleGenre);
 	const [movieResp, tvResp] = await Promise.all([
 		discoverMedia(env, { ...discoverParams, mediaType: 'movie' }),
 		tvEligible
 			? discoverMedia(env, {
 					...discoverParams,
-					genres: genres.filter(g => TV_COMPATIBLE_GENRE_IDS.has(g)),
+					genres: [
+						...new Set(genres.filter(isTvCompatibleGenre).map(toTvGenreId)),
+					],
 					mediaType: 'tv',
 				})
 			: Promise.resolve({ results: [] }),

--- a/services/api/src/lib/stripe.test.ts
+++ b/services/api/src/lib/stripe.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest';
+import { isStripeConfigured, verifyWebhookSignature } from './stripe';
+
+const WEBHOOK_SECRET = 'whsec_test_secret';
+const encoder = new TextEncoder();
+
+/** Independent of `verifyWebhookSignature`'s own implementation -- signs the same way Stripe
+ * itself does (stripe.com/docs/webhooks#verify-manually), not by reusing the code under test. */
+const sign = async (
+	payload: string,
+	secret: string,
+	timestamp: number
+): Promise<string> => {
+	const key = await crypto.subtle.importKey(
+		'raw',
+		encoder.encode(secret),
+		{ name: 'HMAC', hash: 'SHA-256' },
+		false,
+		['sign']
+	);
+	const digest = await crypto.subtle.sign(
+		'HMAC',
+		key,
+		encoder.encode(`${timestamp}.${payload}`)
+	);
+	const hex = [...new Uint8Array(digest)]
+		.map(b => b.toString(16).padStart(2, '0'))
+		.join('');
+	return `t=${timestamp},v1=${hex}`;
+};
+
+describe('verifyWebhookSignature', () => {
+	const payload = '{"type":"checkout.session.completed"}';
+	const now = 1_700_000_000_000;
+
+	it('accepts a validly signed payload', async () => {
+		const header = await sign(payload, WEBHOOK_SECRET, Math.floor(now / 1000));
+		expect(
+			await verifyWebhookSignature(payload, header, WEBHOOK_SECRET, 300, now)
+		).toBe(true);
+	});
+
+	it('rejects a tampered payload', async () => {
+		const header = await sign(payload, WEBHOOK_SECRET, Math.floor(now / 1000));
+		expect(
+			await verifyWebhookSignature(
+				'{"type":"tampered"}',
+				header,
+				WEBHOOK_SECRET,
+				300,
+				now
+			)
+		).toBe(false);
+	});
+
+	it('rejects a signature made with the wrong secret', async () => {
+		const header = await sign(payload, 'whsec_wrong', Math.floor(now / 1000));
+		expect(
+			await verifyWebhookSignature(payload, header, WEBHOOK_SECRET, 300, now)
+		).toBe(false);
+	});
+
+	it('rejects a timestamp outside the tolerance window', async () => {
+		const staleSeconds = Math.floor(now / 1000) - 301;
+		const header = await sign(payload, WEBHOOK_SECRET, staleSeconds);
+		expect(
+			await verifyWebhookSignature(payload, header, WEBHOOK_SECRET, 300, now)
+		).toBe(false);
+	});
+
+	it('rejects a malformed or missing header', async () => {
+		expect(
+			await verifyWebhookSignature(payload, null, WEBHOOK_SECRET, 300, now)
+		).toBe(false);
+		expect(
+			await verifyWebhookSignature(
+				payload,
+				'not-a-real-header',
+				WEBHOOK_SECRET,
+				300,
+				now
+			)
+		).toBe(false);
+		expect(
+			await verifyWebhookSignature(payload, 't=123', WEBHOOK_SECRET, 300, now)
+		).toBe(false);
+	});
+});
+
+describe('isStripeConfigured', () => {
+	it('requires both the secret key and the price id', () => {
+		expect(
+			isStripeConfigured({
+				STRIPE_SECRET_KEY: 'sk_test',
+				STRIPE_PRICE_PREMIUM: 'price_1',
+			})
+		).toBe(true);
+		expect(isStripeConfigured({ STRIPE_SECRET_KEY: 'sk_test' })).toBe(false);
+		expect(isStripeConfigured({ STRIPE_PRICE_PREMIUM: 'price_1' })).toBe(false);
+		expect(isStripeConfigured({})).toBe(false);
+	});
+});

--- a/services/api/src/lib/stripe.ts
+++ b/services/api/src/lib/stripe.ts
@@ -1,0 +1,156 @@
+import { timingSafeEqual } from './crypto';
+import type { Bindings } from '../types';
+
+/**
+ * Minimal Stripe REST client -- raw fetch against the Stripe API rather than the `stripe` npm
+ * SDK, matching creatorgrid's `lib/stripe.ts` (the pattern CLAUDE.md names to port). The SDK
+ * needs Node APIs this Worker doesn't otherwise require (see wrangler.jsonc's "no nodejs_compat"
+ * comment); this file only ever touches `fetch`, `URLSearchParams`, `btoa`, and `crypto.subtle`.
+ *
+ * "Unconfigured is a valid state": there's no guard function here -- every call site checks
+ * `isStripeConfigured`/the relevant env var before calling in, and these functions take the
+ * secret as a parameter rather than reading `env` internally, matching creatorgrid's split
+ * between "is this configured" (checked by the route) and "do the Stripe call" (this file).
+ */
+const STRIPE_API = 'https://api.stripe.com/v1';
+const encoder = new TextEncoder();
+
+type StripeConfigEnv = Pick<
+	Bindings,
+	'STRIPE_SECRET_KEY' | 'STRIPE_PRICE_PREMIUM'
+>;
+
+/** Pairflix is single-tier (free/premium), unlike creatorgrid's four paid plans -- configured
+ * means both the secret key and the one price id are set. A type predicate so callers
+ * (lib/billing.ts) get `env.STRIPE_SECRET_KEY`/`env.STRIPE_PRICE_PREMIUM` narrowed to `string`
+ * after an `if (isStripeConfigured(env))` check, rather than needing a non-null assertion. Takes
+ * just the two fields it needs rather than all of `Bindings`, so it stays a type guard against the
+ * full `Bindings` at real call sites while still being constructible directly in tests. */
+export const isStripeConfigured = (
+	env: StripeConfigEnv
+): env is StripeConfigEnv & {
+	STRIPE_SECRET_KEY: string;
+	STRIPE_PRICE_PREMIUM: string;
+} => Boolean(env.STRIPE_SECRET_KEY && env.STRIPE_PRICE_PREMIUM);
+
+const stripeRequest = async <T>(
+	secretKey: string,
+	path: string,
+	body: URLSearchParams
+): Promise<T> => {
+	const response = await fetch(`${STRIPE_API}${path}`, {
+		method: 'POST',
+		headers: {
+			Authorization: `Basic ${btoa(`${secretKey}:`)}`,
+			'Content-Type': 'application/x-www-form-urlencoded',
+		},
+		body,
+	});
+	if (!response.ok) {
+		throw new Error(
+			`Stripe API error (${response.status}): ${await response.text()}`
+		);
+	}
+	return response.json();
+};
+
+export type CreateCheckoutSessionParams = {
+	secretKey: string;
+	priceId: string;
+	customerId: string | null;
+	customerEmail: string;
+	successUrl: string;
+	cancelUrl: string;
+	householdId: string;
+};
+
+/** Metadata is stamped onto both the session and `subscription_data[metadata]` so the
+ * `customer.subscription.*` webhook events carry `householdId` too, not just
+ * `checkout.session.completed` -- lets the webhook resolve a household even if a subscription
+ * event arrives before (or without) that event, see `routes/billing.ts`. */
+export const createCheckoutSession = async (
+	params: CreateCheckoutSessionParams
+): Promise<{ url: string }> => {
+	const body = new URLSearchParams({
+		mode: 'subscription',
+		'line_items[0][price]': params.priceId,
+		'line_items[0][quantity]': '1',
+		success_url: params.successUrl,
+		cancel_url: params.cancelUrl,
+		'metadata[householdId]': params.householdId,
+		'subscription_data[metadata][householdId]': params.householdId,
+	});
+	if (params.customerId) {
+		body.set('customer', params.customerId);
+	} else {
+		body.set('customer_email', params.customerEmail);
+	}
+	const session = await stripeRequest<{ url: string | null }>(
+		params.secretKey,
+		'/checkout/sessions',
+		body
+	);
+	if (!session.url) throw new Error('Stripe did not return a checkout URL');
+	return { url: session.url };
+};
+
+export type CreatePortalSessionParams = {
+	secretKey: string;
+	customerId: string;
+	returnUrl: string;
+};
+
+export const createPortalSession = async (
+	params: CreatePortalSessionParams
+): Promise<{ url: string }> =>
+	stripeRequest<{ url: string }>(
+		params.secretKey,
+		'/billing_portal/sessions',
+		new URLSearchParams({
+			customer: params.customerId,
+			return_url: params.returnUrl,
+		})
+	);
+
+/** Manual signature verification per Stripe's "verify manually" docs
+ * (stripe.com/docs/webhooks#verify-manually) -- HMAC-SHA256 over `${timestamp}.${payload}` via
+ * Web Crypto (native to Workers), compared with the existing constant-time `timingSafeEqual`
+ * rather than a second copy of it. `now`/`toleranceSeconds` are parameters (not read from
+ * `Date.now()` internally) purely so this is unit-testable with a fixed clock. */
+export const verifyWebhookSignature = async (
+	payload: string,
+	signatureHeader: string | null,
+	webhookSecret: string,
+	toleranceSeconds = 300,
+	now: number = Date.now()
+): Promise<boolean> => {
+	if (!signatureHeader) return false;
+	const parts: Record<string, string> = {};
+	for (const part of signatureHeader.split(',')) {
+		const [key, value] = part.split('=');
+		if (key && value) parts[key] = value;
+	}
+	const timestamp = parts.t;
+	const signature = parts.v1;
+	if (!timestamp || !signature) return false;
+	const timestampSeconds = Number(timestamp);
+	if (!Number.isFinite(timestampSeconds)) return false;
+	if (Math.abs(now / 1000 - timestampSeconds) > toleranceSeconds) return false;
+
+	const key = await crypto.subtle.importKey(
+		'raw',
+		encoder.encode(webhookSecret),
+		{ name: 'HMAC', hash: 'SHA-256' },
+		false,
+		['sign']
+	);
+	const digest = await crypto.subtle.sign(
+		'HMAC',
+		key,
+		encoder.encode(`${timestamp}.${payload}`)
+	);
+	const expected = [...new Uint8Array(digest)]
+		.map(b => b.toString(16).padStart(2, '0'))
+		.join('');
+	return timingSafeEqual(expected, signature);
+};

--- a/services/api/src/routes/billing.e2e.test.ts
+++ b/services/api/src/routes/billing.e2e.test.ts
@@ -1,0 +1,245 @@
+import { env } from 'cloudflare:workers';
+import { describe, expect, it } from 'vitest';
+import {
+	callApp,
+	createLoggedInUser,
+	postJson,
+	type Cookies,
+} from '../test/test-helpers';
+
+let counter = 0;
+const uniqueEmail = () => `billing-e2e-${Date.now()}-${counter++}@example.com`;
+
+const createHousehold = async (cookies: Cookies): Promise<string> => {
+	const result = await postJson<{ household: { id: string } }>(
+		'/api/households',
+		{},
+		cookies
+	);
+	if (result.status !== 201) {
+		throw new Error(
+			`createHousehold failed: ${result.status} ${JSON.stringify(result.body)}`
+		);
+	}
+	return result.body.household.id;
+};
+
+type SubscriptionRow = {
+	tier: string;
+	status: string;
+	stripe_customer_id: string | null;
+	stripe_subscription_id: string | null;
+	current_period_end: number | null;
+};
+
+const getSubscriptionRow = (
+	householdId: string
+): Promise<SubscriptionRow | null> =>
+	env.DB.prepare('SELECT * FROM subscriptions WHERE household_id = ?1')
+		.bind(householdId)
+		.first<SubscriptionRow>();
+
+const WEBHOOK_SECRET = 'whsec_test_secret'; // matches vitest.config.mts's fixed test binding
+const encoder = new TextEncoder();
+
+/** Independent of routes/billing.ts's own verifyWebhookSignature call -- signs the same way
+ * Stripe itself does, not by reusing the code under test (mirrors lib/stripe.test.ts's `sign`). */
+const signWebhook = async (payload: string): Promise<string> => {
+	const timestamp = Math.floor(Date.now() / 1000);
+	const key = await crypto.subtle.importKey(
+		'raw',
+		encoder.encode(WEBHOOK_SECRET),
+		{ name: 'HMAC', hash: 'SHA-256' },
+		false,
+		['sign']
+	);
+	const digest = await crypto.subtle.sign(
+		'HMAC',
+		key,
+		encoder.encode(`${timestamp}.${payload}`)
+	);
+	const hex = [...new Uint8Array(digest)]
+		.map(b => b.toString(16).padStart(2, '0'))
+		.join('');
+	return `t=${timestamp},v1=${hex}`;
+};
+
+const postWebhook = async (event: unknown) => {
+	const payload = JSON.stringify(event);
+	const signature = await signWebhook(payload);
+	return callApp('/api/billing/webhook', {
+		method: 'POST',
+		body: payload,
+		headers: {
+			'stripe-signature': signature,
+			'content-type': 'application/json',
+		},
+	});
+};
+
+describe('GET /api/billing/status', () => {
+	it('reports Stripe as unconfigured when the secret key and price id are unset', async () => {
+		const result = await callApp<{ configured: boolean }>(
+			'/api/billing/status'
+		);
+		expect(result.status).toBe(200);
+		expect(result.body.configured).toBe(false);
+	});
+});
+
+describe('POST /api/billing/webhook', () => {
+	it('rejects a missing signature header', async () => {
+		const result = await callApp('/api/billing/webhook', {
+			method: 'POST',
+			body: JSON.stringify({ type: 'checkout.session.completed' }),
+		});
+		expect(result.status).toBe(400);
+	});
+
+	it('rejects an invalid signature', async () => {
+		const result = await callApp('/api/billing/webhook', {
+			method: 'POST',
+			body: JSON.stringify({ type: 'checkout.session.completed' }),
+			headers: { 'stripe-signature': 't=1,v1=not-a-real-signature' },
+		});
+		expect(result.status).toBe(400);
+	});
+
+	it('checkout.session.completed creates a subscription row keyed by householdId, without yet granting premium', async () => {
+		const { cookies } = await createLoggedInUser(uniqueEmail());
+		const householdId = await createHousehold(cookies);
+
+		const result = await postWebhook({
+			type: 'checkout.session.completed',
+			data: {
+				object: {
+					customer: 'cus_test_1',
+					subscription: 'sub_test_1',
+					metadata: { householdId },
+				},
+			},
+		});
+		expect(result.status).toBe(200);
+
+		const row = await getSubscriptionRow(householdId);
+		expect(row?.stripe_customer_id).toBe('cus_test_1');
+		expect(row?.stripe_subscription_id).toBe('sub_test_1');
+		// No current_period_end yet -- Stripe's Session object never carries it, only the
+		// Subscription object does (see customer.subscription.updated below). Until it's set,
+		// isEffectivelyPremium (lib/entitlements.ts) can't treat this household as premium.
+		expect(row?.current_period_end).toBeNull();
+
+		const entitlements = await callApp<{ tier: string }>(
+			`/api/households/${householdId}/entitlements`,
+			{ cookies }
+		);
+		expect(entitlements.body.tier).toBe('free');
+	});
+
+	it('customer.subscription.updated sets current_period_end and actually grants premium', async () => {
+		const { cookies } = await createLoggedInUser(uniqueEmail());
+		const householdId = await createHousehold(cookies);
+		await postWebhook({
+			type: 'checkout.session.completed',
+			data: {
+				object: {
+					customer: 'cus_test_2',
+					subscription: 'sub_test_2',
+					metadata: { householdId },
+				},
+			},
+		});
+
+		const periodEnd = Math.floor(Date.now() / 1000) + 30 * 24 * 60 * 60;
+		const result = await postWebhook({
+			type: 'customer.subscription.updated',
+			data: {
+				object: {
+					id: 'sub_test_2',
+					customer: 'cus_test_2',
+					current_period_end: periodEnd,
+				},
+			},
+		});
+		expect(result.status).toBe(200);
+
+		const row = await getSubscriptionRow(householdId);
+		expect(row?.tier).toBe('premium');
+		expect(row?.status).toBe('active');
+		expect(row?.current_period_end).toBe(periodEnd * 1000);
+
+		const entitlements = await callApp<{ tier: string }>(
+			`/api/households/${householdId}/entitlements`,
+			{ cookies }
+		);
+		expect(entitlements.body.tier).toBe('premium');
+	});
+
+	it('customer.subscription.updated falls back to subscription_data.metadata when it arrives before checkout.session.completed', async () => {
+		const { cookies } = await createLoggedInUser(uniqueEmail());
+		const householdId = await createHousehold(cookies);
+		const periodEnd = Math.floor(Date.now() / 1000) + 30 * 24 * 60 * 60;
+
+		// No prior checkout.session.completed -- stripeCustomerId isn't on any row yet, so the
+		// lookup-by-customer branch finds nothing and this has to fall back to metadata.
+		const result = await postWebhook({
+			type: 'customer.subscription.updated',
+			data: {
+				object: {
+					id: 'sub_test_3',
+					customer: 'cus_test_3',
+					current_period_end: periodEnd,
+					metadata: { householdId },
+				},
+			},
+		});
+		expect(result.status).toBe(200);
+
+		const row = await getSubscriptionRow(householdId);
+		expect(row?.tier).toBe('premium');
+		expect(row?.stripe_customer_id).toBe('cus_test_3');
+		expect(row?.current_period_end).toBe(periodEnd * 1000);
+	});
+
+	it('customer.subscription.deleted cancels without resetting current_period_end', async () => {
+		const { cookies } = await createLoggedInUser(uniqueEmail());
+		const householdId = await createHousehold(cookies);
+		const periodEnd = Math.floor(Date.now() / 1000) + 30 * 24 * 60 * 60;
+		await postWebhook({
+			type: 'customer.subscription.updated',
+			data: {
+				object: {
+					id: 'sub_test_4',
+					customer: 'cus_test_4',
+					current_period_end: periodEnd,
+					metadata: { householdId },
+				},
+			},
+		});
+
+		const result = await postWebhook({
+			type: 'customer.subscription.deleted',
+			data: { object: { id: 'sub_test_4', customer: 'cus_test_4' } },
+		});
+		expect(result.status).toBe(200);
+
+		const row = await getSubscriptionRow(householdId);
+		expect(row?.status).toBe('canceled');
+		// Matches lib/billing.ts's mock cancelSubscription -- current_period_end is left as-is.
+		expect(row?.current_period_end).toBe(periodEnd * 1000);
+
+		const entitlements = await callApp<{ tier: string }>(
+			`/api/households/${householdId}/entitlements`,
+			{ cookies }
+		);
+		expect(entitlements.body.tier).toBe('free');
+	});
+
+	it('is a no-op for an event type it does not handle', async () => {
+		const result = await postWebhook({
+			type: 'invoice.paid',
+			data: { object: {} },
+		});
+		expect(result.status).toBe(200);
+	});
+});

--- a/services/api/src/routes/billing.ts
+++ b/services/api/src/routes/billing.ts
@@ -1,0 +1,146 @@
+import { createDb, subscriptions, type Database } from '@pairflix/db';
+import { eq } from 'drizzle-orm';
+import { Hono } from 'hono';
+import { auditInfo } from '../lib/audit';
+import { newId } from '../lib/id';
+import { isStripeConfigured, verifyWebhookSignature } from '../lib/stripe';
+import type { AppEnv } from '../types';
+
+/**
+ * Global Stripe surface -- unlike the household-scoped checkout/portal actions
+ * (routes/households.ts, gated by requireHouseholdOwner), `/status` and `/webhook` must stay
+ * public and unscoped to any one household: the frontend checks `/status` before showing a real
+ * "subscribe" button, and Stripe calls `/webhook` with no household context in the URL at all
+ * (the household is resolved from the event payload's metadata). Mounted at `/api/billing`.
+ */
+export const billingRoutes = new Hono<AppEnv>();
+
+billingRoutes.get('/status', c => {
+	return c.json({ configured: isStripeConfigured(c.env) });
+});
+
+type StripeCheckoutSessionObject = {
+	customer?: string;
+	subscription?: string;
+	metadata?: Record<string, string>;
+};
+
+type StripeSubscriptionObject = {
+	id: string;
+	customer?: string;
+	current_period_end?: number;
+	metadata?: Record<string, string>;
+};
+
+/** Upserts a household's subscription row to premium/active. Shared by both webhook handlers
+ * below since either can be the first to see a given household -- `checkout.session.completed`
+ * only ever carries the customer/subscription ids (Stripe's Session object has no period-end),
+ * `customer.subscription.created`/`.updated` carry the real `current_period_end` this product's
+ * `isEffectivelyPremium` check requires but arrive keyed by customer id, which may not be on the
+ * row yet the very first time. */
+const upsertPremiumSubscription = async (
+	db: Database,
+	householdId: string,
+	fields: {
+		stripeCustomerId: string;
+		stripeSubscriptionId?: string;
+		currentPeriodEnd?: Date;
+	}
+): Promise<void> => {
+	const now = new Date();
+	await db
+		.insert(subscriptions)
+		.values({
+			id: newId('sub'),
+			householdId,
+			tier: 'premium',
+			status: 'active',
+			...fields,
+			createdAt: now,
+			updatedAt: now,
+		})
+		.onConflictDoUpdate({
+			target: subscriptions.householdId,
+			set: { tier: 'premium', status: 'active', ...fields, updatedAt: now },
+		});
+};
+
+billingRoutes.post('/webhook', async c => {
+	const webhookSecret = c.env.STRIPE_WEBHOOK_SECRET;
+	if (!webhookSecret) return c.json({ error: 'not_configured' }, 501);
+
+	const payload = await c.req.text();
+	const valid = await verifyWebhookSignature(
+		payload,
+		c.req.header('stripe-signature') ?? null,
+		webhookSecret
+	);
+	if (!valid) return c.json({ error: 'invalid_signature' }, 400);
+
+	// Trusted Stripe API response body -- shape documented at stripe.com/docs/api/events/object.
+	const event = JSON.parse(payload) as {
+		type: string;
+		data: { object: unknown };
+	};
+	const db = createDb(c.env.DB);
+
+	if (event.type === 'checkout.session.completed') {
+		const session = event.data.object as StripeCheckoutSessionObject;
+		const householdId = session.metadata?.householdId;
+		if (householdId && session.customer) {
+			await upsertPremiumSubscription(db, householdId, {
+				stripeCustomerId: session.customer,
+				stripeSubscriptionId: session.subscription,
+			});
+			await auditInfo(db, 'Stripe checkout completed', 'stripe-webhook', {
+				householdId,
+			});
+		}
+	} else if (
+		event.type === 'customer.subscription.created' ||
+		event.type === 'customer.subscription.updated'
+	) {
+		const subscription = event.data.object as StripeSubscriptionObject;
+		if (subscription.customer && subscription.current_period_end) {
+			const currentPeriodEnd = new Date(subscription.current_period_end * 1000);
+			const updated = await db
+				.update(subscriptions)
+				.set({
+					tier: 'premium',
+					status: 'active',
+					stripeSubscriptionId: subscription.id,
+					currentPeriodEnd,
+					updatedAt: new Date(),
+				})
+				.where(eq(subscriptions.stripeCustomerId, subscription.customer))
+				.returning({ householdId: subscriptions.householdId });
+			// This event beat checkout.session.completed to stamping stripeCustomerId onto the
+			// row -- subscription_data.metadata (lib/stripe.ts's createCheckoutSession) carries
+			// the same householdId, so it's resolvable here too.
+			if (updated.length === 0 && subscription.metadata?.householdId) {
+				await upsertPremiumSubscription(db, subscription.metadata.householdId, {
+					stripeCustomerId: subscription.customer,
+					stripeSubscriptionId: subscription.id,
+					currentPeriodEnd,
+				});
+			}
+			await auditInfo(db, 'Stripe subscription active', 'stripe-webhook', {
+				stripeCustomerId: subscription.customer,
+			});
+		}
+	} else if (event.type === 'customer.subscription.deleted') {
+		const subscription = event.data.object as StripeSubscriptionObject;
+		if (subscription.customer) {
+			// currentPeriodEnd is left untouched, matching lib/billing.ts's mock cancelSubscription.
+			await db
+				.update(subscriptions)
+				.set({ status: 'canceled', updatedAt: new Date() })
+				.where(eq(subscriptions.stripeCustomerId, subscription.customer));
+			await auditInfo(db, 'Stripe subscription canceled', 'stripe-webhook', {
+				stripeCustomerId: subscription.customer,
+			});
+		}
+	}
+
+	return c.json({ received: true });
+});

--- a/services/api/src/routes/households.e2e.test.ts
+++ b/services/api/src/routes/households.e2e.test.ts
@@ -741,6 +741,7 @@ describe('POST /api/households/:id/pick -- TV candidates', () => {
 		mockExternalApis([COMEDY_MOVIE_SAME_ERA], undefined, [SHOW_ACTION]);
 		const result = await postJson<{
 			pick: { tmdbId: number; mediaType: string };
+			rationale: string;
 		}>(
 			`/api/households/${householdId}/pick`,
 			{ mood: 'action', minutes: 120 },
@@ -749,6 +750,47 @@ describe('POST /api/households/:id/pick -- TV candidates', () => {
 		expect(result.status).toBe(200);
 		expect(result.body.pick.mediaType).toBe('tv');
 		expect(result.body.pick.tmdbId).toBe(SHOW_ACTION.id);
+		// buildRationale reads the pick's own genre_ids too -- proves the id-remap reaches it, not
+		// just scoreCandidate, or this would fall back to the generic "matches your mood" text.
+		expect(result.body.rationale).toContain('action');
+	});
+
+	it('rating a TV action/adventure title nudges the movie action/adventure genre weights', async () => {
+		const { userId, cookies } = await createLoggedInUser(uniqueEmail());
+		const householdId = await createHousehold(cookies);
+
+		// cacheContentDetails (called from commitPick) persists content.genreIds from TMDb's raw TV
+		// response -- [10759], not [28, 12]. Without normalizing it the same way pickForHousehold's
+		// in-memory candidates are, recomputeTasteFromRating's nudgeGenreWeights would silently skip
+		// this rating entirely (10759 isn't a key in GENRE_NAMES), and neither weight would move.
+		mockExternalApis([], undefined, [SHOW_ACTION]);
+		const commit = await postJson<{ id: string }>(
+			`/api/households/${householdId}/picks/${SHOW_ACTION.id}/commit`,
+			{ mediaType: 'tv', mood: 'action', minutes: 120 },
+			cookies
+		);
+		expect(commit.status).toBe(201);
+		const patch = await postJson<{ entry: { enjoyed: boolean | null } }>(
+			`/api/households/${householdId}/history/${commit.body.id}`,
+			{ enjoyed: true },
+			cookies,
+			{ method: 'PATCH' }
+		);
+		expect(patch.status).toBe(200);
+
+		const profileRow = await waitForRow(() =>
+			env.DB.prepare('SELECT weights FROM taste_profiles WHERE user_id = ?1')
+				.bind(userId)
+				.first<{ weights: string }>()
+		);
+		const weights = JSON.parse(profileRow.weights) as {
+			genres: Record<string, number>;
+		};
+		// Same EMA-from-neutral math as the movie case (0.35 * 0.75 + 1.0 * 0.25 = 0.5125) -- both
+		// ids nudge independently, since nudgeGenreWeights loops every rated genre id on its own.
+		expect(weights.genres['28']).toBeCloseTo(0.5125, 5);
+		expect(weights.genres['12']).toBeCloseTo(0.5125, 5);
+		expect(weights.genres['35']).toBeCloseTo(0.35, 5);
 	});
 
 	it('does not exclude a TV candidate whose id matches a watched movie', async () => {

--- a/services/api/src/routes/households.e2e.test.ts
+++ b/services/api/src/routes/households.e2e.test.ts
@@ -188,6 +188,52 @@ const SHOW_A: MockShow = {
 	episode_run_time: [112],
 };
 
+// Fixtures for the "action mood recognizes TV's Action & Adventure id" test below. Rated (not
+// offered as a candidate) purely to seed a household genre/tone preference before the real
+// comparison -- its own era bucket (1980s) is deliberately far from the two candidates' (2010s) so
+// its era nudge can't touch either of them.
+const RATED_ACTION_MOVIE: MockMovie = {
+	id: 501,
+	title: 'Explosive Pursuit',
+	overview:
+		'Rated to seed an action genre/tone preference; not itself a candidate afterward.',
+	poster_path: null,
+	release_date: '1985-06-01',
+	vote_average: 6.5,
+	vote_count: 300,
+	genre_ids: [28],
+	popularity: 20,
+	runtime: 100,
+};
+// Same release year (era bucket) and runtime as COMEDY_MOVIE_SAME_ERA below -- recencyBonus,
+// eraPref, and runtimeFit are all identical between the two, so only genre-based scoring
+// (genreMatch, genreMoodHit) can decide which one wins.
+const SHOW_ACTION: MockShow = {
+	id: 502,
+	name: 'Chase Protocol',
+	overview: 'A TV action/adventure series.',
+	poster_path: null,
+	first_air_date: '2015-06-15',
+	vote_average: 7.5,
+	vote_count: 400,
+	// TMDb's real TV genre for this -- not [28, 12], which don't exist in TV's taxonomy.
+	genre_ids: [10759],
+	popularity: 45,
+	episode_run_time: [105],
+};
+const COMEDY_MOVIE_SAME_ERA: MockMovie = {
+	id: 503,
+	title: 'Sitcom Reruns',
+	overview: 'An unrelated comedy, matched on every dimension except genre.',
+	poster_path: null,
+	release_date: '2015-01-01',
+	vote_average: 7.5,
+	vote_count: 400,
+	genre_ids: [35],
+	popularity: 45,
+	runtime: 105,
+};
+
 const jsonResponse = (data: unknown, status = 200): Response =>
 	new Response(JSON.stringify(data), {
 		status,
@@ -651,16 +697,58 @@ describe('POST /api/households/:id/pick -- TV candidates', () => {
 		const { cookies } = await createLoggedInUser(uniqueEmail());
 		const householdId = await createHousehold(cookies);
 
-		// action mood's genres (28 action, 12 adventure) have no TV equivalent -- see
+		// romantic mood's only genre (10749, romance) has no TV equivalent at all -- see
 		// TV_COMPATIBLE_GENRE_IDS.
 		const capturedUrls = mockExternalApis(DEFAULT_MOVIES, undefined, [SHOW_A]);
 		const result = await postJson(
+			`/api/households/${householdId}/pick`,
+			{ mood: 'romantic', minutes: 120 },
+			cookies
+		);
+		expect(result.status).toBe(200);
+		expect(capturedUrls.some(u => u.includes('/3/discover/tv'))).toBe(false);
+	});
+
+	it('recognizes TV Action & Adventure (10759) as the action mood, not just fetches it', async () => {
+		const { userId, cookies } = await createLoggedInUser(uniqueEmail());
+		const householdId = await createHousehold(cookies);
+
+		// Seed an action genre/tone preference -- SHOW_ACTION and COMEDY_MOVIE_SAME_ERA are
+		// identical on every other scored dimension (era bucket, runtime), so only genre-based
+		// scoring can decide the winner below. If TV's genre id (10759) weren't correctly mapped
+		// back to the movie ids (28, 12) this preference is keyed by, SHOW_ACTION would score a
+		// flat 0 on both genreMatch and the genre half of moodHit and lose easily instead.
+		mockExternalApis([RATED_ACTION_MOVIE]);
+		const commit = await postJson<{ id: string }>(
+			`/api/households/${householdId}/picks/${RATED_ACTION_MOVIE.id}/commit`,
+			{ mediaType: 'movie', mood: 'action', minutes: 120 },
+			cookies
+		);
+		expect(commit.status).toBe(201);
+		const patch = await postJson<{ entry: { enjoyed: boolean | null } }>(
+			`/api/households/${householdId}/history/${commit.body.id}`,
+			{ enjoyed: true },
+			cookies,
+			{ method: 'PATCH' }
+		);
+		expect(patch.status).toBe(200);
+		await waitForRow(() =>
+			env.DB.prepare('SELECT weights FROM taste_profiles WHERE user_id = ?1')
+				.bind(userId)
+				.first<{ weights: string }>()
+		);
+
+		mockExternalApis([COMEDY_MOVIE_SAME_ERA], undefined, [SHOW_ACTION]);
+		const result = await postJson<{
+			pick: { tmdbId: number; mediaType: string };
+		}>(
 			`/api/households/${householdId}/pick`,
 			{ mood: 'action', minutes: 120 },
 			cookies
 		);
 		expect(result.status).toBe(200);
-		expect(capturedUrls.some(u => u.includes('/3/discover/tv'))).toBe(false);
+		expect(result.body.pick.mediaType).toBe('tv');
+		expect(result.body.pick.tmdbId).toBe(SHOW_ACTION.id);
 	});
 
 	it('does not exclude a TV candidate whose id matches a watched movie', async () => {

--- a/services/api/src/routes/households.e2e.test.ts
+++ b/services/api/src/routes/households.e2e.test.ts
@@ -1469,6 +1469,39 @@ describe('billing routes', () => {
 		expect(asOwner.body.checkoutUrl).toContain(householdId);
 	});
 
+	it('POST /:id/billing/portal is owner-only and 501s while Stripe is unconfigured', async () => {
+		const { cookies: ownerCookies } = await createLoggedInUser(uniqueEmail());
+		const { cookies: memberCookies } = await createLoggedInUser(uniqueEmail());
+		const householdId = await createHousehold(ownerCookies);
+		const invite = await postJson<{ invite: { token: string } }>(
+			`/api/households/${householdId}/invites`,
+			{},
+			ownerCookies
+		);
+		await postJson(
+			`/api/households/invites/${invite.body.invite.token}/accept`,
+			{},
+			memberCookies
+		);
+
+		const asMember = await postJson(
+			`/api/households/${householdId}/billing/portal`,
+			{},
+			memberCookies
+		);
+		expect(asMember.status).toBe(403);
+
+		// STRIPE_SECRET_KEY/STRIPE_PRICE_PREMIUM are deliberately unset throughout this test
+		// suite (vitest.config.mts) -- real Stripe calls (createPortalSession) are otherwise
+		// unreachable/manual-verification-only, matching creatorgrid's own lib/stripe.ts coverage.
+		const asOwner = await postJson(
+			`/api/households/${householdId}/billing/portal`,
+			{},
+			ownerCookies
+		);
+		expect(asOwner.status).toBe(501);
+	});
+
 	it('mock-activate flips the household to premium, cancel reverts it', async () => {
 		const { cookies } = await createLoggedInUser(uniqueEmail());
 		const householdId = await createHousehold(cookies);

--- a/services/api/src/routes/households.ts
+++ b/services/api/src/routes/households.ts
@@ -17,7 +17,8 @@ import {
 	cancelSubscription,
 	isBillingMockEnabled,
 	mockActivatePremium,
-	startCheckout,
+	startPortalSession,
+	startRealOrMockCheckout,
 } from '../lib/billing';
 import { getEntitlements } from '../lib/entitlements';
 import { listHistory, setEnjoyed } from '../lib/history';
@@ -449,9 +450,40 @@ householdsRoutes.get('/:id/entitlements', requireHouseholdMember, async c => {
 	return c.json(entitlements);
 });
 
-householdsRoutes.post('/:id/billing/checkout', requireHouseholdOwner, c => {
+householdsRoutes.post(
+	'/:id/billing/checkout',
+	requireHouseholdOwner,
+	async c => {
+		const householdId = c.req.param('id');
+		const userId = c.get('userId') as string;
+		const db = createDb(c.env.DB);
+		const session = await startRealOrMockCheckout(
+			c.env,
+			db,
+			householdId,
+			userId
+		);
+		return c.json(session);
+	}
+);
+
+/**
+ * Stripe's self-service Billing Portal -- where a real subscription actually gets changed or
+ * canceled once Stripe is configured. 501s (not configured) or 400s (no checkout yet) rather
+ * than 404ing like `mock-activate` below, since this route is meant to be discoverable/callable
+ * regardless of Stripe's configuration state -- the frontend can show a clear reason instead of
+ * a generic missing-route error.
+ */
+householdsRoutes.post('/:id/billing/portal', requireHouseholdOwner, async c => {
 	const householdId = c.req.param('id');
-	return c.json(startCheckout(householdId));
+	const db = createDb(c.env.DB);
+	const result = await startPortalSession(c.env, db, householdId);
+	if (!result.ok) {
+		return result.reason === 'not_configured'
+			? c.json({ error: 'billing_not_configured' }, 501)
+			: c.json({ error: 'no_billing_account' }, 400);
+	}
+	return c.json({ portalUrl: result.portalUrl });
 });
 
 householdsRoutes.post('/:id/billing/cancel', requireHouseholdOwner, async c => {

--- a/services/api/src/types.ts
+++ b/services/api/src/types.ts
@@ -26,6 +26,17 @@ export type Bindings = {
 	 * `ENVIRONMENT !== 'production'`, same "unconfigured is a valid state" default as the current
 	 * Express `isBillingMockEnabled()`. Set to the literal string `'false'` to hard-disable. */
 	BILLING_MOCK_ENABLED?: string;
+	/** Real Stripe billing (lib/stripe.ts) -- `isStripeConfigured` requires both this and
+	 * STRIPE_PRICE_PREMIUM; absent means `POST /:id/billing/checkout` falls back to the existing
+	 * mock checkout, same "unconfigured is a valid state" pattern as the rest of this Bindings
+	 * type. */
+	STRIPE_SECRET_KEY?: string;
+	/** Verifies `POST /api/billing/webhook`'s `stripe-signature` header -- absent means the
+	 * webhook route 501s rather than trusting an unverifiable payload. */
+	STRIPE_WEBHOOK_SECRET?: string;
+	/** Stripe Price id for the one paid tier -- pairflix is free/premium only, unlike creatorgrid's
+	 * per-plan price ids. */
+	STRIPE_PRICE_PREMIUM?: string;
 };
 
 /** Request-scoped values set by middleware. */

--- a/services/api/vitest.config.mts
+++ b/services/api/vitest.config.mts
@@ -45,6 +45,12 @@ export default defineConfig(async () => {
             // short-circuit before the stub is called.
             TMDB_API_KEY: 'test-tmdb-key',
             ANTHROPIC_API_KEY: 'test-anthropic-key',
+            // Lets billing.e2e.test.ts sign real webhook payloads and exercise
+            // routes/billing.ts's actual event-handling logic. STRIPE_SECRET_KEY/
+            // STRIPE_PRICE_PREMIUM are deliberately left unset (like RESEND_API_KEY) so
+            // isStripeConfigured stays false and every existing checkout/portal test keeps
+            // exercising the mock-fallback path unchanged.
+            STRIPE_WEBHOOK_SECRET: 'whsec_test_secret',
           },
         },
       }),


### PR DESCRIPTION
> **Note:** this PR ended up bundling two independent, unrelated changes onto one branch -- pushed the second one without first checking whether this PR had already merged (it hadn't). Documenting both clearly below rather than untangling the git history at this point. Sorry for the noise -- treat this as two reviews in one.

---

## Part 1: TV action-mood genre mapping (original scope)

### 🚀 What's New

- ✨ Feature: the `action` mood can now surface TV candidates, using TMDb's TV "Action & Adventure" genre (10759).
- 🧪 Test: a new e2e test isolates genre-based scoring to prove a TV action candidate wins on merit, not just that it gets fetched.

### 📝 Description

Follow-up to the "TV moods" decision from the closed-alpha review: fix `action`'s TV mapping now, leave `dark`/`tense`/`romantic` movie-only (no code change there -- see Notes for Reviewers for why).

TMDb's TV genre taxonomy has no standalone Horror/Romance/Thriller at all, so those three genuinely have nothing to map onto. Action is different: TMDb still has an equivalent TV category, it's just numbered differently -- movie Action (28) and Adventure (12) both merge into a single TV id, 10759 ("Action & Adventure"). The existing `TV_COMPATIBLE_GENRE_IDS` check only recognized genres that share the *same* id between movie and TV, so it silently treated `action` as incompatible too, even though a real mapping exists.

Two places needed the mapping, not just one:

- **Fetch side** (`lib/recommendation.ts`'s TV-eligibility check and `/discover/tv` genre filter): 28/12 now count as TV-compatible, remapped to 10759 before the TMDb call.
- **Scoring side** (`scoreCandidate`, then generalized -- see the Copilot-review follow-up commit): a TV item's `genre_ids` carries `10759`, not `28`/`12`. Without expanding it back, a TV action candidate would fetch fine but always score `genreMatch = 0` and `genreMoodHit = 0`, plus lose genre signal in `recomputeTasteFromRating`, `buildRationale`, and the LLM candidate payload -- all fixed via a shared `toMovieGenreIds` helper applied at both places raw TV genre ids enter the system (`pickForHousehold`'s candidate construction, and `cacheContentDetails`'s persistence into `content.genreIds`).

The new test (`recognizes TV Action & Adventure (10759) as the action mood, not just fetches it`) seeds a household genre/tone preference via a rated action movie, then races a TV show tagged `[10759]` against a movie tagged `[35]` (comedy) that's identical on every *other* scored dimension -- so only genre-based scoring can decide the winner. A second new test proves rating a TV action title actually nudges the household's learned `genres['28']`/`['12']` weights.

**Why `dark`/`tense`/`romantic` aren't touched**: TMDb's TV taxonomy has no Horror, Thriller, or Romance genre at all -- there's no id to map, correct or otherwise. Approximating with an adjacent TV genre (Mystery/Crime, Drama) would trade pick accuracy for coverage -- a product tradeoff, not an engineering gap.

---

## Part 2: Real Stripe billing scaffold (unrelated addition)

### 🚀 What's New

- ✨ Feature: real Stripe checkout/portal/webhook, ported from creatorgrid's `lib/stripe.ts` + `routes/billing.ts` pattern (the target CLAUDE.md's Stripe section already named), collapsed to pairflix's single premium tier.

### 📝 Description

Decided via a "scaffold it now vs. wait for go-live" question -- scaffold it now was the choice. Researched creatorgrid's actual implementation before writing anything (hand-rolled `fetch`, not the `stripe` npm SDK, specifically to avoid needing `wrangler.jsonc`'s `nodejs_compat` flag), then adapted it to pairflix's per-household tenancy and existing `subscriptions` schema rather than copying verbatim.

- `lib/stripe.ts` (new): `createCheckoutSession`, `createPortalSession`, `verifyWebhookSignature` (manual HMAC-SHA256 per Stripe's docs, reusing the existing `timingSafeEqual`), `isStripeConfigured` (a type predicate).
- `routes/billing.ts` (new): the global, non-household-scoped surface -- `GET /status`, `POST /webhook`. Handles `checkout.session.completed` (Stripe's Session object never carries `current_period_end`) and `customer.subscription.created`/`.updated` (which do) so a household becomes genuinely premium regardless of which event arrives first -- verified with real end-to-end webhook tests including the out-of-order-delivery fallback.
- `lib/billing.ts`: `startRealOrMockCheckout` falls back to the existing mock when Stripe isn't configured, so `routes/households.ts`'s existing `POST /:id/billing/checkout` doesn't need to branch itself. New `POST /:id/billing/portal` (self-service cancellation/changes once Stripe is live -- the existing mock `cancel` only ever moves this product's own DB state).
- No migration -- pairflix's existing `subscriptions` table already had every column this needs.

**Not live**: `STRIPE_SECRET_KEY`/`STRIPE_PRICE_PREMIUM` stay unset (like `RESEND_API_KEY`) throughout the test suite and in this deploy, so every existing checkout/portal test keeps exercising the mock-fallback path unchanged. Going live from here is a config/account step, gated on go-live sign-off, not more code.

---

### ✅ Checklist (both parts)

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented parts that are complex or non-obvious
- [x] I have updated relevant documentation
- [x] I have added or updated tests
- [x] No new warnings or errors are introduced
- [x] All tests pass locally

**Verification run (after both parts, full re-run):**

- [x] `pnpm -r type-check` -- clean across all 8 workspaces
- [x] `pnpm --filter @pairflix/api lint` / `pnpm lint` (monorepo) -- 0 errors
- [x] `pnpm --filter @pairflix/api test` -- 163/163
- [x] `pnpm build` -- all 4 buildable workspaces succeed, including the Worker's `wrangler deploy --dry-run` bundle check (no `nodejs_compat` needed)

---

### ⚠️ Notes for Reviewers

- Real Stripe HTTP calls (checkout/portal session creation) are manual-verification-only in this PR, matching creatorgrid's own precedent -- confirmed via research that creatorgrid itself has no automated coverage for those either (only its pure-function webhook-signature/config logic is unit-tested, same as this PR's `lib/stripe.test.ts`).
- The two Copilot review rounds already addressed on the TV-genre-mapping commits are folded into the description above rather than re-narrated -- see the commit history for the exact findings and fixes.

---

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XaZAU6ca9bxsD6vhj8j392