### PR TITLE
chore(api): seed dev households, including premium/unlimited ones

### DIFF
--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -71,6 +71,21 @@ pnpm exec wrangler d1 execute pairflix-db --local --command "select * from house
 
 The local D1 lives under `.wrangler/` and is disposable — delete it and re-migrate to reset.
 
+### Dev seed data
+
+```bash
+pnpm --filter @pairflix/api db:seed:local             # flat DevLogin fixture users (see below)
+pnpm --filter @pairflix/api db:seed:households:local   # paired-up households, free + premium
+```
+
+Both are `--local`-only and idempotent (safe to rerun). `db:seed:local` seeds the account-status
+fixtures `apps/client/src/components/dev/DevLogin.tsx`'s dev-only quick-login panel expects
+(active/banned/suspended/admin), with no households attached. `db:seed:households:local` seeds five
+households (two free-tier, three premium/active — i.e. unlimited daily picks, no region lock) so a
+household-scoped flow (pick/commit, quota, provider filters) can be exercised without first
+hand-creating a household through the UI/API; it prints each household's name, tier, and owner
+login email on completion. All seeded users share the password `password123`.
+
 ## Environment & secrets
 
 - **Local Worker vars** go in `services/api/.dev.vars` (gitignored): `TMDB_API_KEY`,

--- a/services/api/package.json
+++ b/services/api/package.json
@@ -17,7 +17,8 @@
 		"format:check": "prettier --check \"src/**/*.{ts,tsx,js,jsx,json,md,mdx}\"",
 		"db:migrate:local": "wrangler d1 migrations apply pairflix-db --local",
 		"db:migrate:remote": "wrangler d1 migrations apply pairflix-db --remote",
-		"db:seed:local": "node scripts/seed-dev-users.mjs"
+		"db:seed:local": "node scripts/seed-dev-users.mjs",
+		"db:seed:households:local": "node scripts/seed-dev-households.mjs"
 	},
 	"dependencies": {
 		"@pairflix/db": "workspace:*",

--- a/services/api/scripts/seed-dev-households.mjs
+++ b/services/api/scripts/seed-dev-households.mjs
@@ -135,7 +135,7 @@ const run = async () => {
 		});
 
 		if (household.tier === 'premium') {
-			const subscriptionId = idFor('subscription', household.slug);
+			const subscriptionId = idFor('sub', household.slug);
 			const currentPeriodEnd = now + THIRTY_DAYS_MS;
 			statements.push(
 				`INSERT OR IGNORE INTO subscriptions (id, household_id, tier, status, stripe_customer_id, stripe_subscription_id, current_period_end, created_at, updated_at) VALUES (${sqlString(subscriptionId)}, ${sqlString(householdId)}, 'premium', 'active', NULL, NULL, ${currentPeriodEnd}, ${now}, ${now});`

--- a/services/api/scripts/seed-dev-households.mjs
+++ b/services/api/scripts/seed-dev-households.mjs
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+// Seeds paired-up households into local D1 -- unlike seed-dev-users.mjs's flat DevLogin fixtures,
+// these exist so a dev can exercise household-scoped flows (pick/commit, quota, provider filters)
+// without first hand-creating a household through the UI/API. Includes premium ("unlimited picks")
+// households so free-tier's 3-picks/day quota doesn't get in the way of repeated manual testing.
+// --local only -- never touches a real D1 database.
+
+import { hashPassword, runD1File, sqlString } from './seed-lib.mjs';
+
+const PASSWORD = 'password123';
+
+// Deterministic, not random -- reruns must resolve to the same ids so `INSERT OR IGNORE` actually
+// no-ops on a second run instead of leaving orphaned household_members/subscriptions rows pointed
+// at a user_id nothing re-inserted.
+const idFor = (prefix, slug) => `${prefix}_hhseed_${slug}`;
+
+const HOUSEHOLDS = [
+	{
+		slug: 'free1',
+		name: 'Free Household',
+		tier: 'free',
+		members: [
+			{
+				slug: 'free1-owner',
+				email: 'hh-free1-owner@example.com',
+				username: 'hhfree1owner',
+			},
+			{
+				slug: 'free1-partner',
+				email: 'hh-free1-partner@example.com',
+				username: 'hhfree1partner',
+			},
+		],
+	},
+	{
+		slug: 'free2',
+		name: 'Popcorn Club',
+		tier: 'free',
+		members: [
+			{
+				slug: 'free2-owner',
+				email: 'hh-free2-owner@example.com',
+				username: 'hhfree2owner',
+			},
+			{
+				slug: 'free2-partner',
+				email: 'hh-free2-partner@example.com',
+				username: 'hhfree2partner',
+			},
+		],
+	},
+	{
+		slug: 'premium1',
+		name: 'Unlimited Picks HQ',
+		tier: 'premium',
+		members: [
+			{
+				slug: 'premium1-owner',
+				email: 'hh-premium1-owner@example.com',
+				username: 'hhpremium1owner',
+			},
+			{
+				slug: 'premium1-partner',
+				email: 'hh-premium1-partner@example.com',
+				username: 'hhpremium1partner',
+			},
+		],
+	},
+	{
+		slug: 'premium2',
+		name: 'Binge Squad',
+		tier: 'premium',
+		members: [
+			{
+				slug: 'premium2-owner',
+				email: 'hh-premium2-owner@example.com',
+				username: 'hhpremium2owner',
+			},
+			{
+				slug: 'premium2-partner',
+				email: 'hh-premium2-partner@example.com',
+				username: 'hhpremium2partner',
+			},
+		],
+	},
+	{
+		slug: 'premium3',
+		name: 'Multi-Region Movie Night',
+		tier: 'premium',
+		members: [
+			{
+				slug: 'premium3-owner',
+				email: 'hh-premium3-owner@example.com',
+				username: 'hhpremium3owner',
+			},
+			{
+				slug: 'premium3-partner',
+				email: 'hh-premium3-partner@example.com',
+				username: 'hhpremium3partner',
+			},
+		],
+	},
+];
+
+const defaultPreferences = JSON.stringify({
+	theme: 'dark',
+	viewStyle: 'grid',
+	emailNotifications: true,
+	autoArchiveDays: 30,
+	favoriteGenres: [],
+});
+
+const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
+
+const run = async () => {
+	const passwordHash = await hashPassword(PASSWORD);
+	const now = Date.now();
+	const statements = [];
+
+	for (const household of HOUSEHOLDS) {
+		const householdId = idFor('household', household.slug);
+		statements.push(
+			`INSERT OR IGNORE INTO households (id, name, created_at, updated_at) VALUES (${sqlString(householdId)}, ${sqlString(household.name)}, ${now}, ${now});`
+		);
+
+		household.members.forEach((member, index) => {
+			const userId = idFor('user', member.slug);
+			statements.push(
+				`INSERT OR IGNORE INTO users (user_id, username, email, password_hash, role, status, email_verified, preferences, created_at, updated_at) VALUES (${sqlString(userId)}, ${sqlString(member.username)}, ${sqlString(member.email)}, ${sqlString(passwordHash)}, 'user', 'active', 1, ${sqlString(defaultPreferences)}, ${now}, ${now});`
+			);
+			const role = index === 0 ? 'owner' : 'member';
+			statements.push(
+				`INSERT OR IGNORE INTO household_members (household_id, user_id, role, joined_at) VALUES (${sqlString(householdId)}, ${sqlString(userId)}, ${sqlString(role)}, ${now});`
+			);
+		});
+
+		if (household.tier === 'premium') {
+			const subscriptionId = idFor('subscription', household.slug);
+			const currentPeriodEnd = now + THIRTY_DAYS_MS;
+			statements.push(
+				`INSERT OR IGNORE INTO subscriptions (id, household_id, tier, status, stripe_customer_id, stripe_subscription_id, current_period_end, created_at, updated_at) VALUES (${sqlString(subscriptionId)}, ${sqlString(householdId)}, 'premium', 'active', NULL, NULL, ${currentPeriodEnd}, ${now}, ${now});`
+			);
+		}
+	}
+
+	runD1File(statements, 'seed-dev-households');
+
+	const memberCount = HOUSEHOLDS.reduce((sum, h) => sum + h.members.length, 0);
+	console.log(
+		`\nSeeded ${HOUSEHOLDS.length} households (${memberCount} users, password: ${PASSWORD}):`
+	);
+	for (const household of HOUSEHOLDS) {
+		const owner = household.members[0];
+		console.log(
+			`  - ${household.name} [${household.tier}] -- log in as ${owner.email}`
+		);
+	}
+};
+
+run();

--- a/services/api/scripts/seed-dev-users.mjs
+++ b/services/api/scripts/seed-dev-users.mjs
@@ -4,37 +4,11 @@
 // but never ported it, so DevLogin has been referencing users that don't exist since the cutover.
 // --local only -- never touches a real D1 database.
 
-import { execFileSync } from 'node:child_process';
-import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { hashPassword, runD1File, sqlString } from './seed-lib.mjs';
 
 const PASSWORD = 'password123';
-const ITERATIONS = 100_000; // must match services/api/src/lib/crypto.ts
-
-const encoder = new TextEncoder();
-const toBase64 = bytes => btoa(String.fromCharCode(...new Uint8Array(bytes)));
-
-const hashPassword = async password => {
-	const salt = crypto.getRandomValues(new Uint8Array(16));
-	const key = await crypto.subtle.importKey(
-		'raw',
-		encoder.encode(password),
-		'PBKDF2',
-		false,
-		['deriveBits']
-	);
-	const bits = await crypto.subtle.deriveBits(
-		{ name: 'PBKDF2', salt, iterations: ITERATIONS, hash: 'SHA-256' },
-		key,
-		256
-	);
-	return `pbkdf2$${ITERATIONS}$${toBase64(salt.buffer)}$${toBase64(bits)}`;
-};
 
 const newId = () => `user_${crypto.randomUUID().replace(/-/g, '')}`;
-
-const sqlString = value => `'${value.replace(/'/g, "''")}'`;
 
 // Mirrors apps/client/src/components/dev/DevLogin.tsx's testUsers list.
 const users = [
@@ -155,30 +129,7 @@ const run = async () => {
 		return `INSERT OR IGNORE INTO users (user_id, username, email, password_hash, role, status, email_verified, preferences, created_at, updated_at) VALUES (${sqlString(id)}, ${sqlString(user.username)}, ${sqlString(user.email)}, ${sqlString(passwordHash)}, ${sqlString(user.role)}, ${sqlString(user.status)}, ${user.emailVerified ? 1 : 0}, ${sqlString(defaultPreferences)}, ${now}, ${now});`;
 	});
 
-	const dir = mkdtempSync(join(tmpdir(), 'pairflix-seed-'));
-	const sqlFile = join(dir, 'seed-dev-users.sql');
-	writeFileSync(sqlFile, statements.join('\n'));
-
-	try {
-		execFileSync(
-			'pnpm',
-			[
-				'exec',
-				'wrangler',
-				'd1',
-				'execute',
-				'pairflix-db',
-				'--local',
-				`--file=${sqlFile}`,
-			],
-			{
-				stdio: 'inherit',
-				shell: true,
-			}
-		);
-	} finally {
-		rmSync(dir, { recursive: true, force: true });
-	}
+	runD1File(statements, 'seed-dev-users');
 
 	console.log(`\nSeeded ${users.length} dev users (password: ${PASSWORD}).`);
 };

--- a/services/api/scripts/seed-lib.mjs
+++ b/services/api/scripts/seed-lib.mjs
@@ -1,0 +1,60 @@
+// Shared helpers for the local-D1 dev seed scripts (seed-dev-users.mjs, seed-dev-households.mjs).
+// --local only -- callers must never point this at a real D1 database.
+
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+export const ITERATIONS = 100_000; // must match services/api/src/lib/crypto.ts
+
+const encoder = new TextEncoder();
+const toBase64 = bytes => btoa(String.fromCharCode(...new Uint8Array(bytes)));
+
+export const hashPassword = async password => {
+	const salt = crypto.getRandomValues(new Uint8Array(16));
+	const key = await crypto.subtle.importKey(
+		'raw',
+		encoder.encode(password),
+		'PBKDF2',
+		false,
+		['deriveBits']
+	);
+	const bits = await crypto.subtle.deriveBits(
+		{ name: 'PBKDF2', salt, iterations: ITERATIONS, hash: 'SHA-256' },
+		key,
+		256
+	);
+	return `pbkdf2$${ITERATIONS}$${toBase64(salt.buffer)}$${toBase64(bits)}`;
+};
+
+export const sqlString = value => `'${value.replace(/'/g, "''")}'`;
+
+/** Runs a batch of SQL statements against local D1 via a temp file (wrangler has no
+ * multi-statement inline `--command` mode). */
+export const runD1File = (statements, label) => {
+	const dir = mkdtempSync(join(tmpdir(), 'pairflix-seed-'));
+	const sqlFile = join(dir, `${label}.sql`);
+	writeFileSync(sqlFile, statements.join('\n'));
+
+	try {
+		execFileSync(
+			'pnpm',
+			[
+				'exec',
+				'wrangler',
+				'd1',
+				'execute',
+				'pairflix-db',
+				'--local',
+				`--file=${sqlFile}`,
+			],
+			{
+				stdio: 'inherit',
+				shell: true,
+			}
+		);
+	} finally {
+		rmSync(dir, { recursive: true, force: true });
+	}
+};


### PR DESCRIPTION
## Summary
- Adds `pnpm --filter @pairflix/api db:seed:households:local`, seeding 5 households into local D1: 2 free-tier and 3 premium/active (unlimited daily picks, no region lock, matching `getEntitlements`'s definition of premium) -- so household-scoped flows (pick/commit, quota, provider filters, e.g. the starvation fix in #90) can be exercised manually without hand-creating a household through the UI/API first, and without the free tier's 3-picks/day quota interrupting repeated testing.
- Deterministic ids (`household_hhseed_<slug>`, `user_hhseed_<slug>`) so reruns are idempotent -- `INSERT OR IGNORE` actually no-ops instead of leaving orphaned rows behind.
- Extracted the PBKDF2 hashing + wrangler-d1-exec helpers `seed-dev-users.mjs` already had into `scripts/seed-lib.mjs`, since the new script needs the same logic.
- Documented both `db:seed:local` and `db:seed:households:local` in `docs/dev-setup.md` (neither was documented before).
- Surfaced all 10 seeded household members in `DevLogin.tsx`'s quick-login panel (a new "Household Logins" section with free/premium tier badges), mirroring `seed-dev-households.mjs`'s `HOUSEHOLDS` list, so they're reachable without typing credentials by hand.
- Shortened the seeded usernames/emails (e.g. `hhpremium1partner` -> `hhp1partner`) -- the original longer ones visibly overflowed their button in DevLogin's fixed-300px two-column grid; confirmed via a Playwright screenshot before and after.

## Test plan
- [x] `pnpm --filter @pairflix/api db:migrate:local` then `pnpm --filter @pairflix/api db:seed:households:local` -- ran clean, printed all 5 households with owner login emails.
- [x] Queried local D1 directly: free households have no `subscriptions` row (defaults to free tier per `getEntitlements`); premium households have `tier='premium', status='active'` with a 30-day `current_period_end`.
- [x] Re-ran the seed script a second time -- household count stayed at 5 (no duplicates), confirming idempotency.
- [x] `node --check` on all three scripts; `tsc --noEmit` and `eslint` clean on the DevLogin changes.
- [x] Started the client dev server and screenshotted the expanded DevLogin panel with Playwright -- confirmed the new "Household Logins" section renders all 10 users with correct tier badges and no overflow.