### PR TITLE
fix: seed dev fixture users so DevLogin works locally

### DIFF
--- a/services/api/package.json
+++ b/services/api/package.json
@@ -16,7 +16,8 @@
 		"format": "prettier --write \"src/**/*.{ts,tsx,js,jsx,json,md,mdx}\"",
 		"format:check": "prettier --check \"src/**/*.{ts,tsx,js,jsx,json,md,mdx}\"",
 		"db:migrate:local": "wrangler d1 migrations apply pairflix-db --local",
-		"db:migrate:remote": "wrangler d1 migrations apply pairflix-db --remote"
+		"db:migrate:remote": "wrangler d1 migrations apply pairflix-db --remote",
+		"db:seed:local": "node scripts/seed-dev-users.mjs"
 	},
 	"dependencies": {
 		"@pairflix/db": "workspace:*",

--- a/services/api/scripts/seed-dev-users.mjs
+++ b/services/api/scripts/seed-dev-users.mjs
@@ -1,0 +1,186 @@
+#!/usr/bin/env node
+// Seeds the fixture users apps/client/src/components/dev/DevLogin.tsx expects into local D1.
+// The Cloudflare re-platform (ADR 0001) deleted the old Express app's backend/src/db/seeders.ts
+// but never ported it, so DevLogin has been referencing users that don't exist since the cutover.
+// --local only -- never touches a real D1 database.
+
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const PASSWORD = 'password123';
+const ITERATIONS = 100_000; // must match services/api/src/lib/crypto.ts
+
+const encoder = new TextEncoder();
+const toBase64 = bytes => btoa(String.fromCharCode(...new Uint8Array(bytes)));
+
+const hashPassword = async password => {
+	const salt = crypto.getRandomValues(new Uint8Array(16));
+	const key = await crypto.subtle.importKey(
+		'raw',
+		encoder.encode(password),
+		'PBKDF2',
+		false,
+		['deriveBits']
+	);
+	const bits = await crypto.subtle.deriveBits(
+		{ name: 'PBKDF2', salt, iterations: ITERATIONS, hash: 'SHA-256' },
+		key,
+		256
+	);
+	return `pbkdf2$${ITERATIONS}$${toBase64(salt.buffer)}$${toBase64(bits)}`;
+};
+
+const newId = () => `user_${crypto.randomUUID().replace(/-/g, '')}`;
+
+const sqlString = value => `'${value.replace(/'/g, "''")}'`;
+
+// Mirrors apps/client/src/components/dev/DevLogin.tsx's testUsers list.
+const users = [
+	{
+		email: 'useractive@example.com',
+		username: 'useractive',
+		status: 'active',
+		role: 'user',
+		emailVerified: true,
+	},
+	{
+		email: 'userbanned@example.com',
+		username: 'userbanned',
+		status: 'banned',
+		role: 'user',
+		emailVerified: true,
+	},
+	{
+		email: 'usersuspended@example.com',
+		username: 'usersuspended',
+		status: 'suspended',
+		role: 'user',
+		emailVerified: true,
+	},
+	{
+		email: 'admin@example.com',
+		username: 'admin',
+		status: 'active',
+		role: 'admin',
+		emailVerified: true,
+	},
+	{
+		email: 'user1@example.com',
+		username: 'user1',
+		status: 'active',
+		role: 'user',
+		emailVerified: true,
+	},
+	{
+		email: 'user2@example.com',
+		username: 'user2',
+		status: 'active',
+		role: 'user',
+		emailVerified: true,
+	},
+	{
+		email: 'user3@example.com',
+		username: 'user3',
+		status: 'active',
+		role: 'user',
+		emailVerified: false,
+	},
+	{
+		email: 'user4@example.com',
+		username: 'user4',
+		status: 'suspended',
+		role: 'user',
+		emailVerified: true,
+	},
+	{
+		email: 'user5@example.com',
+		username: 'user5',
+		status: 'active',
+		role: 'user',
+		emailVerified: true,
+	},
+	{
+		email: 'user6@example.com',
+		username: 'user6',
+		status: 'active',
+		role: 'user',
+		emailVerified: true,
+	},
+	{
+		email: 'user7@example.com',
+		username: 'user7',
+		status: 'banned',
+		role: 'user',
+		emailVerified: true,
+	},
+	{
+		email: 'user8@example.com',
+		username: 'user8',
+		status: 'active',
+		role: 'user',
+		emailVerified: false,
+	},
+	{
+		email: 'user9@example.com',
+		username: 'user9',
+		status: 'active',
+		role: 'user',
+		emailVerified: true,
+	},
+	{
+		email: 'user10@example.com',
+		username: 'user10',
+		status: 'suspended',
+		role: 'user',
+		emailVerified: true,
+	},
+];
+
+const defaultPreferences = JSON.stringify({
+	theme: 'dark',
+	viewStyle: 'grid',
+	emailNotifications: true,
+	autoArchiveDays: 30,
+	favoriteGenres: [],
+});
+
+const run = async () => {
+	const passwordHash = await hashPassword(PASSWORD);
+	const now = Date.now();
+
+	const statements = users.map(user => {
+		const id = newId();
+		return `INSERT OR IGNORE INTO users (user_id, username, email, password_hash, role, status, email_verified, preferences, created_at, updated_at) VALUES (${sqlString(id)}, ${sqlString(user.username)}, ${sqlString(user.email)}, ${sqlString(passwordHash)}, ${sqlString(user.role)}, ${sqlString(user.status)}, ${user.emailVerified ? 1 : 0}, ${sqlString(defaultPreferences)}, ${now}, ${now});`;
+	});
+
+	const dir = mkdtempSync(join(tmpdir(), 'pairflix-seed-'));
+	const sqlFile = join(dir, 'seed-dev-users.sql');
+	writeFileSync(sqlFile, statements.join('\n'));
+
+	try {
+		execFileSync(
+			'pnpm',
+			[
+				'exec',
+				'wrangler',
+				'd1',
+				'execute',
+				'pairflix-db',
+				'--local',
+				`--file=${sqlFile}`,
+			],
+			{
+				stdio: 'inherit',
+				shell: true,
+			}
+		);
+	} finally {
+		rmSync(dir, { recursive: true, force: true });
+	}
+
+	console.log(`\nSeeded ${users.length} dev users (password: ${PASSWORD}).`);
+};
+
+run();


### PR DESCRIPTION
DevLogin.tsx expects a fixed set of test users (active/banned/suspended/ unverified/admin, password123) but the seed script that used to create them was Express-only and got deleted during the Cloudflare re-platform, never ported to D1/Drizzle. Adds db:seed:local, hashing passwords with the same PBKDF2 scheme the login route verifies against.

### 🚀 What’s New

- ✨ Feature: Briefly describe new functionality or enhancement
- 🐛 Fix: Briefly describe bug fix or issue resolution
- 🛠️ Refactor: Briefly describe code improvements or restructuring
- 📦 Dependency: Note any new or updated packages
- 🧪 Test: Highlight new or updated tests

---

### 📝 Description

<!--
Provide a summary of the changes, reasoning behind them, and any context needed.
Include background info or design decisions if relevant.
-->

Fixes: #<issue-number> <!-- Optional: Link to related issue -->

---

### ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented parts that are complex or non-obvious
- [x] I have updated relevant documentation
- [x] I have added or updated tests
- [x] No new warnings or errors are introduced
- [x] All tests pass locally

---

### 📸 Screenshots (if applicable)

<!-- Include before/after UI, logs, or other visuals -->

---

### 🔗 Related Issues / PRs

<!-- List any related issues, pull requests, or references -->

---

### ⚠️ Notes for Reviewers

<!-- Highlight anything that needs extra attention, manual testing steps, or edge cases -->
