### PR TITLE
docs: fix db:migrate script references to use @pairflix/api

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -156,8 +156,7 @@ pnpm -r type-check               # tsc --noEmit per workspace
 
 # database (local D1 via Miniflare)
 pnpm --filter @pairflix/db db:generate         # drizzle-kit generate
-pnpm --filter @pairflix/db db:migrate:local    # wrangler d1 migrations apply --local
-pnpm --filter @pairflix/db db:seed:local
+pnpm --filter @pairflix/api db:migrate:local   # wrangler d1 migrations apply --local
 ```
 
 Full setup in `docs/dev-setup.md`.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ This is a monorepo containing multiple applications and shared libraries:
 3. **Set up the local database (D1 via Miniflare)**
 
    ```bash
-   pnpm --filter @pairflix/db db:migrate:local
+   pnpm --filter @pairflix/api db:migrate:local
    ```
 
 4. **Configure environment variables**

--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -20,8 +20,7 @@
 git clone <repository-url> && cd pairflix
 pnpm install                     # installs every workspace
 cp services/api/.dev.vars.example services/api/.dev.vars   # local Worker vars (see below)
-pnpm --filter @pairflix/db db:migrate:local                # create + migrate the local D1
-pnpm --filter @pairflix/db db:seed:local                   # optional dev seed
+pnpm --filter @pairflix/api db:migrate:local                # create + migrate the local D1
 pnpm dev                         # turbo: Worker + both Pages apps in parallel
 ```
 
@@ -64,8 +63,7 @@ pnpm -r type-check               # tsc --noEmit per workspace
 
 ```bash
 pnpm --filter @pairflix/db db:generate         # drizzle-kit generate after editing schema.ts
-pnpm --filter @pairflix/db db:migrate:local    # wrangler d1 migrations apply pairflix-db --local
-pnpm --filter @pairflix/db db:seed:local       # wrangler d1 execute ... --local --file seed.sql
+pnpm --filter @pairflix/api db:migrate:local   # wrangler d1 migrations apply pairflix-db --local
 
 # inspect the local DB
 pnpm exec wrangler d1 execute pairflix-db --local --command "select * from households"
@@ -85,7 +83,7 @@ The local D1 lives under `.wrangler/` and is disposable — delete it and re-mig
 ## Deploy
 
 ```bash
-pnpm --filter @pairflix/db db:migrate:remote   # apply migrations to prod D1 first
+pnpm --filter @pairflix/api db:migrate:remote  # apply migrations to prod D1 first
 pnpm --filter @pairflix/api deploy             # wrangler deploy (Worker)
 pnpm --filter @pairflix/client deploy          # wrangler pages deploy
 pnpm --filter @pairflix/admin deploy           # wrangler pages deploy

--- a/services/api/README.md
+++ b/services/api/README.md
@@ -45,7 +45,7 @@ services/api/
 
 ```bash
 cp .dev.vars.example .dev.vars     # local Worker secrets (see the file for what each does)
-pnpm --filter @pairflix/db db:migrate:local
+pnpm --filter @pairflix/api db:migrate:local
 pnpm dev                            # wrangler dev, http://localhost:8787
 ```
 


### PR DESCRIPTION
The db:migrate:local/remote scripts live in services/api/package.json, not packages/db, so `pnpm --filter @pairflix/db db:migrate:local` fails with ERR_PNPM_RECURSIVE_RUN_NO_SCRIPT. Also drops db:seed:local references — no such script exists anywhere in the repo.
