### PR TITLE
Add public landing page with a one-time anonymous demo pick

### DIFF
--- a/apps/client/src/components/layout/Routes.tsx
+++ b/apps/client/src/components/layout/Routes.tsx
@@ -17,6 +17,7 @@ import HistoryPage from '../../features/history/HistoryPage';
 import AcceptInvitePage from '../../features/households/AcceptInvitePage';
 import CreateHouseholdPage from '../../features/households/CreateHouseholdPage';
 import InviteToHouseholdPage from '../../features/households/InviteToHouseholdPage';
+import LandingPage from '../../features/landing/LandingPage';
 import TasteOnboardingPage from '../../features/onboarding/TasteOnboardingPage';
 import TonightPicker from '../../features/tonight/TonightPicker';
 import { useAuth } from '../../hooks/useAuth';
@@ -31,6 +32,11 @@ const ProtectedRoute: React.FC<{ element: React.ReactElement }> = ({
   }
 
   return isAuthenticated ? element : <Navigate to="/login" />;
+};
+
+const LandingRoute: React.FC = () => {
+  const { isAuthenticated } = useAuth();
+  return isAuthenticated ? <Navigate to="/tonight" /> : <LandingPage />;
 };
 
 const LogoutRoute: React.FC = () => {
@@ -51,7 +57,6 @@ const LogoutRoute: React.FC = () => {
 
 const AppRoutes: React.FC = () => {
   const { user, isAuthenticated, logout } = useAuth();
-  const defaultPath = '/tonight';
 
   const handleLogout = () => {
     logout();
@@ -71,6 +76,9 @@ const AppRoutes: React.FC = () => {
 
   return (
     <Routes>
+      {/* Public landing page -- redirects to /tonight for an authenticated visitor */}
+      <Route path="/" element={<LandingRoute />} />
+
       {/* Login and register pages without layout */}
       <Route path="/login" element={<LoginPage />} />
       <Route path="/register" element={<RegisterPage />} />
@@ -124,8 +132,9 @@ const AppRoutes: React.FC = () => {
                 />
               )}
 
-              {/* Default route */}
-              <Route path="/" element={<Navigate to={defaultPath} />} />
+              {/* Unknown paths bounce up to the outer "/" route, which resolves to /tonight for an
+                  authenticated visitor -- this inner subtree never sees an exact "/" itself, since
+                  the outer route above always wins that match first. */}
               <Route path="*" element={<Navigate to="/" />} />
             </Routes>
           </AppLayout>

--- a/apps/client/src/config/moods.ts
+++ b/apps/client/src/config/moods.ts
@@ -1,0 +1,11 @@
+import type { Mood } from '../services/api/households';
+
+export const MOODS: { id: Mood; label: string }[] = [
+  { id: 'funny', label: 'Funny' },
+  { id: 'feelgood', label: 'Feel-good' },
+  { id: 'romantic', label: 'Romantic' },
+  { id: 'thoughtful', label: 'Thoughtful' },
+  { id: 'tense', label: 'Tense' },
+  { id: 'dark', label: 'Dark' },
+  { id: 'action', label: 'Action' },
+];

--- a/apps/client/src/features/landing/LandingPage.css.ts
+++ b/apps/client/src/features/landing/LandingPage.css.ts
@@ -1,0 +1,163 @@
+import { style } from '@vanilla-extract/css';
+import { recipe } from '@vanilla-extract/recipes';
+import { vars } from '@pairflix/components';
+
+// A soft glow behind the hero, tinted from the theme's own primary color via color-mix so it
+// tracks light/dark automatically -- rgba() can't blend a CSS custom property, color-mix can.
+export const page = style({
+  background: `radial-gradient(1100px 480px at 50% -10%, color-mix(in srgb, ${vars.colors.primary} 18%, transparent), transparent 70%)`,
+});
+
+export const hero = style({
+  textAlign: 'center',
+  maxWidth: '640px',
+  margin: '0 auto',
+  paddingTop: vars.spacing.xl,
+});
+
+export const eyebrow = style({
+  marginBottom: vars.spacing.lg,
+});
+
+export const heroTitle = style({
+  fontSize: 'clamp(2.25rem, 5vw, 3.5rem)',
+  fontWeight: vars.typography.fontWeight.bold,
+  lineHeight: 1.1,
+  letterSpacing: '-0.03em',
+  margin: 0,
+});
+
+export const heroSubtitle = style({
+  marginTop: vars.spacing.md,
+  color: vars.colors.text.secondary,
+  fontSize: vars.typography.fontSize.lg,
+});
+
+export const layout = style({
+  marginTop: vars.spacing.xl,
+});
+
+export const valueProps = style({
+  listStyle: 'none',
+  margin: 0,
+  padding: 0,
+  display: 'flex',
+  flexDirection: 'column',
+  gap: vars.spacing.md,
+});
+
+export const valueProp = style({
+  display: 'flex',
+  alignItems: 'flex-start',
+  gap: vars.spacing.sm,
+  fontSize: vars.typography.fontSize.md,
+});
+
+export const valuePropDot = style({
+  flexShrink: 0,
+  marginTop: '7px',
+  width: '8px',
+  height: '8px',
+  borderRadius: '50%',
+  background: vars.colors.primary,
+});
+
+export const reassurance = style({
+  marginTop: vars.spacing.lg,
+  color: vars.colors.text.secondary,
+});
+
+export const demoColumn = style({
+  minWidth: 0,
+});
+
+export const formSection = style({
+  marginBottom: vars.spacing.lg,
+});
+
+export const label = style({
+  marginBottom: vars.spacing.sm,
+  fontWeight: vars.typography.fontWeight.bold,
+});
+
+export const chip = recipe({
+  base: {
+    padding: `${vars.spacing.sm} ${vars.spacing.md}`,
+    borderRadius: '999px',
+    cursor: 'pointer',
+    fontSize: vars.typography.fontSize.sm,
+    fontWeight: vars.typography.fontWeight.medium,
+    transition: 'background 0.15s ease, border-color 0.15s ease',
+  },
+  variants: {
+    selected: {
+      true: {
+        border: `1px solid ${vars.colors.primary}`,
+        background: vars.colors.primary,
+        color: '#ffffff',
+        boxShadow: vars.shadows.sm,
+        selectors: {
+          '&:hover': { background: vars.colors.primary },
+        },
+      },
+      false: {
+        border: `1px solid ${vars.colors.border}`,
+        background: 'transparent',
+        color: vars.colors.text.primary,
+        selectors: {
+          '&:hover': {
+            background: vars.colors.background.secondary,
+            borderColor: vars.colors.primary,
+          },
+        },
+      },
+    },
+  },
+  defaultVariants: {
+    selected: false,
+  },
+});
+
+export const sliderRow = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: vars.spacing.md,
+  margin: `${vars.spacing.md} 0`,
+});
+
+export const slider = style({
+  flex: 1,
+  accentColor: vars.colors.primary,
+});
+
+export const pickButton = style({
+  marginTop: vars.spacing.sm,
+  fontSize: vars.typography.fontSize.lg,
+  boxShadow: vars.shadows.md,
+  transition: 'transform 0.15s ease',
+  selectors: {
+    '&:hover:not(:disabled)': { transform: 'translateY(-1px)' },
+  },
+});
+
+export const microcopy = style({
+  marginTop: vars.spacing.sm,
+  textAlign: 'center',
+});
+
+export const errorMessage = style({
+  marginTop: vars.spacing.md,
+});
+
+export const usedTodayCard = style({
+  textAlign: 'center',
+});
+
+export const signupCta = style({
+  marginTop: vars.spacing.lg,
+});
+
+export const loginLink = style({
+  textAlign: 'center',
+  marginTop: vars.spacing.xl,
+});

--- a/apps/client/src/features/landing/LandingPage.tsx
+++ b/apps/client/src/features/landing/LandingPage.tsx
@@ -1,0 +1,198 @@
+import {
+  Badge,
+  Button,
+  Card,
+  CardContent,
+  Container,
+  Flex,
+  Grid,
+  PageContainer,
+  Typography,
+} from '@pairflix/components';
+import React, { useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { MOODS } from '../../config/moods';
+import type { Mood } from '../../services/api/households';
+import RecommendationResultCard from '../tonight/RecommendationResultCard';
+import * as styles from './LandingPage.css';
+import { useDemoPick } from './useDemoPick';
+import { useDemoPickGate } from './useDemoPickGate';
+
+const SignupCta: React.FC = () => {
+  const navigate = useNavigate();
+  return (
+    <div className={styles.signupCta}>
+      <Button
+        variant="primary"
+        size="large"
+        onClick={() => navigate('/register')}
+        isFullWidth
+      >
+        Create a free account
+      </Button>
+    </div>
+  );
+};
+
+const LandingPage: React.FC = () => {
+  const [mood, setMood] = useState<Mood>('feelgood');
+  const [minutes, setMinutes] = useState<number>(90);
+  const pickMutation = useDemoPick();
+  const { hasUsedToday, markUsed } = useDemoPickGate();
+
+  const result = pickMutation.data;
+
+  const onSubmit = () => {
+    pickMutation.mutate({ mood, minutes }, { onSuccess: () => markUsed() });
+  };
+
+  return (
+    <div className={styles.page}>
+      <PageContainer maxWidth="lg" padding="lg" centered>
+        <Container fluid>
+          <div className={styles.hero}>
+            <Badge variant="primary" pill className={styles.eyebrow}>
+              Free to try &middot; No account needed
+            </Badge>
+            <h1 className={styles.heroTitle}>What should we watch tonight?</h1>
+            <Typography variant="body1" className={styles.heroSubtitle}>
+              Tell us your mood and how much time you&apos;ve got. We&apos;ll
+              find the one thing worth watching tonight.
+            </Typography>
+          </div>
+
+          <Grid
+            columns={2}
+            mobileColumns={1}
+            gap="xl"
+            alignItems="center"
+            className={styles.layout}
+          >
+            <div>
+              <ul className={styles.valueProps}>
+                <li className={styles.valueProp}>
+                  <span className={styles.valuePropDot} />
+                  <Typography variant="body1">
+                    One pick in thirty seconds -- no more scrolling every app
+                  </Typography>
+                </li>
+                <li className={styles.valueProp}>
+                  <span className={styles.valuePropDot} />
+                  <Typography variant="body1">
+                    See exactly where to watch it -- Netflix, Prime, Disney+
+                  </Typography>
+                </li>
+                <li className={styles.valueProp}>
+                  <span className={styles.valuePropDot} />
+                  <Typography variant="body1">
+                    Made for two -- built around what you both like
+                  </Typography>
+                </li>
+              </ul>
+              <Typography variant="body2" className={styles.reassurance}>
+                Free to try right now. Create a free account any time to get a
+                pick every night.
+              </Typography>
+            </div>
+
+            <div className={styles.demoColumn}>
+              {!result && !hasUsedToday && (
+                <Card variant="primary" elevation="high">
+                  <CardContent>
+                    <div className={styles.formSection}>
+                      <Typography variant="body2" className={styles.label}>
+                        Mood
+                      </Typography>
+                      <Flex wrap="wrap" gap="sm">
+                        {MOODS.map(m => (
+                          <button
+                            key={m.id}
+                            className={styles.chip({
+                              selected: mood === m.id,
+                            })}
+                            onClick={() => setMood(m.id)}
+                            type="button"
+                          >
+                            {m.label}
+                          </button>
+                        ))}
+                      </Flex>
+                    </div>
+
+                    <div className={styles.formSection}>
+                      <Typography variant="body2" className={styles.label}>
+                        Time available: {minutes} minutes
+                      </Typography>
+                      <div className={styles.sliderRow}>
+                        <Typography variant="caption">30</Typography>
+                        <input
+                          className={styles.slider}
+                          type="range"
+                          min={30}
+                          max={180}
+                          step={5}
+                          value={minutes}
+                          onChange={e =>
+                            setMinutes(parseInt(e.target.value, 10))
+                          }
+                        />
+                        <Typography variant="caption">180</Typography>
+                      </div>
+                    </div>
+
+                    <Button
+                      className={styles.pickButton}
+                      variant="primary"
+                      size="large"
+                      onClick={onSubmit}
+                      disabled={pickMutation.isPending}
+                      isLoading={pickMutation.isPending}
+                      isFullWidth
+                    >
+                      Show me a pick
+                    </Button>
+                    <Typography variant="caption" className={styles.microcopy}>
+                      One free pick -- no account, no card.
+                    </Typography>
+                  </CardContent>
+                </Card>
+              )}
+
+              {!result && hasUsedToday && (
+                <Card variant="primary" elevation="high">
+                  <CardContent className={styles.usedTodayCard}>
+                    <Typography variant="body1">
+                      You&apos;ve used today&apos;s free pick. Create a free
+                      account to get a pick every night.
+                    </Typography>
+                    <SignupCta />
+                  </CardContent>
+                </Card>
+              )}
+
+              {pickMutation.error && (
+                <Typography variant="body2" className={styles.errorMessage}>
+                  {pickMutation.error.message}
+                </Typography>
+              )}
+
+              {result && (
+                <RecommendationResultCard
+                  card={result.pick}
+                  rationale={result.rationale}
+                  actions={<SignupCta />}
+                />
+              )}
+            </div>
+          </Grid>
+
+          <div className={styles.loginLink}>
+            Already have an account? <Link to="/login">Log in</Link>
+          </div>
+        </Container>
+      </PageContainer>
+    </div>
+  );
+};
+
+export default LandingPage;

--- a/apps/client/src/features/landing/__tests__/LandingPage.test.tsx
+++ b/apps/client/src/features/landing/__tests__/LandingPage.test.tsx
@@ -1,0 +1,60 @@
+import userEvent from '@testing-library/user-event';
+import { demo } from '../../../services/api/demo';
+import { render, screen, waitFor } from '../../../tests/setup';
+import LandingPage from '../LandingPage';
+
+jest.mock('../../../services/api/demo', () => ({
+  demo: { pick: jest.fn() },
+}));
+
+const RESULT = {
+  pick: {
+    tmdbId: 123,
+    mediaType: 'movie' as const,
+    title: 'Test Movie',
+    year: 2020,
+    runtime: 100,
+    overview: 'A test movie.',
+    posterPath: null,
+    providers: {},
+  },
+  alternates: [],
+  rationale: 'Matches your feelgood mood.',
+  score: 0.8,
+};
+
+describe('LandingPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    localStorage.clear();
+  });
+
+  it('lets an anonymous visitor get one pick, with a signup CTA and no household actions', async () => {
+    (demo.pick as jest.Mock).mockResolvedValue(RESULT);
+    const user = userEvent.setup();
+    render(<LandingPage />);
+
+    await user.click(screen.getByRole('button', { name: 'Show me a pick' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Test Movie')).toBeInTheDocument();
+    });
+    expect(demo.pick).toHaveBeenCalledWith({ mood: 'feelgood', minutes: 90 });
+    expect(
+      screen.getByRole('button', { name: 'Create a free account' })
+    ).toBeInTheDocument();
+    expect(screen.queryByText('Watching it')).not.toBeInTheDocument();
+    expect(screen.queryByText('Swap')).not.toBeInTheDocument();
+    expect(screen.queryByText('Not tonight')).not.toBeInTheDocument();
+  });
+
+  it('shows a used-today state instead of the form when already used recently', () => {
+    localStorage.setItem('pairflix.demoPickUsedAt', String(Date.now()));
+    render(<LandingPage />);
+
+    expect(screen.getByText(/used today's free pick/i)).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Show me a pick' })
+    ).not.toBeInTheDocument();
+  });
+});

--- a/apps/client/src/features/landing/useDemoPick.ts
+++ b/apps/client/src/features/landing/useDemoPick.ts
@@ -1,0 +1,12 @@
+import { useMutation } from '@tanstack/react-query';
+import { demo } from '../../services/api/demo';
+import type {
+  PickRequest,
+  RecommendationResult,
+} from '../../services/api/households';
+
+export function useDemoPick() {
+  return useMutation<RecommendationResult, Error, PickRequest>({
+    mutationFn: body => demo.pick(body),
+  });
+}

--- a/apps/client/src/features/landing/useDemoPickGate.ts
+++ b/apps/client/src/features/landing/useDemoPickGate.ts
@@ -1,0 +1,25 @@
+import { useState } from 'react';
+
+const STORAGE_KEY = 'pairflix.demoPickUsedAt';
+const COOLDOWN_MS = 24 * 60 * 60 * 1000;
+
+/** Tracks the landing page's one-time demo pick client-side, in a rolling 24h window matching the
+ * API's own per-IP `ipRateLimit` backstop -- a visitor who bounces today can come back tomorrow
+ * rather than being permanently locked out on this device. This is a UX nicety, not an auth
+ * token: the server-side rate limit is the actual backstop against abuse. */
+export function useDemoPickGate() {
+  const [usedAt, setUsedAt] = useState<number | null>(() => {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    return stored ? Number(stored) : null;
+  });
+
+  const hasUsedToday = usedAt !== null && Date.now() - usedAt < COOLDOWN_MS;
+
+  const markUsed = () => {
+    const now = Date.now();
+    localStorage.setItem(STORAGE_KEY, String(now));
+    setUsedAt(now);
+  };
+
+  return { hasUsedToday, markUsed };
+}

--- a/apps/client/src/features/tonight/RecommendationResultCard.css.ts
+++ b/apps/client/src/features/tonight/RecommendationResultCard.css.ts
@@ -1,0 +1,38 @@
+import { style } from '@vanilla-extract/css';
+import { vars } from '@pairflix/components';
+
+export const resultCard = style({
+  marginTop: vars.spacing.xl,
+});
+
+export const poster = style({
+  width: '200px',
+  aspectRatio: '2/3',
+  objectFit: 'cover',
+  borderRadius: vars.borderRadius.sm,
+  flexShrink: 0,
+});
+
+export const rationale = style({
+  fontStyle: 'italic',
+  color: vars.colors.text.secondary,
+});
+
+export const providerLaunchButton = style({
+  padding: `${vars.spacing.xs} ${vars.spacing.sm}`,
+  borderRadius: '999px',
+  border: `1px solid ${vars.colors.primary}`,
+  background: vars.colors.primary,
+  color: '#ffffff',
+  cursor: 'pointer',
+  fontSize: vars.typography.fontSize.sm,
+  fontWeight: vars.typography.fontWeight.medium,
+  transition: 'opacity 0.15s ease',
+  selectors: {
+    '&:hover': { opacity: 0.85 },
+  },
+});
+
+export const badgeRow = style({
+  flexWrap: 'wrap',
+});

--- a/apps/client/src/features/tonight/RecommendationResultCard.tsx
+++ b/apps/client/src/features/tonight/RecommendationResultCard.tsx
@@ -1,0 +1,86 @@
+import {
+  Badge,
+  Card,
+  CardContent,
+  ErrorText,
+  Flex,
+  H2,
+  Typography,
+} from '@pairflix/components';
+import React from 'react';
+import type { RecommendationCard } from '../../services/api/households';
+import * as styles from './RecommendationResultCard.css';
+
+type RecommendationResultCardProps = {
+  card: RecommendationCard;
+  rationale: string;
+  /** The bottom action slot -- each caller owns its own buttons (and any error text for them)
+   * since which actions are available depends on whether the caller has an authenticated
+   * household to act against. */
+  actions: React.ReactNode;
+  /** Omit to render provider badges as plain (non-interactive) badges instead of "Watch on X"
+   * launch buttons -- the launch endpoint is household-scoped and unavailable to a caller with
+   * no household, e.g. the anonymous landing-page demo. */
+  onLaunchProvider?: (providerName: string) => void;
+  launchError?: string | undefined;
+};
+
+const RecommendationResultCard: React.FC<RecommendationResultCardProps> = ({
+  card,
+  rationale,
+  actions,
+  onLaunchProvider,
+  launchError,
+}) => {
+  const providerBadges = card.providers.flatrate ?? [];
+
+  return (
+    <Card variant="primary" className={styles.resultCard}>
+      <CardContent>
+        <Flex gap="lg" alignItems="flex-start">
+          {card.posterPath && (
+            <img
+              className={styles.poster}
+              src={`https://image.tmdb.org/t/p/w500${card.posterPath}`}
+              alt={card.title}
+            />
+          )}
+          <div>
+            <H2>{card.title}</H2>
+            <Flex gap="sm" className={styles.badgeRow}>
+              {card.year && <Badge variant="secondary">{card.year}</Badge>}
+              {card.runtime && (
+                <Badge variant="secondary">{card.runtime} min</Badge>
+              )}
+              {providerBadges.map(p =>
+                onLaunchProvider ? (
+                  <button
+                    className={styles.providerLaunchButton}
+                    key={p.provider_id}
+                    type="button"
+                    onClick={() => onLaunchProvider(p.provider_name)}
+                  >
+                    Watch on {p.provider_name}
+                  </button>
+                ) : (
+                  <Badge variant="secondary" key={p.provider_id}>
+                    {p.provider_name}
+                  </Badge>
+                )
+              )}
+            </Flex>
+            {launchError && <ErrorText>{launchError}</ErrorText>}
+            <Typography variant="body2" className={styles.rationale}>
+              {rationale}
+            </Typography>
+            <Typography variant="body2">{card.overview}</Typography>
+
+            {actions}
+          </div>
+        </Flex>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default RecommendationResultCard;

--- a/apps/client/src/features/tonight/TonightPicker.css.ts
+++ b/apps/client/src/features/tonight/TonightPicker.css.ts
@@ -55,38 +55,6 @@ export const pickButton = style({
   padding: `${vars.spacing.md} ${vars.spacing.xl}`,
 });
 
-export const resultCard = style({
-  marginTop: vars.spacing.xl,
-});
-
-export const poster = style({
-  width: '200px',
-  aspectRatio: '2/3',
-  objectFit: 'cover',
-  borderRadius: vars.borderRadius.sm,
-  flexShrink: 0,
-});
-
-export const rationale = style({
-  fontStyle: 'italic',
-  color: vars.colors.text.secondary,
-});
-
-export const providerLaunchButton = style({
-  padding: `${vars.spacing.xs} ${vars.spacing.sm}`,
-  borderRadius: '999px',
-  border: `1px solid ${vars.colors.primary}`,
-  background: vars.colors.primary,
-  color: '#ffffff',
-  cursor: 'pointer',
-  fontSize: vars.typography.fontSize.sm,
-  fontWeight: vars.typography.fontWeight.medium,
-  transition: 'opacity 0.15s ease',
-  selectors: {
-    '&:hover': { opacity: 0.85 },
-  },
-});
-
 export const actionRow = style({
   marginTop: vars.spacing.lg,
 });
@@ -102,8 +70,4 @@ export const label = style({
 
 export const errorMessage = style({
   marginTop: vars.spacing.md,
-});
-
-export const badgeRow = style({
-  flexWrap: 'wrap',
 });

--- a/apps/client/src/features/tonight/TonightPicker.tsx
+++ b/apps/client/src/features/tonight/TonightPicker.tsx
@@ -1,38 +1,26 @@
 import {
-  Badge,
   Button,
-  Card,
-  CardContent,
   Container,
   Flex,
   H1,
-  H2,
   PageContainer,
   Typography,
 } from '@pairflix/components';
 import { useMutation } from '@tanstack/react-query';
-import React, { useMemo, useState } from 'react';
+import React, { useState } from 'react';
 import UpgradeBanner from '../billing/UpgradeBanner';
+import { MOODS } from '../../config/moods';
 import { useEntitlements } from '../../hooks/useEntitlements';
 import {
   households,
   type Mood,
   type RecommendationCard,
 } from '../../services/api/households';
+import RecommendationResultCard from './RecommendationResultCard';
 import * as styles from './TonightPicker.css';
 import { useActiveHousehold } from './useActiveHousehold';
 import { useTonightHomepagePreference } from './useTonightHomepage';
 import { useCommitPick, useTonightPick } from './useTonightPick';
-
-const MOODS: { id: Mood; label: string }[] = [
-  { id: 'funny', label: 'Funny' },
-  { id: 'feelgood', label: 'Feel-good' },
-  { id: 'romantic', label: 'Romantic' },
-  { id: 'thoughtful', label: 'Thoughtful' },
-  { id: 'tense', label: 'Tense' },
-  { id: 'dark', label: 'Dark' },
-  { id: 'action', label: 'Action' },
-];
 
 const PROVIDER_OPTIONS: { id: string; label: string }[] = [
   { id: 'netflix', label: 'Netflix' },
@@ -153,11 +141,6 @@ const TonightPicker: React.FC = () => {
     );
   };
 
-  const providerBadges = useMemo(() => {
-    if (!result) return [];
-    return result.pick.providers.flatrate ?? [];
-  }, [result]);
-
   if (householdLoading) {
     return (
       <PageContainer maxWidth="lg" padding="lg" centered>
@@ -275,83 +258,42 @@ const TonightPicker: React.FC = () => {
         )}
 
         {result && !dismissed && (
-          <Card variant="primary" className={styles.resultCard}>
-            <CardContent>
-              <Flex gap="lg" alignItems="flex-start">
-                {result.pick.posterPath && (
-                  <img
-                    className={styles.poster}
-                    src={`https://image.tmdb.org/t/p/w500${result.pick.posterPath}`}
-                    alt={result.pick.title}
-                  />
+          <RecommendationResultCard
+            card={result.pick}
+            rationale={result.rationale}
+            onLaunchProvider={providerName =>
+              onLaunchProvider(result.pick, providerName)
+            }
+            launchError={launchMutation.error?.message}
+            actions={
+              <>
+                <Flex gap="md" wrap="wrap" className={styles.actionRow}>
+                  <Button
+                    variant="success"
+                    onClick={() => onCommit(result.pick)}
+                    disabled={commitMutation.isPending}
+                  >
+                    Watching it
+                  </Button>
+                  <Button
+                    variant="secondary"
+                    onClick={() => onSwap(result.pick)}
+                    disabled={isPending}
+                  >
+                    Swap
+                  </Button>
+                  <Button variant="text" onClick={() => onDismiss(result.pick)}>
+                    Not tonight
+                  </Button>
+                </Flex>
+                {commitMutation.error && (
+                  <Typography variant="body2" className={styles.errorMessage}>
+                    {commitMutation.error.message}
+                  </Typography>
                 )}
-                <div>
-                  <H2>{result.pick.title}</H2>
-                  <Flex gap="sm" className={styles.badgeRow}>
-                    {result.pick.year && (
-                      <Badge variant="secondary">{result.pick.year}</Badge>
-                    )}
-                    {result.pick.runtime && (
-                      <Badge variant="secondary">
-                        {result.pick.runtime} min
-                      </Badge>
-                    )}
-                    {providerBadges.map(p => (
-                      <button
-                        className={styles.providerLaunchButton}
-                        key={p.provider_id}
-                        type="button"
-                        onClick={() =>
-                          onLaunchProvider(result.pick, p.provider_name)
-                        }
-                      >
-                        Watch on {p.provider_name}
-                      </button>
-                    ))}
-                  </Flex>
-                  {launchMutation.error && (
-                    <Typography variant="body2" className={styles.errorMessage}>
-                      {launchMutation.error.message}
-                    </Typography>
-                  )}
-                  <Typography variant="body2" className={styles.rationale}>
-                    {result.rationale}
-                  </Typography>
-                  <Typography variant="body2">
-                    {result.pick.overview}
-                  </Typography>
-
-                  <Flex gap="md" wrap="wrap" className={styles.actionRow}>
-                    <Button
-                      variant="success"
-                      onClick={() => onCommit(result.pick)}
-                      disabled={commitMutation.isPending}
-                    >
-                      Watching it
-                    </Button>
-                    <Button
-                      variant="secondary"
-                      onClick={() => onSwap(result.pick)}
-                      disabled={isPending}
-                    >
-                      Swap
-                    </Button>
-                    <Button
-                      variant="text"
-                      onClick={() => onDismiss(result.pick)}
-                    >
-                      Not tonight
-                    </Button>
-                  </Flex>
-                  {commitMutation.error && (
-                    <Typography variant="body2" className={styles.errorMessage}>
-                      {commitMutation.error.message}
-                    </Typography>
-                  )}
-                </div>
-              </Flex>
-            </CardContent>
-          </Card>
+              </>
+            }
+          />
         )}
       </Container>
     </PageContainer>

--- a/apps/client/src/services/api/demo.ts
+++ b/apps/client/src/services/api/demo.ts
@@ -1,0 +1,16 @@
+import type { PickRequest, RecommendationResult } from './households';
+import { fetchWithAuth } from './utils';
+
+// A visitor with no account can still be carrying a `csrfToken` or `session` cookie (a prior
+// login, a prior visit to /login/register, a leftover dev session) -- fetch's default
+// credentials mode sends those on any same-origin request regardless of auth state, which trips
+// the API's csrfMiddleware if the header isn't attached. `fetchWithAuth` always seeds a fresh
+// CSRF token before a mutating call for exactly this reason (see csrfMiddleware's doc comment);
+// this endpoint isn't actually exempt from that just because it doesn't require a session.
+export const demo = {
+  pick: (body: PickRequest): Promise<RecommendationResult> =>
+    fetchWithAuth('/api/demo/pick', {
+      method: 'POST',
+      body: JSON.stringify(body),
+    }),
+};

--- a/apps/client/src/services/api/index.ts
+++ b/apps/client/src/services/api/index.ts
@@ -1,5 +1,6 @@
 import { auth } from './auth';
 import { billing } from './billing';
+import { demo } from './demo';
 import { emailService } from './email';
 import { history } from './history';
 import { households } from './households';
@@ -34,6 +35,7 @@ export type {
 export {
   auth,
   billing,
+  demo,
   emailService,
   fetchWithAuth,
   history,
@@ -50,6 +52,7 @@ const api = {
   auth,
   user,
   billing,
+  demo,
   email: emailService,
   history,
   households,

--- a/services/api/src/index.ts
+++ b/services/api/src/index.ts
@@ -8,6 +8,7 @@ import { csrfMiddleware } from './middleware/csrf';
 import { adminRoutes } from './routes/admin';
 import { authRoutes } from './routes/auth';
 import { billingRoutes } from './routes/billing';
+import { demoRoutes } from './routes/demo';
 import { healthRoutes } from './routes/health';
 import { householdsRoutes } from './routes/households';
 import { meRoutes } from './routes/me';
@@ -51,6 +52,7 @@ app.route('/api/me', meRoutes);
 app.route('/api/households', householdsRoutes);
 app.route('/api/admin', adminRoutes);
 app.route('/api/billing', billingRoutes);
+app.route('/api/demo', demoRoutes);
 
 app.notFound(c => c.json({ error: 'Not found' }, 404));
 app.onError((error, c) => {

--- a/services/api/src/lib/recommendation.ts
+++ b/services/api/src/lib/recommendation.ts
@@ -397,50 +397,31 @@ const pickProviderName = (providers: RegionProviders): string | null =>
 	providers.buy?.[0]?.provider_name ??
 	null;
 
-export const pickForHousehold = async (
+type RankedCandidate = {
+	entry: {
+		item: TMDbDiscoverMovie | TMDbDiscoverTV;
+		mediaType: 'movie' | 'tv';
+	};
+	card: RecommendationCard;
+	score: number;
+};
+
+/** The household-independent core of a pick: discover -> filter -> score -> hydrate -> re-score.
+ * Depends only on `env`/`request`/`prefs`/exclusion sets -- never `db` or a household id -- so
+ * both `pickForHousehold` (real merged taste prefs) and `pickForAnonymous` (empty/neutral prefs)
+ * can share it without duplicating the scoring pipeline. `hydrateCount` is the caller's decision
+ * (10 when LLM-rerank-eligible, 3 otherwise) since eligibility itself is a household concern this
+ * helper has no business knowing about. */
+const buildRecommendation = async (
 	env: Bindings,
-	db: Database,
-	householdId: string,
-	request: PickRequest
-): Promise<RecommendationResult> => {
+	request: PickRequest,
+	prefs: MergedPreferences,
+	excludedWatched: Set<string>,
+	hydrateCount: number
+): Promise<{ mlResult: RecommendationResult; ranked: RankedCandidate[] }> => {
 	const region = request.region ?? 'GB';
 	const moodCfg = MOOD_FILTERS[request.mood];
-
-	const members = await db
-		.select({ userId: householdMembers.userId })
-		.from(householdMembers)
-		.where(eq(householdMembers.householdId, householdId));
-	if (members.length === 0) {
-		throw new HouseholdNotFoundError();
-	}
-	const memberIds = members.map(m => m.userId);
-
-	const profiles = await db
-		.select()
-		.from(tasteProfiles)
-		.where(inArray(tasteProfiles.userId, memberIds));
-	const merged = mergeProfiles(profiles);
-	const genres = topMergedGenres(merged, moodCfg.genres, 3);
-	const prefs: MergedPreferences = {
-		genres: merged,
-		era: mergeEra(profiles),
-		tone: mergeTone(profiles),
-		runtimePref: mergeRuntimePref(profiles),
-	};
-
-	const watchedRows = await db
-		.select({
-			tmdbId: watchedTogether.tmdbId,
-			mediaType: watchedTogether.mediaType,
-		})
-		.from(watchedTogether)
-		.where(eq(watchedTogether.householdId, householdId));
-	// Keyed by tmdbId+mediaType, not tmdbId alone -- movie and TV ids are assigned from separate
-	// TMDb id spaces, so a watched movie must not exclude an unrelated TV show (or vice versa)
-	// that happens to share the same numeric id, now that both are candidate sources below.
-	const excludedWatched = new Set<string>(
-		watchedRows.map(w => `${w.tmdbId}:${w.mediaType}`)
-	);
+	const genres = topMergedGenres(prefs.genres, moodCfg.genres, 3);
 	const excludedRequested = new Set<number>(request.excludeTmdbIds ?? []);
 
 	const discoverParams = {
@@ -524,8 +505,7 @@ export const pickForHousehold = async (
 				: b.item.vote_average - a.item.vote_average
 		);
 
-	const llmEligible = await isLlmRerankEnabledForHousehold(db, householdId);
-	const top = scored.slice(0, llmEligible ? 10 : 3);
+	const top = scored.slice(0, hydrateCount);
 
 	const hydrated = await Promise.all(
 		top.map(async entry => ({
@@ -578,13 +558,94 @@ export const pickForHousehold = async (
 		rationale: buildRationale(
 			moodCfg.label,
 			mlPick.entry.item.genre_ids ?? [],
-			merged,
+			prefs.genres,
 			request.minutes,
 			mlPick.card.runtime,
 			pickProviderName(mlPick.card.providers)
 		),
 		score: mlPick.score,
 	};
+
+	return { mlResult, ranked };
+};
+
+/** Runs a pick with no household context at all -- empty/neutral taste prefs (the same
+ * degradation `mergeProfiles`/`mergeEra`/`mergeTone`/`mergeRuntimePref` already apply for a
+ * household with zero ratings yet), no watch-history exclusions, and a fixed hydration depth
+ * matching what a free-tier household gets. Calling the real merge functions with `[]` rather
+ * than hand-writing the neutral shape means this can't drift if their degradation logic changes.
+ * LLM rerank is a premium household feature and is structurally unreachable here -- this never
+ * calls `isLlmRerankEnabledForHousehold` or touches the rerank branch below. The only error this
+ * can throw is `NoCandidatesError`; `HouseholdNotFoundError` only comes from the membership gate
+ * in `pickForHousehold`, which this path never runs. */
+export const pickForAnonymous = async (
+	env: Bindings,
+	request: PickRequest
+): Promise<RecommendationResult> => {
+	const prefs: MergedPreferences = {
+		genres: mergeProfiles([]),
+		era: mergeEra([]),
+		tone: mergeTone([]),
+		runtimePref: mergeRuntimePref([]),
+	};
+	const { mlResult } = await buildRecommendation(
+		env,
+		request,
+		prefs,
+		new Set(),
+		3
+	);
+	return mlResult;
+};
+
+export const pickForHousehold = async (
+	env: Bindings,
+	db: Database,
+	householdId: string,
+	request: PickRequest
+): Promise<RecommendationResult> => {
+	const members = await db
+		.select({ userId: householdMembers.userId })
+		.from(householdMembers)
+		.where(eq(householdMembers.householdId, householdId));
+	if (members.length === 0) {
+		throw new HouseholdNotFoundError();
+	}
+	const memberIds = members.map(m => m.userId);
+
+	const profiles = await db
+		.select()
+		.from(tasteProfiles)
+		.where(inArray(tasteProfiles.userId, memberIds));
+	const prefs: MergedPreferences = {
+		genres: mergeProfiles(profiles),
+		era: mergeEra(profiles),
+		tone: mergeTone(profiles),
+		runtimePref: mergeRuntimePref(profiles),
+	};
+
+	const watchedRows = await db
+		.select({
+			tmdbId: watchedTogether.tmdbId,
+			mediaType: watchedTogether.mediaType,
+		})
+		.from(watchedTogether)
+		.where(eq(watchedTogether.householdId, householdId));
+	// Keyed by tmdbId+mediaType, not tmdbId alone -- movie and TV ids are assigned from separate
+	// TMDb id spaces, so a watched movie must not exclude an unrelated TV show (or vice versa)
+	// that happens to share the same numeric id, now that both are candidate sources below.
+	const excludedWatched = new Set<string>(
+		watchedRows.map(w => `${w.tmdbId}:${w.mediaType}`)
+	);
+
+	const llmEligible = await isLlmRerankEnabledForHousehold(db, householdId);
+	const { mlResult, ranked } = await buildRecommendation(
+		env,
+		request,
+		prefs,
+		excludedWatched,
+		llmEligible ? 10 : 3
+	);
 
 	if (!llmEligible || ranked.length < 2) {
 		return mlResult;
@@ -599,6 +660,7 @@ export const pickForHousehold = async (
 		}),
 	}));
 
+	const currentYear = new Date().getFullYear();
 	const llmCandidates: LlmCandidate[] = ranked.map(p => ({
 		tmdbId: p.card.tmdbId,
 		title: p.card.title,

--- a/services/api/src/routes/demo.e2e.test.ts
+++ b/services/api/src/routes/demo.e2e.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+import {
+	callApp,
+	mockExternalApis,
+	uniqueIp,
+	type MockMovie,
+} from '../test/test-helpers';
+
+const MOVIE_A: MockMovie = {
+	id: 901,
+	title: 'The Comedy Hour',
+	overview: 'A very funny movie.',
+	poster_path: null,
+	release_date: '2020-01-01',
+	vote_average: 7.5,
+	vote_count: 500,
+	genre_ids: [35],
+	popularity: 50,
+	runtime: 100,
+};
+const MOVIE_B: MockMovie = {
+	id: 902,
+	title: 'Laughs Ahead',
+	overview: 'Another funny movie.',
+	poster_path: null,
+	release_date: '2019-01-01',
+	vote_average: 7.0,
+	vote_count: 400,
+	genre_ids: [35],
+	popularity: 40,
+	runtime: 95,
+};
+const DEFAULT_MOVIES = [MOVIE_A, MOVIE_B];
+
+const demoPick = (ip: string, body: unknown) =>
+	callApp<{
+		pick?: { tmdbId: number; mediaType: string };
+		rationale?: string;
+		error?: string;
+	}>('/api/demo/pick', {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify(body),
+		ip,
+	});
+
+describe('POST /api/demo/pick', () => {
+	it('returns a recommendation with no cookies/session at all', async () => {
+		mockExternalApis(DEFAULT_MOVIES);
+		const result = await demoPick(uniqueIp(), { mood: 'funny', minutes: 120 });
+
+		expect(result.status).toBe(200);
+		expect(DEFAULT_MOVIES.map(m => m.id)).toContain(result.body.pick?.tmdbId);
+		expect(result.body.pick?.mediaType).toBe('movie');
+		expect(typeof result.body.rationale).toBe('string');
+		expect(result.body.rationale?.length ?? 0).toBeGreaterThan(0);
+	});
+
+	it('returns 404 when no candidates match', async () => {
+		mockExternalApis([]);
+		const result = await demoPick(uniqueIp(), { mood: 'funny', minutes: 120 });
+
+		expect(result.status).toBe(404);
+		expect(result.body.error).toBe('No candidates found for these inputs');
+	});
+
+	it('rate-limits repeated calls from the same IP', async () => {
+		const ip = uniqueIp();
+		for (let i = 0; i < 3; i++) {
+			mockExternalApis(DEFAULT_MOVIES);
+			const ok = await demoPick(ip, { mood: 'funny', minutes: 120 });
+			expect(ok.status).toBe(200);
+		}
+
+		mockExternalApis(DEFAULT_MOVIES);
+		const limited = await demoPick(ip, { mood: 'funny', minutes: 120 });
+		expect(limited.status).toBe(429);
+		expect(limited.body.error).toBe('Too many requests');
+	});
+});

--- a/services/api/src/routes/demo.ts
+++ b/services/api/src/routes/demo.ts
@@ -1,0 +1,63 @@
+import { PickRequestSchema, type PickRequest } from '@pairflix/lib.validation';
+import { Hono } from 'hono';
+import { NoCandidatesError, pickForAnonymous } from '../lib/recommendation';
+import { ipRateLimit } from '../middleware/ip-rate-limit';
+import type { AppEnv } from '../types';
+
+/**
+ * Public, unauthenticated pick endpoint for the landing page's one-time demo -- deliberately its
+ * own router rather than a route on `householdsRoutes`, since that router applies `requireAuth`
+ * to everything mounted on it (`households.ts` line 74). No such gate is added here.
+ *
+ * "One time" is enforced in two layers: the client hides the form after a successful pick
+ * (`apps/client`'s `useDemoPickGate`), and this route's `demoPickRateLimit` is the abuse
+ * backstop for scripted/repeated calls. `limit: 3` rather than `1` -- a hard per-visitor cap
+ * would also 429 a second household member on the same IP the moment the first one tries it.
+ */
+export const demoRoutes = new Hono<AppEnv>();
+
+const demoPickRateLimit = ipRateLimit({
+	routeName: 'demo-pick',
+	limit: 3,
+	windowMinutes: 1440,
+});
+
+demoRoutes.post('/pick', demoPickRateLimit, async c => {
+	const parsed = PickRequestSchema.safeParse(
+		await c.req.json().catch(() => null)
+	);
+	if (!parsed.success) {
+		return c.json(
+			{
+				error: 'Invalid input',
+				details: parsed.error.issues.map(i => i.message),
+			},
+			400
+		);
+	}
+
+	// Cloudflare's edge geo, not the caller-supplied region -- same reasoning as the free-tier
+	// `enforceRegionLock` (households.ts line 167): deterministic and not client-controllable.
+	// 'T1' is Cloudflare's "Tor exit node" placeholder, not a real country. Falls through to
+	// `undefined` (and from there to buildRecommendation's own 'GB' default) when `cf` is absent,
+	// which only happens outside the real Cloudflare edge (local `wrangler dev`).
+	const geoCountry = c.req.raw.cf?.country;
+	const region: string | undefined =
+		typeof geoCountry === 'string' && geoCountry !== 'T1'
+			? geoCountry
+			: undefined;
+	const request: PickRequest = {
+		...parsed.data,
+		...(region ? { region } : {}),
+	};
+
+	try {
+		const result = await pickForAnonymous(c.env, request);
+		return c.json(result);
+	} catch (error) {
+		if (error instanceof NoCandidatesError) {
+			return c.json({ error: error.message }, 404);
+		}
+		throw error;
+	}
+});

--- a/services/api/src/routes/households.e2e.test.ts
+++ b/services/api/src/routes/households.e2e.test.ts
@@ -1,13 +1,16 @@
 import { env } from 'cloudflare:workers';
 import { createDb, settings, subscriptions } from '@pairflix/db';
-import { afterEach, describe, expect, it } from 'vitest';
-import { GENRE_NAMES } from '../lib/genres';
+import { describe, expect, it } from 'vitest';
 import {
 	callApp,
 	createLoggedInUser,
 	getCsrfToken,
+	mockExternalApis,
 	postJson,
 	type Cookies,
+	type MockAnthropic,
+	type MockMovie,
+	type MockShow,
 } from '../test/test-helpers';
 
 let counter = 0;
@@ -15,27 +18,6 @@ let counter = 0;
  * within one file. */
 const uniqueEmail = () =>
 	`households-e2e-${Date.now()}-${counter++}@example.com`;
-
-type MockMovie = {
-	id: number;
-	title: string;
-	overview: string;
-	poster_path: string | null;
-	release_date: string;
-	vote_average: number;
-	vote_count: number;
-	genre_ids: number[];
-	popularity: number;
-	runtime: number;
-	providers?: {
-		flatrate?: Array<{
-			provider_id: number;
-			provider_name: string;
-			logo_path: string;
-		}>;
-		link?: string;
-	};
-};
 
 const MOVIE_A: MockMovie = {
 	id: 101,
@@ -80,20 +62,6 @@ const MOVIE_C: MockMovie = {
 	runtime: 110,
 };
 const DEFAULT_MOVIES = [MOVIE_A, MOVIE_B, MOVIE_C];
-
-type MockShow = {
-	id: number;
-	name: string;
-	overview: string;
-	poster_path: string | null;
-	first_air_date: string;
-	vote_average: number;
-	vote_count: number;
-	genre_ids: number[];
-	popularity: number;
-	episode_run_time: number[];
-	providers?: MockMovie['providers'];
-};
 
 // A deliberately-mismatched pair for the runtime re-ranking test below: OLD_GOOD_RUNTIME scores
 // lower pre-hydration (older, so a smaller recencyBonus) but has a real runtime close to the
@@ -248,122 +216,6 @@ const COMEDY_MOVIE_SAME_ERA: MockMovie = {
 	genre_ids: [35],
 	popularity: 45,
 	runtime: 105,
-};
-
-const jsonResponse = (data: unknown, status = 200): Response =>
-	new Response(JSON.stringify(data), {
-		status,
-		headers: { 'content-type': 'application/json' },
-	});
-
-type MockAnthropic =
-	| { pickTmdbId: number; alternatesTmdbIds: number[]; rationale: string }
-	| 'error';
-
-const REAL_FETCH = globalThis.fetch;
-afterEach(() => {
-	globalThis.fetch = REAL_FETCH;
-});
-
-/** Replaces the global fetch for the rest of the current test so pick/commit flows never hit the
- * real TMDb/Anthropic APIs -- unreachable from the test sandbox, and non-deterministic even if
- * reachable. Returns the list of URLs actually requested, so tests can assert on outgoing call
- * shape (e.g. proving the region-lock override reached TMDb). */
-const mockExternalApis = (
-	movies: MockMovie[],
-	anthropic?: MockAnthropic,
-	shows: MockShow[] = []
-): string[] => {
-	const capturedUrls: string[] = [];
-	globalThis.fetch = (async (input: RequestInfo | URL) => {
-		const url =
-			typeof input === 'string'
-				? input
-				: input instanceof URL
-					? input.toString()
-					: input.url;
-		capturedUrls.push(url);
-		const { hostname, pathname } = new URL(url);
-
-		if (hostname === 'api.themoviedb.org') {
-			if (pathname === '/3/discover/movie')
-				return jsonResponse({ results: movies });
-			if (pathname === '/3/discover/tv')
-				return jsonResponse({ results: shows });
-			const detail = /^\/3\/movie\/(\d+)$/.exec(pathname);
-			if (detail) {
-				const movie = movies.find(m => m.id === Number(detail[1]));
-				if (!movie) return jsonResponse({}, 404);
-				return jsonResponse({
-					id: movie.id,
-					title: movie.title,
-					overview: movie.overview,
-					poster_path: movie.poster_path,
-					runtime: movie.runtime,
-					release_date: movie.release_date,
-					genres: movie.genre_ids.map(id => ({
-						id,
-						name: GENRE_NAMES[id] ?? 'Unknown',
-					})),
-				});
-			}
-			const tvDetail = /^\/3\/tv\/(\d+)$/.exec(pathname);
-			if (tvDetail) {
-				const show = shows.find(s => s.id === Number(tvDetail[1]));
-				if (!show) return jsonResponse({}, 404);
-				return jsonResponse({
-					id: show.id,
-					name: show.name,
-					overview: show.overview,
-					poster_path: show.poster_path,
-					episode_run_time: show.episode_run_time,
-					first_air_date: show.first_air_date,
-					genres: show.genre_ids.map(id => ({
-						id,
-						name: GENRE_NAMES[id] ?? 'Unknown',
-					})),
-				});
-			}
-			const providers = /^\/3\/movie\/(\d+)\/watch\/providers$/.exec(pathname);
-			if (providers) {
-				const movie = movies.find(m => m.id === Number(providers[1]));
-				return jsonResponse({
-					results: movie?.providers ? { GB: movie.providers } : {},
-				});
-			}
-			const tvProviders = /^\/3\/tv\/(\d+)\/watch\/providers$/.exec(pathname);
-			if (tvProviders) {
-				const show = shows.find(s => s.id === Number(tvProviders[1]));
-				return jsonResponse({
-					results: show?.providers ? { GB: show.providers } : {},
-				});
-			}
-		}
-
-		if (hostname === 'api.anthropic.com' && pathname === '/v1/messages') {
-			if (anthropic === 'error')
-				return jsonResponse({ error: 'mocked failure' }, 500);
-			if (anthropic) {
-				return jsonResponse({
-					content: [
-						{
-							type: 'tool_use',
-							name: 'submit_pick',
-							input: {
-								pick_tmdb_id: anthropic.pickTmdbId,
-								alternates_tmdb_ids: anthropic.alternatesTmdbIds,
-								rationale: anthropic.rationale,
-							},
-						},
-					],
-					usage: { input_tokens: 100, output_tokens: 50 },
-				});
-			}
-		}
-
-		throw new Error(`Unmocked fetch in test: ${url}`);
-	}) as typeof fetch;
-	return capturedUrls;
 };
 
 const createHousehold = async (

--- a/services/api/src/test/test-helpers.ts
+++ b/services/api/src/test/test-helpers.ts
@@ -1,4 +1,6 @@
 import { env, exports } from 'cloudflare:workers';
+import { afterEach } from 'vitest';
+import { GENRE_NAMES } from '../lib/genres';
 import { currentTotpCode } from '../lib/totp';
 
 const BASE_URL = 'https://example.com';
@@ -270,4 +272,157 @@ export const createLoggedInAdmin = async (
 		);
 	}
 	return { userId, cookies: secondLogin.cookies, totpSecret: secret };
+};
+
+export type MockMovie = {
+	id: number;
+	title: string;
+	overview: string;
+	poster_path: string | null;
+	release_date: string;
+	vote_average: number;
+	vote_count: number;
+	genre_ids: number[];
+	popularity: number;
+	runtime: number;
+	providers?: {
+		flatrate?: Array<{
+			provider_id: number;
+			provider_name: string;
+			logo_path: string;
+		}>;
+		link?: string;
+	};
+};
+
+export type MockShow = {
+	id: number;
+	name: string;
+	overview: string;
+	poster_path: string | null;
+	first_air_date: string;
+	vote_average: number;
+	vote_count: number;
+	genre_ids: number[];
+	popularity: number;
+	episode_run_time: number[];
+	providers?: MockMovie['providers'];
+};
+
+export type MockAnthropic =
+	| { pickTmdbId: number; alternatesTmdbIds: number[]; rationale: string }
+	| 'error';
+
+const jsonResponse = (data: unknown, status = 200): Response =>
+	new Response(JSON.stringify(data), {
+		status,
+		headers: { 'content-type': 'application/json' },
+	});
+
+const REAL_FETCH = globalThis.fetch;
+afterEach(() => {
+	globalThis.fetch = REAL_FETCH;
+});
+
+/** Replaces the global fetch for the rest of the current test so pick/commit flows never hit the
+ * real TMDb/Anthropic APIs -- unreachable from the test sandbox, and non-deterministic even if
+ * reachable. Returns the list of URLs actually requested, so tests can assert on outgoing call
+ * shape (e.g. proving the region-lock override reached TMDb). Shared by every e2e suite that
+ * exercises a pick path (household-scoped or anonymous) so there's one TMDb/Anthropic mock to
+ * keep in sync with the real API shapes, not one per test file. */
+export const mockExternalApis = (
+	movies: MockMovie[],
+	anthropic?: MockAnthropic,
+	shows: MockShow[] = []
+): string[] => {
+	const capturedUrls: string[] = [];
+	globalThis.fetch = (async (input: RequestInfo | URL) => {
+		const url =
+			typeof input === 'string'
+				? input
+				: input instanceof URL
+					? input.toString()
+					: input.url;
+		capturedUrls.push(url);
+		const { hostname, pathname } = new URL(url);
+
+		if (hostname === 'api.themoviedb.org') {
+			if (pathname === '/3/discover/movie')
+				return jsonResponse({ results: movies });
+			if (pathname === '/3/discover/tv')
+				return jsonResponse({ results: shows });
+			const detail = /^\/3\/movie\/(\d+)$/.exec(pathname);
+			if (detail) {
+				const movie = movies.find(m => m.id === Number(detail[1]));
+				if (!movie) return jsonResponse({}, 404);
+				return jsonResponse({
+					id: movie.id,
+					title: movie.title,
+					overview: movie.overview,
+					poster_path: movie.poster_path,
+					runtime: movie.runtime,
+					release_date: movie.release_date,
+					genres: movie.genre_ids.map(id => ({
+						id,
+						name: GENRE_NAMES[id] ?? 'Unknown',
+					})),
+				});
+			}
+			const tvDetail = /^\/3\/tv\/(\d+)$/.exec(pathname);
+			if (tvDetail) {
+				const show = shows.find(s => s.id === Number(tvDetail[1]));
+				if (!show) return jsonResponse({}, 404);
+				return jsonResponse({
+					id: show.id,
+					name: show.name,
+					overview: show.overview,
+					poster_path: show.poster_path,
+					episode_run_time: show.episode_run_time,
+					first_air_date: show.first_air_date,
+					genres: show.genre_ids.map(id => ({
+						id,
+						name: GENRE_NAMES[id] ?? 'Unknown',
+					})),
+				});
+			}
+			const providers = /^\/3\/movie\/(\d+)\/watch\/providers$/.exec(pathname);
+			if (providers) {
+				const movie = movies.find(m => m.id === Number(providers[1]));
+				return jsonResponse({
+					results: movie?.providers ? { GB: movie.providers } : {},
+				});
+			}
+			const tvProviders = /^\/3\/tv\/(\d+)\/watch\/providers$/.exec(pathname);
+			if (tvProviders) {
+				const show = shows.find(s => s.id === Number(tvProviders[1]));
+				return jsonResponse({
+					results: show?.providers ? { GB: show.providers } : {},
+				});
+			}
+		}
+
+		if (hostname === 'api.anthropic.com' && pathname === '/v1/messages') {
+			if (anthropic === 'error')
+				return jsonResponse({ error: 'mocked failure' }, 500);
+			if (anthropic) {
+				return jsonResponse({
+					content: [
+						{
+							type: 'tool_use',
+							name: 'submit_pick',
+							input: {
+								pick_tmdb_id: anthropic.pickTmdbId,
+								alternates_tmdb_ids: anthropic.alternatesTmdbIds,
+								rationale: anthropic.rationale,
+							},
+						},
+					],
+					usage: { input_tokens: 100, output_tokens: 50 },
+				});
+			}
+		}
+
+		throw new Error(`Unmocked fetch in test: ${url}`);
+	}) as typeof fetch;
+	return capturedUrls;
 };


### PR DESCRIPTION
## Summary

- New public `/` landing page lets an anonymous visitor run the real mood+time recommendation pipeline once (client-side gate backed by a per-IP rate-limited `POST /api/demo/pick`), to demonstrate the product before asking for signup.
- `pickForHousehold`'s household-independent core is extracted into a shared `buildRecommendation` helper so the new anonymous path reuses the real discovery/scoring pipeline instead of duplicating it; `TonightPicker`'s result card and mood list are similarly extracted so the demo visually matches the real product.
- Shared TMDb-mocking test infrastructure extracted from `households.e2e.test.ts` into `test-helpers.ts` so both suites can use it.

## Test plan

- [ ] `pnpm --filter @pairflix/api test` -- new `demo.e2e.test.ts` (happy path, no-candidates 404, rate-limit 429) plus a regression pass on `households.e2e.test.ts` after the `recommendation.ts` refactor
- [ ] `pnpm --filter @pairflix/client test` -- new `LandingPage.test.tsx`
- [ ] `pnpm -r type-check` -- clean on both workspaces (verified locally)
- [ ] Manual: anonymous visit to `/` shows the demo form; submitting returns a real pick with provider links and a signup CTA; reloading shows the "used today" state; an authenticated visit to `/` redirects to `/tonight`

Note for the reviewer: this local dev environment has two pre-existing, unrelated issues blocking either test suite from running directly -- a `@vitest/pretty-format` version conflict in `services/api`'s `node_modules`, and `jest.config.ts` failing to parse under the resolved TypeScript's `verbatimModuleSyntax` in `apps/client`. Both reproduce on files untouched by this branch. In lieu of running the suites, I verified the full flow live against the running dev servers (real TMDb calls, real rate-limiting, real CSRF handling) and both workspaces type-check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)