### PR TITLE
feat(client): surface seeded households in the DevLogin quick-login panel

### DIFF
--- a/apps/client/src/components/dev/DevLogin.css.ts
+++ b/apps/client/src/components/dev/DevLogin.css.ts
@@ -57,6 +57,8 @@ export const statusBadge = recipe({
       banned: { background: vars.colors.text.error },
       suspended: { background: vars.colors.text.warning },
       admin: { background: vars.colors.primary },
+      free: { background: vars.colors.background.hover },
+      premium: { background: vars.colors.primary },
     },
   },
   defaultVariants: {

--- a/apps/client/src/components/dev/DevLogin.tsx
+++ b/apps/client/src/components/dev/DevLogin.tsx
@@ -12,6 +12,14 @@ interface TestUser {
   description: string;
 }
 
+interface HouseholdTestUser {
+  email: string;
+  username: string;
+  household: string;
+  role: 'owner' | 'member';
+  tier: 'free' | 'premium';
+}
+
 const testUsers: TestUser[] = [
   {
     email: 'useractive@example.com',
@@ -99,6 +107,83 @@ const testUsers: TestUser[] = [
   },
 ];
 
+// Mirrors services/api/scripts/seed-dev-households.mjs's HOUSEHOLDS list -- paired household
+// members (unlike testUsers above, which have no household), including premium/"unlimited picks"
+// households so the free tier's 3-picks/day quota doesn't get in the way of manually exercising
+// pick/commit flows.
+const householdTestUsers: HouseholdTestUser[] = [
+  {
+    email: 'hh-f1-owner@example.com',
+    username: 'hhf1owner',
+    household: 'Free Household',
+    role: 'owner',
+    tier: 'free',
+  },
+  {
+    email: 'hh-f1-partner@example.com',
+    username: 'hhf1partner',
+    household: 'Free Household',
+    role: 'member',
+    tier: 'free',
+  },
+  {
+    email: 'hh-f2-owner@example.com',
+    username: 'hhf2owner',
+    household: 'Popcorn Club',
+    role: 'owner',
+    tier: 'free',
+  },
+  {
+    email: 'hh-f2-partner@example.com',
+    username: 'hhf2partner',
+    household: 'Popcorn Club',
+    role: 'member',
+    tier: 'free',
+  },
+  {
+    email: 'hh-p1-owner@example.com',
+    username: 'hhp1owner',
+    household: 'Unlimited Picks HQ',
+    role: 'owner',
+    tier: 'premium',
+  },
+  {
+    email: 'hh-p1-partner@example.com',
+    username: 'hhp1partner',
+    household: 'Unlimited Picks HQ',
+    role: 'member',
+    tier: 'premium',
+  },
+  {
+    email: 'hh-p2-owner@example.com',
+    username: 'hhp2owner',
+    household: 'Binge Squad',
+    role: 'owner',
+    tier: 'premium',
+  },
+  {
+    email: 'hh-p2-partner@example.com',
+    username: 'hhp2partner',
+    household: 'Binge Squad',
+    role: 'member',
+    tier: 'premium',
+  },
+  {
+    email: 'hh-p3-owner@example.com',
+    username: 'hhp3owner',
+    household: 'Multi-Region Movie Night',
+    role: 'owner',
+    tier: 'premium',
+  },
+  {
+    email: 'hh-p3-partner@example.com',
+    username: 'hhp3partner',
+    household: 'Multi-Region Movie Night',
+    role: 'member',
+    tier: 'premium',
+  },
+];
+
 const DevLogin: React.FC = () => {
   const navigate = useNavigate();
   const { checkAuth } = useAuth();
@@ -182,6 +267,32 @@ const DevLogin: React.FC = () => {
               <div className={styles.devTip}>
                 💡 Users vary by account status (active/banned/suspended/admin)
                 for testing
+              </div>
+
+              <div className={styles.quickLoginHeader}>
+                Household Logins (password: password123)
+              </div>
+
+              <div className={styles.userGrid}>
+                {householdTestUsers.map(user => (
+                  <Button
+                    className={styles.quickLoginButton}
+                    key={user.email}
+                    variant="secondary"
+                    onClick={() => handleQuickLogin(user.email, user.username)}
+                    title={`Login as ${user.household} ${user.role} (${user.tier})`}
+                  >
+                    {user.username}
+                    <span className={styles.statusBadge({ status: user.tier })}>
+                      {user.tier}
+                    </span>
+                  </Button>
+                ))}
+              </div>
+
+              <div className={styles.devTip}>
+                💡 Paired household members for testing pick/commit flows --
+                premium households have unlimited daily picks
               </div>
             </>
           )}

--- a/services/api/scripts/seed-dev-households.mjs
+++ b/services/api/scripts/seed-dev-households.mjs
@@ -16,9 +16,10 @@ const PASSWORD = 'password123';
 // at a user_id nothing re-inserted.
 const idFor = (prefix, slug) => `${prefix}_hhseed_${slug}`;
 
-// Usernames stay short (<=11 chars, matching the longest of seed-dev-users.mjs's fixtures,
-// "usersuspended") -- the DevLogin quick-login panel is a fixed 300px wide (DevLogin.css.ts's
-// devContainer), and a longer username visibly overflows its button in that two-column grid.
+// Usernames stay short (<=10 chars) — the DevLogin quick-login panel is a fixed 300px wide
+// (DevLogin.css.ts's devContainer), and longer usernames visibly overflow buttons in its two-column grid.
+// If you previously seeded with different emails/usernames, wipe/reset local D1: this script uses
+// deterministic ids + `INSERT OR IGNORE`, so reruns won't update existing rows.
 const HOUSEHOLDS = [
 	{
 		slug: 'free1',

--- a/services/api/scripts/seed-dev-households.mjs
+++ b/services/api/scripts/seed-dev-households.mjs
@@ -1,8 +1,10 @@
 #!/usr/bin/env node
-// Seeds paired-up households into local D1 -- unlike seed-dev-users.mjs's flat DevLogin fixtures,
+// Seeds paired-up households into local D1 -- unlike seed-dev-users.mjs's flat, unpaired accounts,
 // these exist so a dev can exercise household-scoped flows (pick/commit, quota, provider filters)
 // without first hand-creating a household through the UI/API. Includes premium ("unlimited picks")
 // households so free-tier's 3-picks/day quota doesn't get in the way of repeated manual testing.
+// Mirrored in apps/client/src/components/dev/DevLogin.tsx's householdTestUsers -- keep both in sync
+// if this list changes.
 // --local only -- never touches a real D1 database.
 
 import { hashPassword, runD1File, sqlString } from './seed-lib.mjs';
@@ -14,6 +16,9 @@ const PASSWORD = 'password123';
 // at a user_id nothing re-inserted.
 const idFor = (prefix, slug) => `${prefix}_hhseed_${slug}`;
 
+// Usernames stay short (<=11 chars, matching the longest of seed-dev-users.mjs's fixtures,
+// "usersuspended") -- the DevLogin quick-login panel is a fixed 300px wide (DevLogin.css.ts's
+// devContainer), and a longer username visibly overflows its button in that two-column grid.
 const HOUSEHOLDS = [
 	{
 		slug: 'free1',
@@ -22,13 +27,13 @@ const HOUSEHOLDS = [
 		members: [
 			{
 				slug: 'free1-owner',
-				email: 'hh-free1-owner@example.com',
-				username: 'hhfree1owner',
+				email: 'hh-f1-owner@example.com',
+				username: 'hhf1owner',
 			},
 			{
 				slug: 'free1-partner',
-				email: 'hh-free1-partner@example.com',
-				username: 'hhfree1partner',
+				email: 'hh-f1-partner@example.com',
+				username: 'hhf1partner',
 			},
 		],
 	},
@@ -39,13 +44,13 @@ const HOUSEHOLDS = [
 		members: [
 			{
 				slug: 'free2-owner',
-				email: 'hh-free2-owner@example.com',
-				username: 'hhfree2owner',
+				email: 'hh-f2-owner@example.com',
+				username: 'hhf2owner',
 			},
 			{
 				slug: 'free2-partner',
-				email: 'hh-free2-partner@example.com',
-				username: 'hhfree2partner',
+				email: 'hh-f2-partner@example.com',
+				username: 'hhf2partner',
 			},
 		],
 	},
@@ -56,13 +61,13 @@ const HOUSEHOLDS = [
 		members: [
 			{
 				slug: 'premium1-owner',
-				email: 'hh-premium1-owner@example.com',
-				username: 'hhpremium1owner',
+				email: 'hh-p1-owner@example.com',
+				username: 'hhp1owner',
 			},
 			{
 				slug: 'premium1-partner',
-				email: 'hh-premium1-partner@example.com',
-				username: 'hhpremium1partner',
+				email: 'hh-p1-partner@example.com',
+				username: 'hhp1partner',
 			},
 		],
 	},
@@ -73,13 +78,13 @@ const HOUSEHOLDS = [
 		members: [
 			{
 				slug: 'premium2-owner',
-				email: 'hh-premium2-owner@example.com',
-				username: 'hhpremium2owner',
+				email: 'hh-p2-owner@example.com',
+				username: 'hhp2owner',
 			},
 			{
 				slug: 'premium2-partner',
-				email: 'hh-premium2-partner@example.com',
-				username: 'hhpremium2partner',
+				email: 'hh-p2-partner@example.com',
+				username: 'hhp2partner',
 			},
 		],
 	},
@@ -90,13 +95,13 @@ const HOUSEHOLDS = [
 		members: [
 			{
 				slug: 'premium3-owner',
-				email: 'hh-premium3-owner@example.com',
-				username: 'hhpremium3owner',
+				email: 'hh-p3-owner@example.com',
+				username: 'hhp3owner',
 			},
 			{
 				slug: 'premium3-partner',
-				email: 'hh-premium3-partner@example.com',
-				username: 'hhpremium3partner',
+				email: 'hh-p3-partner@example.com',
+				username: 'hhp3partner',
 			},
 		],
 	},


### PR DESCRIPTION
## Summary
Follow-up to #91 (already merged) -- that PR's `db:seed:households:local` script wasn't reachable from `DevLogin.tsx`'s quick-login panel, so testing the seeded households still meant typing credentials by hand.

- Adds a "Household Logins" section to the DevLogin panel listing all 10 seeded household members with free/premium tier badges, mirroring `seed-dev-households.mjs`'s `HOUSEHOLDS` list.
- Shortens the seeded usernames/emails (e.g. `hhpremium1partner` -> `hhp1partner`) -- DevLogin's panel is a fixed 300px wide, and the original longer usernames visibly overflowed their button in its two-column grid. Confirmed via a Playwright screenshot before and after.
- Adds a `free`/`premium` variant to `DevLogin.css.ts`'s `statusBadge` recipe for the new tier badges.

## Test plan
- [x] `tsc --noEmit` and `eslint` clean on the DevLogin changes.
- [x] Re-ran `db:seed:households:local` locally with the shortened usernames/emails -- seeded cleanly, printed all 5 households.
- [x] Started the client dev server and screenshotted the expanded DevLogin panel with Playwright -- confirmed all 10 household buttons render fully within the panel with correct tier badges (no overflow, which the original longer usernames did show).