### PR TITLE
feat(api): give dark mood partial TV coverage via crime

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -26,10 +26,13 @@
   this to one app and fixes it.
 - ~~**Recommender is runtime-blind**~~ — fixed; candidates are re-scored on real runtime after
   hydration and re-sorted before the final pick. TV candidates now appear for genre-compatible
-  moods (funny/feelgood/thoughtful) and for action (TMDb's TV "Action & Adventure" id, 10759, maps
-  back onto movie Action/Adventure for scoring); dark/tense/romantic stay movie-only -- TV's genre
-  taxonomy has no Horror/Romance/Thriller equivalent to map onto at all.
-- **Billing is mock-only** (no Stripe).
+  moods (funny/feelgood/thoughtful), for action (TMDb's TV "Action & Adventure" id, 10759, maps
+  back onto movie Action/Adventure for scoring), and partially for dark (its crime genre has a TV
+  equivalent even though thriller doesn't -- eligibility only needs one matching genre, not both);
+  tense/romantic stay movie-only by decision -- TV's genre taxonomy has no Horror/Romance/Thriller
+  equivalent to map onto at all.
+- **Billing is Stripe-scaffolded but not live** — mock checkout is still the fallback until a real
+  Stripe account is wired up (see "Real Stripe" below).
 - ~~**Thin tests on the pivot**~~ — no longer true; `households.e2e.test.ts` alone is 1,300+ lines
   covering pick/commit/history/entitlements/TV/runtime-ranking, plus dedicated suites for auth,
   admin, `/api/me`, and providers.
@@ -293,12 +296,14 @@ Independent of the platform, needed before opening to an invited cohort:
 
 - Validate the LLM re-rank actually improves first-pick acceptance (premium only) -- it's wired in
   and feature-flagged, needs real usage data to judge.
-- ~~Extend the recommender to TV~~ — done for genre-compatible moods (funny/feelgood/thoughtful)
-  and for action (TMDb's TV genre taxonomy has an actual equivalent, just under a different id --
-  see `TV_ACTION_ADVENTURE_GENRE_ID`). dark/tense/romantic stay movie-only by decision, not by
-  gap: TV has no Horror/Thriller/Romance genre at all, so there's nothing accurate to map onto --
-  approximating with an adjacent TV genre (Mystery, Crime, Drama) would serve picks that don't
-  actually match what the mood promised.
+- ~~Extend the recommender to TV~~ — done for genre-compatible moods (funny/feelgood/thoughtful),
+  for action (TMDb's TV genre taxonomy has an actual equivalent, just under a different id -- see
+  `TV_ACTION_ADVENTURE_GENRE_ID`), and partially for dark: one of its two genres, crime, is
+  directly shared with TV's taxonomy (an exact match, not an approximation), so dark's TV
+  candidates are crime-only -- the other genre, thriller, has no TV equivalent at all. tense/
+  romantic stay fully movie-only by decision, not by gap: TV has no Horror/Thriller/Romance genre
+  at all, so there's nothing accurate to map onto -- approximating with an adjacent TV genre
+  (Mystery, Drama) would serve picks that don't actually match what the mood promised.
 - ~~Make runtime actually influence scoring~~ — done; candidates are re-scored with their real
   runtime after hydration and re-sorted before the final pick, instead of only ever scoring against
   a neutral runtime guess.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -299,8 +299,9 @@ Independent of the platform, needed before opening to an invited cohort:
 - ~~Extend the recommender to TV~~ — done for genre-compatible moods (funny/feelgood/thoughtful),
   for action (TMDb's TV genre taxonomy has an actual equivalent, just under a different id -- see
   `TV_ACTION_ADVENTURE_GENRE_ID`), and partially for dark: one of its two genres, crime, is
-  directly shared with TV's taxonomy (an exact match, not an approximation), so dark's TV
-  candidates are crime-only -- the other genre, thriller, has no TV equivalent at all. tense/
+  directly shared with TV's taxonomy (an exact match, not an approximation), so dark now qualifies
+  for TV at all -- the other genre, thriller, has no TV equivalent, and dark's actual TV query can
+  include other TV-compatible taste-derived genres alongside crime, not crime alone. tense/
   romantic stay fully movie-only by decision, not by gap: TV has no Horror/Thriller/Romance genre
   at all, so there's nothing accurate to map onto -- approximating with an adjacent TV genre
   (Mystery, Drama) would serve picks that don't actually match what the mood promised.

--- a/services/api/src/lib/genres.ts
+++ b/services/api/src/lib/genres.ts
@@ -26,11 +26,13 @@ export const GENRE_NAMES: Record<number, string> = {
 /** TMDb's TV genre list only shares these ids with the movie list above -- TV has no standalone
  * Horror (27), Romance (10749), or Thriller (53) at all. That rules TV out entirely for `tense`
  * (thriller + horror, neither has a TV equivalent) and `romantic` (romance alone, same problem),
- * but not for `dark`: one of its two genres is crime (80), which *is* in this set, so `dark` gets
- * TV candidates filtered to just that genre -- see `lib/recommendation.ts`'s `tvEligible` (mood
- * eligibility needs only one compatible genre, not all of them) for why. That same file's TV call
- * filters `genres` down to the compatible subset either way, so a `/discover/tv` call never
- * filters on an id that doesn't exist in TV's taxonomy, regardless of why the mood qualified. */
+ * but not for `dark`: one of its two genres is crime (80), which *is* in this set, so `dark`
+ * qualifies for TV at all -- see `lib/recommendation.ts`'s `tvEligible` (mood eligibility needs
+ * only one compatible genre, not all of them) for why. That same file's TV call filters the full
+ * merged `genres` list (mood genres plus up to 3 taste-derived extras) down to the compatible
+ * subset either way, so a `/discover/tv` call never filters on an id that doesn't exist in TV's
+ * taxonomy -- for `dark` that means crime plus whatever other TV-compatible genres the household's
+ * taste happened to merge in, not crime alone. */
 export const TV_COMPATIBLE_GENRE_IDS = new Set<number>([
 	16, 35, 80, 99, 18, 10751, 9648, 37,
 ]);

--- a/services/api/src/lib/genres.ts
+++ b/services/api/src/lib/genres.ts
@@ -24,10 +24,13 @@ export const GENRE_NAMES: Record<number, string> = {
 };
 
 /** TMDb's TV genre list only shares these ids with the movie list above -- TV has no standalone
- * Horror (27), Romance (10749), or Thriller (53) at all, so there's no way to map `dark`/`tense`/
- * `romantic` onto TV. `lib/recommendation.ts` only fetches TV candidates when every genre id a mood
- * would filter on is either in this set or is the Action/Adventure exception below, so a
- * `/discover/tv` call never filters on an id that doesn't exist in TV's taxonomy. */
+ * Horror (27), Romance (10749), or Thriller (53) at all. That rules TV out entirely for `tense`
+ * (thriller + horror, neither has a TV equivalent) and `romantic` (romance alone, same problem),
+ * but not for `dark`: one of its two genres is crime (80), which *is* in this set, so `dark` gets
+ * TV candidates filtered to just that genre -- see `lib/recommendation.ts`'s `tvEligible` (mood
+ * eligibility needs only one compatible genre, not all of them) for why. That same file's TV call
+ * filters `genres` down to the compatible subset either way, so a `/discover/tv` call never
+ * filters on an id that doesn't exist in TV's taxonomy, regardless of why the mood qualified. */
 export const TV_COMPATIBLE_GENRE_IDS = new Set<number>([
 	16, 35, 80, 99, 18, 10751, 9648, 37,
 ]);

--- a/services/api/src/lib/recommendation.ts
+++ b/services/api/src/lib/recommendation.ts
@@ -449,20 +449,21 @@ export const pickForHousehold = async (
 		voteCountGte: 200,
 		region,
 	};
-	// Only fetch TV candidates when every genre the *mood itself* filters on is valid in TV's genre
-	// taxonomy -- see TV_COMPATIBLE_GENRE_IDS's doc comment. The up-to-3 extra ids pulled in from
-	// the household's taste weights don't gate eligibility -- an eligible mood can still pull in an
-	// incompatible one, so the TV call filters `genres` (mood + taste extras) down to the
-	// compatible subset itself, not the full list the movie call uses. Action (28) and Adventure
-	// (12) aren't literally in TV_COMPATIBLE_GENRE_IDS -- TMDb merges them into the
-	// differently-numbered TV_ACTION_ADVENTURE_GENRE_ID -- so both the eligibility check and the
-	// filter treat that pair as compatible too, remapped to the TV id `/discover/tv` actually
-	// understands.
+	// Fetch TV candidates when at least one genre the *mood itself* filters on is valid in TV's
+	// genre taxonomy -- see TV_COMPATIBLE_GENRE_IDS's doc comment. Not "every genre": dark's two
+	// genres are crime (80, already shared with TV) and thriller (53, no TV equivalent at all) --
+	// requiring both would discard a mood that already owns a real TV genre just because TMDb can't
+	// express the rest of it. The TV call itself filters `genres` (mood + up to 3 taste extras) down
+	// to the compatible subset either way, so an ineligible id never reaches it regardless of why the
+	// mood as a whole qualified. Action (28) and Adventure (12) aren't literally in
+	// TV_COMPATIBLE_GENRE_IDS -- TMDb merges them into the differently-numbered
+	// TV_ACTION_ADVENTURE_GENRE_ID -- so both the eligibility check and the filter treat that pair as
+	// compatible too, remapped to the TV id `/discover/tv` actually understands.
 	const isTvCompatibleGenre = (g: number) =>
 		TV_COMPATIBLE_GENRE_IDS.has(g) || g === 28 || g === 12;
 	const toTvGenreId = (g: number) =>
 		g === 28 || g === 12 ? TV_ACTION_ADVENTURE_GENRE_ID : g;
-	const tvEligible = moodCfg.genres.every(isTvCompatibleGenre);
+	const tvEligible = moodCfg.genres.some(isTvCompatibleGenre);
 	const [movieResp, tvResp] = await Promise.all([
 		discoverMedia(env, { ...discoverParams, mediaType: 'movie' }),
 		tvEligible

--- a/services/api/src/routes/households.e2e.test.ts
+++ b/services/api/src/routes/households.e2e.test.ts
@@ -188,6 +188,22 @@ const SHOW_A: MockShow = {
 	episode_run_time: [112],
 };
 
+// dark's other genre (thriller, 53) has no TV equivalent, but this one (crime, 80) does -- same
+// recency-driven win pattern as SHOW_A, just proving TV eligibility now only needs one of dark's
+// two genres to match instead of both.
+const SHOW_DARK: MockShow = {
+	id: 202,
+	name: 'The Precinct',
+	overview: 'A dark TV crime drama.',
+	poster_path: null,
+	first_air_date: '2026-01-01',
+	vote_average: 8.0,
+	vote_count: 600,
+	genre_ids: [80],
+	popularity: 60,
+	episode_run_time: [112],
+};
+
 // Fixtures for the "action mood recognizes TV's Action & Adventure id" test below. Rated (not
 // offered as a candidate) purely to seed a household genre/tone preference before the real
 // comparison -- its own era bucket (1980s) is deliberately far from the two candidates' (2010s) so
@@ -691,6 +707,26 @@ describe('POST /api/households/:id/pick -- TV candidates', () => {
 		expect(result.status).toBe(200);
 		expect(result.body.pick.mediaType).toBe('tv');
 		expect(result.body.pick.tmdbId).toBe(SHOW_A.id);
+	});
+
+	it('dark mood can win the pick via TV on a partial genre match (crime, not thriller)', async () => {
+		const { cookies } = await createLoggedInUser(uniqueEmail());
+		const householdId = await createHousehold(cookies);
+
+		// DEFAULT_MOVIES are all genre 35 (comedy) -- a full mismatch against dark's [80, 53], so
+		// SHOW_DARK (genre 80) wins on both genre match and recency, proving tvEligible now queries
+		// TV for dark even though only one of its two genres (crime) has a TV equivalent.
+		mockExternalApis(DEFAULT_MOVIES, undefined, [SHOW_DARK]);
+		const result = await postJson<{
+			pick: { tmdbId: number; mediaType: string };
+		}>(
+			`/api/households/${householdId}/pick`,
+			{ mood: 'dark', minutes: 120 },
+			cookies
+		);
+		expect(result.status).toBe(200);
+		expect(result.body.pick.mediaType).toBe('tv');
+		expect(result.body.pick.tmdbId).toBe(SHOW_DARK.id);
 	});
 
 	it('never queries TV for a mood outside the TV-compatible genre set', async () => {


### PR DESCRIPTION
### 🚀 What's New

- ✨ Feature: the `dark` mood can now surface TV candidates, filtered to its crime genre.
- 🧪 Test: a new e2e test proves a TV crime title can win the `dark`-mood pick.

---

### 📝 Description

Follow-up to the closed-alpha "TV moods" decision, revisited: the earlier fix scoped to `action` only, deliberately leaving `dark`/`tense`/`romantic` movie-only pending a closer look at whether they were really an undifferentiated group.

They aren't. `dark`'s two genres (`MOOD_FILTERS.dark = [80 crime, 53 thriller]`) split unevenly in TMDb's TV taxonomy: crime (80) is directly shared between movies and TV (no id remapping needed, unlike action's `TV_ACTION_ADVENTURE_GENRE_ID`); thriller (53) has no TV equivalent at all. `tense` (`[53 thriller, 27 horror]`) and `romantic` (`[10749 romance]`) both have **zero** TV-compatible genres — TMDb's TV taxonomy has no standalone Horror, Thriller, or Romance category to map onto, so there's genuinely nothing accurate to fetch for either.

The bug wasn't a missing genre mapping, it was `tvEligible` requiring **every** mood genre to be TV-compatible (`.every(isTvCompatibleGenre)`). That silently excluded `dark` outright even though it already owns one perfectly valid, directly-shared TV genre. Loosened to `.some(isTvCompatibleGenre)` -- dark now qualifies (crime matches), while tense/romantic are correctly still excluded (neither has any compatible genre, so `.some()` is still `false` for both). Action's existing compatible-with-remap check is unaffected either way, and every fully-compatible mood (funny/feelgood/thoughtful) was already `true` under `.every()` and stays `true` under `.some()`.

The `/discover/tv` call already filtered the full merged `genres` list (mood genres plus up to 3 taste-derived extras, not just `moodCfg.genres`) down to the TV-compatible subset before this change, so once eligible, dark's TV query includes crime plus whatever other TV-compatible taste genres a household's profile contributes -- not crime alone. No filter-side change was needed, only the eligibility gate. And because crime needs no id remapping, this fix required no scoring-side changes either (unlike action's `toMovieGenreIds` expansion) -- a TV item tagged `genre_ids: [80]` already reads correctly everywhere `GENRE_NAMES`/`MOOD_FILTERS`/taste-weight scoring expect movie-keyspace ids, since 80 already *is* that id.

---

### ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented parts that are complex or non-obvious
- [x] I have updated relevant documentation
- [x] I have added or updated tests
- [x] No new warnings or errors are introduced
- [x] All tests pass locally

**Verification run:**

- [x] `pnpm --filter @pairflix/api type-check` -- clean
- [x] `pnpm exec vitest run` (services/api, full suite) -- 164/164
- [x] `pnpm --filter @pairflix/api lint` -- 0 errors
- [x] `pnpm -r type-check` -- clean across all 8 workspaces
- [x] `pnpm build` -- all 4 buildable workspaces succeed, including the Worker's `wrangler deploy --dry-run` bundle check

---

### 🔗 Related Issues / PRs

- Follow-up to #83 (action mood's TV mapping, same underlying genre-taxonomy gap).

---

### ⚠️ Notes for Reviewers

- `tense`/`romantic` are unchanged and stay movie-only -- confirmed via the existing "never queries TV for a mood outside the TV-compatible genre set" test (uses `mood: 'romantic'`), which still passes since `.some()` is still `false` for both.
- `docs/roadmap.md`'s two TV-mood bullets are updated to describe dark's new partial coverage instead of lumping it with tense/romantic. A third, unrelated one-line staleness in the same file ("Billing is mock-only (no Stripe)", left over from PR #83's Stripe scaffold landing without this doc line being touched) is also corrected while in the file -- not otherwise related to this change.
- Copilot's review caught an overstated "crime-only" claim in `genres.ts`'s doc comment and the roadmap bullet -- fixed in a follow-up commit (the actual TV query can include other TV-compatible taste-derived genres alongside crime, per `lib/recommendation.ts`'s own comment which already said this correctly).

---

Co-Authored-By: Claude Sonnet 5
Claude-Session: https://claude.ai/code/session_01XaZAU6ca9bxsD6vhj8j392