### PR TITLE
fix(client): make RegisterPage validation reachable

### DIFF
--- a/apps/client/src/features/auth/RegisterPage.tsx
+++ b/apps/client/src/features/auth/RegisterPage.tsx
@@ -26,7 +26,12 @@ const RegisterPage: React.FC = () => {
   const [isLoading, setIsLoading] = useState(false);
 
   const validateForm = () => {
-    if (!email || !password || !confirmPassword || !username) {
+    if (
+      !email.trim() ||
+      !password.trim() ||
+      !confirmPassword.trim() ||
+      !username.trim()
+    ) {
       setError('All fields are required');
       return false;
     }

--- a/apps/client/src/features/auth/RegisterPage.tsx
+++ b/apps/client/src/features/auth/RegisterPage.tsx
@@ -113,13 +113,6 @@ const RegisterPage: React.FC = () => {
     }
   };
 
-  const isFormValid =
-    email.trim() &&
-    password.trim() &&
-    confirmPassword.trim() &&
-    username.trim() &&
-    !isLoading;
-
   // Show success state after registration
   if (success) {
     return (
@@ -169,7 +162,11 @@ const RegisterPage: React.FC = () => {
       <Card className={styles.registerCard}>
         <CardContent>
           <H2 className={styles.createAccountHeading}>Create Account</H2>
-          <form className={styles.registerForm} onSubmit={handleSubmit}>
+          <form
+            className={styles.registerForm}
+            onSubmit={handleSubmit}
+            noValidate
+          >
             <InputGroup>
               <Input
                 type="text"
@@ -218,7 +215,6 @@ const RegisterPage: React.FC = () => {
             <Button
               type="submit"
               variant="primary"
-              disabled={!isFormValid}
               isLoading={isLoading}
               isFullWidth
             >

--- a/apps/client/src/features/auth/__tests__/RegisterPage.test.tsx
+++ b/apps/client/src/features/auth/__tests__/RegisterPage.test.tsx
@@ -1,7 +1,7 @@
 import userEvent from '@testing-library/user-event';
 import type { Mock } from 'vitest';
 import { auth } from '../../../services/api';
-import { fireEvent, render, screen, waitFor } from '../../../tests/setup';
+import { render, screen, waitFor } from '../../../tests/setup';
 import RegisterPage from '../RegisterPage';
 
 // Mock the API module
@@ -67,20 +67,11 @@ describe('RegisterPage', () => {
     ).toBeInTheDocument();
   });
 
-  it('shows "All fields are required" when submitting with a blank field', () => {
+  it('shows "All fields are required" when submitting with a blank field', async () => {
+    const user = userEvent.setup();
     render(<RegisterPage />);
 
-    // The submit button is disabled while any field is blank, so a real click
-    // cannot reach validateForm -- submit the form directly to exercise it.
-    expect(
-      screen.getByRole('button', { name: 'Create Account' })
-    ).toBeDisabled();
-
-    const form = document.querySelector('form');
-    if (!form) {
-      throw new Error('Could not find registration form');
-    }
-    fireEvent.submit(form);
+    await user.click(screen.getByRole('button', { name: 'Create Account' }));
 
     expect(screen.getByText('All fields are required')).toBeInTheDocument();
     expect(auth.register).not.toHaveBeenCalled();
@@ -90,11 +81,9 @@ describe('RegisterPage', () => {
     const user = userEvent.setup();
     render(<RegisterPage />);
 
-    // "user@domain" passes the browser's native type="email" check (so the form
-    // submits) but fails the component's stricter validator (no dot in domain).
     await fillForm(user, {
       username: 'validuser',
-      email: 'user@domain',
+      email: 'notanemail',
       password: 'password123',
       confirmPassword: 'password123',
     });

--- a/apps/client/src/features/auth/__tests__/RegisterPage.test.tsx
+++ b/apps/client/src/features/auth/__tests__/RegisterPage.test.tsx
@@ -77,6 +77,22 @@ describe('RegisterPage', () => {
     expect(auth.register).not.toHaveBeenCalled();
   });
 
+  it('treats a whitespace-only field as missing', async () => {
+    const user = userEvent.setup();
+    render(<RegisterPage />);
+
+    await fillForm(user, {
+      username: 'validuser',
+      email: 'valid@example.com',
+      password: '        ',
+      confirmPassword: '        ',
+    });
+    await user.click(screen.getByRole('button', { name: 'Create Account' }));
+
+    expect(screen.getByText('All fields are required')).toBeInTheDocument();
+    expect(auth.register).not.toHaveBeenCalled();
+  });
+
   it('rejects an invalid email address', async () => {
     const user = userEvent.setup();
     render(<RegisterPage />);


### PR DESCRIPTION
### 🚀 What's New

- 🐛 Fix: `RegisterPage` form validation messages that were previously unreachable

---

### 📝 Description

`validateForm` in `apps/client/src/features/auth/RegisterPage.tsx` had two effectively dead branches, surfaced by the test suite:

- The **"All fields are required"** message could never fire from a real click — the submit button was `disabled={!isFormValid}`, and `isFormValid` already required every field to be non-empty.
- The email input's `type="email"` let the browser's native constraint validation intercept obviously-invalid input (e.g. `notanemail`) **before** the component's own `isValidEmail` ran, so **"Please provide a valid email address"** never showed for such input.

Fix: add `noValidate` to the `<form>` (so the component's own `validateForm` is authoritative, matching how `LoginPage` validates), and remove the redundant `disabled={!isFormValid}` guard so a click with blank fields runs validation and surfaces the message. The `Button` still disables itself via `isLoading`, so in-flight-submit disabling is preserved; `isFormValid` became unused and was deleted.

---

### ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented parts that are complex or non-obvious
- [x] I have updated relevant documentation
- [x] I have added or updated tests
- [x] No new warnings or errors are introduced
- [x] All tests pass locally

Verified: client suite 145/145, `pnpm lint`, `pnpm type-check`, `pnpm format:check` all green.

---

### 📸 Screenshots (if applicable)

N/A — validation-logic fix.

---

### 🔗 Related Issues / PRs

Follow-up to #94, which flagged this defect in its reviewer notes.

---

### ⚠️ Notes for Reviewers

- The `RegisterPage.test.tsx` cases were updated to drive the UI normally now that the button is enabled: the blank-field case clicks the button (instead of `fireEvent.submit` on a disabled one), and the invalid-email case uses `notanemail` (which now reaches the custom validator).
- `e2e/tests/register.spec.ts` needed no change (its scenarios already fill all fields before submitting).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PPSGBo2VvwEAEMy263XCU3

---
_Generated by [Claude Code](https://claude.ai/code/session_01PPSGBo2VvwEAEMy263XCU3)_